### PR TITLE
Fix storage driver buffer duration default value.

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -27,6 +27,9 @@ import (
 	"github.com/google/cadvisor/storage"
 )
 
+// Housekeeping duration
+const HousekeepingTick = 1 * time.Second
+
 // Internal mirror of the external data structure.
 type containerStat struct {
 	Timestamp time.Time
@@ -105,7 +108,7 @@ func NewContainerData(containerName string, driver storage.StorageDriver) (*cont
 
 func (c *containerData) housekeeping() {
 	// Housekeep every second.
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(HousekeepingTick)
 	defer ticker.Stop()
 	for {
 		select {

--- a/pages/static/containers_js.go
+++ b/pages/static/containers_js.go
@@ -92,6 +92,7 @@ function getMachineInfo(callback) {
 function getStats(containerName, callback) {
 	// Request 60s of container history and no samples.
 	var request = JSON.stringify({
+                // Update main.statsRequestedByUI while updating "num_stats" here.
 		"num_stats": 60,
 		"num_samples": 0
 	});


### PR DESCRIPTION
The cache will now hold atlest the minimum number of stats required by the UI and more
if the buffer duration is longer than the default.

Docker-DCO-1.1-Signed-off-by: Vishnu Kannan vishnuk@google.com (github: vishh)
