### PR TITLE
influxdb changed their API, again.

### DIFF
--- a/storage/influxdb/influxdb.go
+++ b/storage/influxdb/influxdb.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/cadvisor/info"
 	"github.com/google/cadvisor/storage"
-	"github.com/influxdb/influxdb/client"
+	influxdb "github.com/influxdb/influxdb/client"
 )
 
 type influxdbStorage struct {

--- a/storage/influxdb/influxdb_test.go
+++ b/storage/influxdb/influxdb_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/cadvisor/storage"
 	"github.com/google/cadvisor/storage/test"
-	"github.com/influxdb/influxdb/client"
+	influxdb "github.com/influxdb/influxdb/client"
 )
 
 func runStorageTest(f func(storage.StorageDriver, *testing.T), t *testing.T) {


### PR DESCRIPTION
In influxdb/influxdb@f6ae65d1, influxdb changed the package name of their client library.

@vishh, once this PR merged, you need to do a rebase for #96 to pass CI.
