### PR TITLE
Factor out data comparator for storage tests.

### DIFF
--- a/storage/cache/memcache_test.go
+++ b/storage/cache/memcache_test.go
@@ -22,14 +22,17 @@ import (
 	"github.com/google/cadvisor/storage/test"
 )
 
-func runStorageTest(f func(storage.StorageDriver, *testing.T), t *testing.T) {
+func runStorageTest(f func(test.TestStorageDriver, *testing.T), t *testing.T) {
 	maxSize := 200
 
 	var driver storage.StorageDriver
+	var testDriver test.TestStorageDriver
+	testDriver.StatsEq = test.DefaultStatsEq
 	for N := 10; N < maxSize; N += 10 {
 		backend := memory.New(N*2, N*2)
 		driver = MemoryCache(N, N, backend)
-		f(driver, t)
+		testDriver.Driver = driver
+		f(testDriver, t)
 	}
 
 }
@@ -54,7 +57,8 @@ func TestPercentiles(t *testing.T) {
 	N := 100
 	backend := memory.New(N*2, N*2)
 	driver := MemoryCache(N, N, backend)
-	test.StorageDriverTestPercentiles(driver, t)
+	testDriver := test.TestStorageDriver{Driver: driver, StatsEq: test.DefaultStatsEq}
+	test.StorageDriverTestPercentiles(testDriver, t)
 }
 
 func TestRetrievePartialRecentStats(t *testing.T) {

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -21,13 +21,16 @@ import (
 	"github.com/google/cadvisor/storage/test"
 )
 
-func runStorageTest(f func(storage.StorageDriver, *testing.T), t *testing.T) {
+func runStorageTest(f func(test.TestStorageDriver, *testing.T), t *testing.T) {
 	maxSize := 200
 
 	var driver storage.StorageDriver
+	var testDriver test.TestStorageDriver
+	testDriver.StatsEq = test.DefaultStatsEq
 	for N := 10; N < maxSize; N += 10 {
 		driver = New(N, N)
-		f(driver, t)
+		testDriver.Driver = driver
+		f(testDriver, t)
 	}
 
 }
@@ -51,7 +54,8 @@ func TestPercentilesWithoutSample(t *testing.T) {
 func TestPercentiles(t *testing.T) {
 	N := 100
 	driver := New(N, N)
-	test.StorageDriverTestPercentiles(driver, t)
+	testDriver := test.TestStorageDriver{Driver: driver, StatsEq: test.DefaultStatsEq}
+	test.StorageDriverTestPercentiles(testDriver, t)
 }
 
 func TestRetrievePartialRecentStats(t *testing.T) {


### PR DESCRIPTION
For influxdb, we are planning to export lesser data. Having a separate
comparator will let us reuse the same tests.

Docker-DCO-1.1-Signed-off-by: Rohit Jnagal jnagal@google.com (github: rjnagal)
