### PR TITLE
fix the memory leak problem mentioned in #26

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -36,6 +36,7 @@ var argResetPeriod = flag.Duration("reset_period", 2*time.Hour, "period to reset
 
 func main() {
 	flag.Parse()
+
 	// XXX(dengnan): Should we allow users to specify which sampler they want to use?
 	container.SetStatsParameter(&container.StatsParameter{
 		Sampler:     "uniform",

--- a/manager/container.go
+++ b/manager/container.go
@@ -37,9 +37,9 @@ type containerStat struct {
 type containerInfo struct {
 	info.ContainerReference
 	Subcontainers []info.ContainerReference
-	Spec         *info.ContainerSpec
-	Stats        *list.List
-	StatsSummary *info.ContainerStatsPercentiles
+	Spec          *info.ContainerSpec
+	Stats         *list.List
+	StatsSummary  *info.ContainerStatsPercentiles
 }
 
 type containerData struct {
@@ -100,12 +100,14 @@ func NewContainerData(containerName string) (*containerData, error) {
 
 func (c *containerData) housekeeping() {
 	// Housekeep every second.
-	for true {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	for {
 		select {
 		case <-c.stop:
 			// Stop housekeeping when signaled.
 			return
-		case <-time.Tick(time.Second):
+		case <-ticker.C:
 			start := time.Now()
 			c.housekeepingTick()
 


### PR DESCRIPTION
In `containerData.housekeeping()`, `time.Tick()` is called in every iteration, which will start a new timer in every iteration.

To fix this, we only call `time.NewTicker()` once in the beginning of the function and use this timer in all iterations.
