### PR TITLE
Fix cpu limit to report cpu shares.

### DIFF
--- a/pages/containers.go
+++ b/pages/containers.go
@@ -36,6 +36,7 @@ var funcMap = template.FuncMap{
 	"containerLink":         containerLink,
 	"printMask":             printMask,
 	"printCores":            printCores,
+	"printShares":           printShares,
 	"printMegabytes":        printMegabytes,
 	"getMemoryUsage":        getMemoryUsage,
 	"getMemoryUsagePercent": getMemoryUsagePercent,
@@ -136,6 +137,10 @@ func printCores(millicores *uint64) string {
 	}
 	cores := float64(*millicores) / 1000
 	return strconv.FormatFloat(cores, 'f', 3, 64)
+}
+
+func printShares(shares *uint64) string {
+	return fmt.Sprintf("%d", *shares)
 }
 
 func toMegabytes(bytes uint64) float64 {

--- a/pages/containers_html.go
+++ b/pages/containers_html.go
@@ -68,7 +68,7 @@ const containersHtmlTemplate = `
 	<ul class="list-group">
           <li class="list-group-item active isolation-title panel-title">CPU</li>
           {{if .Spec.Cpu.Limit}}
-          <li class="list-group-item"><span class="stat-label">Limit</span> {{printCores .Spec.Cpu.Limit}} <span class="unit-label">cores</span></li>
+          <li class="list-group-item"><span class="stat-label">Shares</span> {{printShares .Spec.Cpu.Limit}} <span class="unit-label">shares</span></li>
           {{end}}
           {{if .Spec.Cpu.MaxLimit}}
           <li class="list-group-item"><span class="stat-label">Max Limit</span> {{printCores .Spec.Cpu.MaxLimit}} <span class="unit-label">cores</span></li>


### PR DESCRIPTION
It is currently treating shares as millicores.

Changed 'CPU Limit 1.024 cores' to 'CPU shares 1024 shares'.

Docker-DCO-1.1-Signed-off-by: Rohit Jnagal jnagal@google.com (github: rjnagal)
