### PR TITLE
Add cAdvisor version to VersionInfo.

### DIFF
--- a/info/machine.go
+++ b/info/machine.go
@@ -31,6 +31,9 @@ type VersionInfo struct {
 
 	// Docker version.
 	DockerVersion string `json:"docker_version"`
+
+	// cAdvisor version.
+	CadvisorVersion string `json:"cadvisor_version"`
 }
 
 type MachineInfoFactory interface {

--- a/manager/machine.go
+++ b/manager/machine.go
@@ -75,6 +75,7 @@ func getVersionInfo() (*info.VersionInfo, error) {
 		KernelVersion:      kernel_version,
 		ContainerOsVersion: container_os,
 		DockerVersion:      docker_version,
+		CadvisorVersion:    info.VERSION,
 	}, nil
 }
 


### PR DESCRIPTION
Sample -
 Version: 
{KernelVersion:3.11.0-17-generic ContainerOsVersion:Ubuntu 14.04 LTS DockerVersion:1.0.0 CadvisorVersion:0.1.0}

Docker-DCO-1.1-Signed-off-by: Rohit Jnagal jnagal@google.com (github: rjnagal)
