### PR TITLE
Create cAdvisor client without querying machine information. 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -50,7 +50,6 @@ func (self *Client) MachineInfo() (minfo *info.MachineInfo, err error) {
 		return
 	}
 	minfo = ret
-
 	return
 }
 


### PR DESCRIPTION
Fixed https://github.com/GoogleCloudPlatform/kubernetes/issues/608
