### PR TITLE
Adding image tag to 14.04

### DIFF
--- a/quickstart/Dockerfile
+++ b/quickstart/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:14.04
 MAINTAINER kyurtsever@google.com dengnan@google.com vmarmol@google.com
 
 # Get the lmctfy dependencies.


### PR DESCRIPTION
Tagging this to Ubuntu LTS 14.04.  A known version is "safer" than whatever may come with "latest".  Also, 14.04 will be around until late 2019. :)
