### PR TITLE
unit test for SplitName()

### DIFF
--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -1,8 +1,21 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (
 	"bufio"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -10,8 +23,9 @@ import (
 
 	"github.com/docker/libcontainer"
 	"github.com/docker/libcontainer/cgroups"
-	"github.com/docker/libcontainer/cgroups/fs"
+	cgroupfs "github.com/docker/libcontainer/cgroups/fs"
 	"github.com/google/cadvisor/info"
+	"github.com/google/cadvisor/utils/fs"
 )
 
 // Get stats of the specified container
@@ -25,7 +39,7 @@ func GetStats(config *libcontainer.Config, state *libcontainer.State) (*info.Con
 }
 
 func GetStatsCgroupOnly(cgroup *cgroups.Cgroup) (*info.ContainerStats, error) {
-	s, err := fs.GetStats(cgroup)
+	s, err := cgroupfs.GetStats(cgroup)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +92,7 @@ func toContainerStats(libcontainerStats *libcontainer.ContainerStats) *info.Cont
 // Given a container name, returns the parent and name of the container to be fed to libcontainer.
 func SplitName(containerName string) (string, string, error) {
 	parent, id := path.Split(containerName)
-	cgroupSelf, err := os.Open("/proc/1/cgroup")
+	cgroupSelf, err := fs.Open("/proc/1/cgroup")
 	if err != nil {
 		return "", "", err
 	}

--- a/container/libcontainer/helpers_test.go
+++ b/container/libcontainer/helpers_test.go
@@ -1,0 +1,90 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libcontainer
+
+import (
+	"testing"
+
+	"code.google.com/p/gomock/gomock"
+
+	"github.com/google/cadvisor/utils/fs"
+	"github.com/google/cadvisor/utils/fs/mockfs"
+)
+
+var initCgroupsToParentAndID = []struct {
+	InitCgroupFileContent string
+	ContainerPath         string
+	Parent                string
+	Id                    string
+	Error                 error
+}{
+	{
+		`
+11:name=systemd:/
+10:hugetlb:/
+9:perf_event:/
+8:blkio:/
+7:freezer:/
+6:devices:/
+5:memory:/
+4:cpuacct:/
+3:cpu:/
+2:cpuset:/
+`,
+		"/",
+		"",
+		"",
+		nil,
+	},
+	{
+		`
+11:name=systemd:/
+10:hugetlb:/
+9:perf_event:/
+8:blkio:/
+7:freezer:/
+6:devices:/
+5:memory:/docker/hash
+4:cpuacct:/
+3:cpu:/docker/hash
+2:cpuset:/
+`,
+		"/parent/id",
+		"../../parent",
+		"id",
+		nil,
+	},
+}
+
+func TestSplitName(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	for _, testCase := range initCgroupsToParentAndID {
+		mfs := mockfs.NewMockFileSystem(mockCtrl)
+		mockfs.AddTextFile(mfs, "/proc/1/cgroup", testCase.InitCgroupFileContent)
+		fs.ChangeFileSystem(mfs)
+		parent, id, err := SplitName(testCase.ContainerPath)
+		if testCase.Error != nil {
+			if err == nil {
+				t.Fatalf("did not receive expected error.\ncontent:%v\n, path:%v\n, expected error:%v\n", testCase.InitCgroupFileContent, testCase.ContainerPath, testCase.Error)
+			}
+			continue
+		}
+		if testCase.Parent != parent || testCase.Id != id {
+			t.Errorf("unexpected parent or id:\ncontent:%v\npath:%v\nexpected parent: %v; recevied parent: %v;\nexpected id: %v; received id: %v", testCase.InitCgroupFileContent, testCase.ContainerPath, testCase.Parent, parent, testCase.Id, id)
+		}
+	}
+}


### PR DESCRIPTION
Use the mock file system to test `SplitName()`.
