### PR TITLE
Remove support for influxdb until influxdb/influxdb#756 get fixed

### DIFF
--- a/storage/influxdb/influxdb.go
+++ b/storage/influxdb/influxdb.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 package influxdb
 
 import (
@@ -22,7 +24,7 @@ import (
 
 	"github.com/google/cadvisor/info"
 	"github.com/google/cadvisor/storage"
-	"github.com/influxdb/influxdb-go"
+	"github.com/influxdb/influxdb/client"
 )
 
 type influxdbStorage struct {

--- a/storage/influxdb/influxdb_test.go
+++ b/storage/influxdb/influxdb_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 package influxdb
 
 import (
@@ -21,7 +23,7 @@ import (
 
 	"github.com/google/cadvisor/storage"
 	"github.com/google/cadvisor/storage/test"
-	"github.com/influxdb/influxdb-go"
+	"github.com/influxdb/influxdb/client"
 )
 
 func runStorageTest(f func(storage.StorageDriver, *testing.T), t *testing.T) {

--- a/storagedriver.go
+++ b/storagedriver.go
@@ -17,11 +17,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
-	"time"
 
 	"github.com/google/cadvisor/storage"
-	"github.com/google/cadvisor/storage/influxdb"
 	"github.com/google/cadvisor/storage/memory"
 )
 
@@ -43,24 +40,26 @@ func NewStorageDriver(driverName string) (storage.StorageDriver, error) {
 	case "memory":
 		storageDriver = memory.New(*argSampleSize, *argHistoryDuration)
 		return storageDriver, nil
-	case "influxdb":
-		var hostname string
-		hostname, err = os.Hostname()
-		if err != nil {
-			return nil, err
-		}
+	/*
+		case "influxdb":
+			var hostname string
+			hostname, err = os.Hostname()
+			if err != nil {
+				return nil, err
+			}
 
-		storageDriver, err = influxdb.New(
-			hostname,
-			"cadvisorTable",
-			*argDbName,
-			*argDbUsername,
-			*argDbPassword,
-			*argDbHost,
-			*argDbIsSecure,
-			// TODO(monnand): One hour? Or user-defined?
-			1*time.Hour,
-		)
+			storageDriver, err = influxdb.New(
+				hostname,
+				"cadvisorTable",
+				*argDbName,
+				*argDbUsername,
+				*argDbPassword,
+				*argDbHost,
+				*argDbIsSecure,
+				// TODO(monnand): One hour? Or user-defined?
+				1*time.Hour,
+			)
+	*/
 	default:
 		err = fmt.Errorf("Unknown database driver: %v", *argDbDriver)
 	}


### PR DESCRIPTION
This is very unfortunate but we cannot support influxdb since influxdb/influxdb#756 is not fixed. We could enable it later if its client package becomes go-get-able again.
