### PR TITLE
calculate working set based on #. pages in active LRU.

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -209,10 +209,10 @@ func libcontainerToContainerStats(s *cgroups.Stats, mi *info.MachineInfo) *info.
 		ret.Memory.ContainerData.Pgmajfault = v
 		ret.Memory.HierarchicalData.Pgmajfault = v
 	}
-	if v, ok := s.MemoryStats.Stats["active_anon"]; ok {
-		ret.Memory.WorkingSet = v
-		if v, ok := s.MemoryStats.Stats["active_file"]; ok {
-			ret.Memory.WorkingSet += v
+	if v, ok := s.MemoryStats.Stats["total_inactive_anon"]; ok {
+		ret.Memory.WorkingSet = ret.Memory.Usage - v
+		if v, ok := s.MemoryStats.Stats["total_active_file"]; ok {
+			ret.Memory.WorkingSet -= v
 		}
 	}
 	return ret


### PR DESCRIPTION
lmctfy uses `memory.idle_page_stats` to calculate the working set. However, this file is currently not available in upstream kernel. Instead, we use active LRU to calculate working set.
