### PR TITLE
Use full flags and...

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ To quickly tryout cAdvisor on your machine with Docker (version 0.11 or above), 
 
 ```
 sudo docker run \
-  --interactive=false \
-  --tty=true \
   --volume=/var/run:/var/run:rw \
   --volume=/sys/fs/cgroup/:/sys/fs/cgroup:ro \
   --volume=/var/lib/docker/:/var/lib/docker:ro \


### PR DESCRIPTION
move to the background.  Having it in the foreground that you cannot easily exit out of is jarring.  I am more than happy to remove the background flags, but I feel it is a better user user experience this way.
