### PR TITLE
Fix a bug when using influxdb: GUI shows negative CPU usage

### DIFF
--- a/storage/influxdb/influxdb.go
+++ b/storage/influxdb/influxdb.go
@@ -331,8 +331,13 @@ func (self *influxdbStorage) RecentStats(containerName string, numStats int) ([]
 		return nil, err
 	}
 	statsList := make([]*info.ContainerStats, 0, len(series))
-	for _, s := range series {
-		for _, values := range s.Points {
+	// By default, influxDB returns data in time descending order.
+	// RecentStats() requires stats in time increasing order,
+	// so we need to go through from the last one to the first one.
+	for i := len(series) - 1; i >= 0; i-- {
+		s := series[i]
+		for j := len(s.Points) - 1; j >= 0; j-- {
+			values := s.Points[j]
 			stats, err := self.valuesToContainerStats(s.Columns, values)
 			if err != nil {
 				return nil, err
@@ -358,8 +363,10 @@ func (self *influxdbStorage) Samples(containerName string, numSamples int) ([]*i
 		return nil, err
 	}
 	sampleList := make([]*info.ContainerStatsSample, 0, len(series))
-	for _, s := range series {
-		for _, values := range s.Points {
+	for i := len(series) - 1; i >= 0; i-- {
+		s := series[i]
+		for j := len(s.Points) - 1; j >= 0; j-- {
+			values := s.Points[j]
 			sample, err := self.valuesToContainerSample(s.Columns, values)
 			if err != nil {
 				return nil, err

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -21,7 +21,9 @@ type StorageDriver interface {
 
 	// Read most recent stats. numStats indicates max number of stats
 	// returned. The returned stats must be consecutive observed stats. If
-	// numStats < 0, then return all stats stored in the storage.
+	// numStats < 0, then return all stats stored in the storage. The
+	// returned stats should be sorted in time increasing order, i.e. Most
+	// recent stats should be the last.
 	RecentStats(containerName string, numStats int) ([]*info.ContainerStats, error)
 
 	// Read the specified percentiles of CPU and memory usage of the container.

--- a/storage/test/storagetests.go
+++ b/storage/test/storagetests.go
@@ -392,14 +392,10 @@ func StorageDriverTestRetrievePartialRecentStats(driver storage.StorageDriver, t
 
 	actualRecentStats := trace[len(trace)-len(recentStats):]
 
-	for _, r := range recentStats {
-		found := false
-		for _, s := range actualRecentStats {
-			if statsEq(s, r) {
-				found = true
-			}
-		}
-		if !found {
+	// The returned stats should be sorted in time increasing order
+	for i, s := range actualRecentStats {
+		r := recentStats[i]
+		if !statsEq(s, r) {
 			t.Errorf("unexpected stats %+v with memory usage %v", r, r.Memory.Usage)
 		}
 	}
@@ -438,14 +434,10 @@ func StorageDriverTestRetrieveAllRecentStats(driver storage.StorageDriver, t *te
 
 	actualRecentStats := trace[len(trace)-len(recentStats):]
 
-	for _, r := range recentStats {
-		found := false
-		for _, s := range actualRecentStats {
-			if statsEq(s, r) {
-				found = true
-			}
-		}
-		if !found {
+	// The returned stats should be sorted in time increasing order
+	for i, s := range actualRecentStats {
+		r := recentStats[i]
+		if !statsEq(s, r) {
 			t.Errorf("unexpected stats %+v with memory usage %v", r, r.Memory.Usage)
 		}
 	}


### PR DESCRIPTION
Influxdb returns data in time descending order. However, our GUI assumes that data is in time increasing order. This gives us negative CPU usage on the page when using influxdb.

In this PR, we require the storage driver to return stats in time increasing order.
