### PR TITLE
fix a bug demostrated in TestPercentilesSmallDataSet()

### DIFF
--- a/info/container.go
+++ b/info/container.go
@@ -238,6 +238,9 @@ func (self uint64Slice) Percentiles(requestedPercentiles ...int) []percentile {
 	sort.Sort(self)
 	for _, p := range requestedPercentiles {
 		idx := (len(self) * p / 100) - 1
+		if idx < 0 {
+			idx = 0
+		}
 		ret = append(
 			ret,
 			percentile{

--- a/info/container_test.go
+++ b/info/container_test.go
@@ -80,13 +80,23 @@ func TestPercentiles(t *testing.T) {
 		if s.Value != uint64(s.Percentage) {
 			t.Errorf("%v percentile data should be %v, but got %v", s.Percentage, s.Percentage, s.Value)
 		}
-		/*
-			p := percentages[i]
-			d := uint64(N * p / 100)
-			if d != s {
-				t.Errorf("%v percentile data should be %v, but got %v", p, d, s)
-			}
-		*/
+	}
+}
+
+func TestPercentilesSmallDataSet(t *testing.T) {
+	var value uint64 = 11
+	data := []uint64{value}
+
+	percentages := []int{
+		80,
+		90,
+		50,
+	}
+	percentiles := uint64Slice(data).Percentiles(percentages...)
+	for _, s := range percentiles {
+		if s.Value != value {
+			t.Errorf("%v percentile data should be %v, but got %v", s.Percentage, value, s.Value)
+		}
 	}
 }
 


### PR DESCRIPTION
If the requested percentiles is larger than number of samples, then the program will panic. This bug could be fixed by checking if idx is smaller than zero.
