### PR TITLE
Fix cpu gauge to show percent of machine cpu capacity being used by a container.

### DIFF
--- a/pages/static/containers_js.go
+++ b/pages/static/containers_js.go
@@ -168,7 +168,7 @@ function drawOverallUsage(elementId, machineInfo, containerInfo) {
 		var rawUsage = cur.cpu.usage.total - prev.cpu.usage.total;
 
 		// Convert to millicores and take the percentage
-		cpuUsage = Math.round(((rawUsage / 1000000) / containerInfo.spec.cpu.limit) * 100);
+		cpuUsage = Math.round(((rawUsage / 1000000) / (machineInfo.num_cores * 1000)) * 100);
 		if (cpuUsage > 100) {
 			cpuUsage = 100;
 		}


### PR DESCRIPTION
Fix cpu gauge to show percent of machine cpu capacity being used by a container.
For a container using one full core on a 4-core machine, the gauge will show 25% usage.

Docker-DCO-1.1-Signed-off-by: Rohit Jnagal jnagal@google.com (github: rjnagal)
