### PR TITLE
[WIP] Making AddStats() accept multiple parameters.

### DIFF
--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -23,31 +23,11 @@ import (
 )
 
 type memoryTestStorageDriver struct {
-	base storage.StorageDriver
+	storage.StorageDriver
 }
 
 func (self *memoryTestStorageDriver) StatsEq(a, b *info.ContainerStats) bool {
 	return test.DefaultStatsEq(a, b)
-}
-
-func (self *memoryTestStorageDriver) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
-	return self.base.AddStats(ref, stats)
-}
-
-func (self *memoryTestStorageDriver) RecentStats(containerName string, numStats int) ([]*info.ContainerStats, error) {
-	return self.base.RecentStats(containerName, numStats)
-}
-
-func (self *memoryTestStorageDriver) Percentiles(containerName string, cpuUsagePercentiles []int, memUsagePercentiles []int) (*info.ContainerStatsPercentiles, error) {
-	return self.base.Percentiles(containerName, cpuUsagePercentiles, memUsagePercentiles)
-}
-
-func (self *memoryTestStorageDriver) Samples(containerName string, numSamples int) ([]*info.ContainerStatsSample, error) {
-	return self.base.Samples(containerName, numSamples)
-}
-
-func (self *memoryTestStorageDriver) Close() error {
-	return self.base.Close()
 }
 
 func runStorageTest(f func(test.TestStorageDriver, *testing.T), t *testing.T) {
@@ -55,7 +35,7 @@ func runStorageTest(f func(test.TestStorageDriver, *testing.T), t *testing.T) {
 
 	for N := 10; N < maxSize; N += 10 {
 		testDriver := &memoryTestStorageDriver{}
-		testDriver.base = New(N, N)
+		testDriver.StorageDriver = New(N, N)
 		f(testDriver, t)
 	}
 }
@@ -79,7 +59,7 @@ func TestPercentilesWithoutSample(t *testing.T) {
 func TestPercentiles(t *testing.T) {
 	N := 100
 	testDriver := &memoryTestStorageDriver{}
-	testDriver.base = New(N, N)
+	testDriver.StorageDriver = New(N, N)
 	test.StorageDriverTestPercentiles(testDriver, t)
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -16,8 +16,18 @@ package storage
 
 import "github.com/google/cadvisor/info"
 
+type ContainerRefStatsPair struct {
+	Reference info.ContainerReference
+	Stats     []*info.ContainerStats
+}
+
 type StorageDriver interface {
-	AddStats(ref info.ContainerReference, stats *info.ContainerStats) error
+	// Write a series of stats into the storage. This method could be
+	// either an atomic operation (i.e. all or nothing), or a sequence of
+	// write operations depending on the underlying storage driver
+	// implementation. This means it may write partial data into the
+	// storage and return an error.
+	AddStats(pairs ...ContainerRefStatsPair) error
 
 	// Read most recent stats. numStats indicates max number of stats
 	// returned. The returned stats must be consecutive observed stats. If

--- a/storage/test/mock.go
+++ b/storage/test/mock.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"github.com/google/cadvisor/info"
+	"github.com/google/cadvisor/storage"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -24,8 +25,8 @@ type MockStorageDriver struct {
 	MockCloseMethod bool
 }
 
-func (self *MockStorageDriver) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
-	args := self.Called(ref, stats)
+func (self *MockStorageDriver) AddStats(pairs ...storage.ContainerRefStatsPair) error {
+	args := self.Called(pairs)
 	return args.Error(0)
 }
 

--- a/storage/test/storagetests.go
+++ b/storage/test/storagetests.go
@@ -183,7 +183,7 @@ func StorageDriverFillRandomStatsFunc(
 	trace := buildTrace(cpuTrace, memTrace, samplePeriod)
 
 	for _, stats := range trace {
-		err := driver.AddStats(ref, stats)
+		err := driver.AddStats(storage.ContainerRefStatsPair{ref, []*info.ContainerStats{stats}})
 		if err != nil {
 			t.Fatalf("unable to add stats: %v", err)
 		}
@@ -211,7 +211,7 @@ func StorageDriverTestSampleCpuUsage(driver TestStorageDriver, t *testing.T) {
 	trace := buildTrace(cpuTrace, memTrace, samplePeriod)
 
 	for _, stats := range trace {
-		err := driver.AddStats(ref, stats)
+		err := driver.AddStats(storage.ContainerRefStatsPair{ref, []*info.ContainerStats{stats}})
 		if err != nil {
 			t.Fatalf("unable to add stats: %v", err)
 		}
@@ -261,7 +261,7 @@ func StorageDriverTestMaxMemoryUsage(driver TestStorageDriver, t *testing.T) {
 	trace := buildTrace(cpuTrace, memTrace, 1*time.Second)
 
 	for _, stats := range trace {
-		err := driver.AddStats(ref, stats)
+		err := driver.AddStats(storage.ContainerRefStatsPair{ref, []*info.ContainerStats{stats}})
 		if err != nil {
 			t.Fatalf("unable to add stats: %v", err)
 		}
@@ -292,7 +292,10 @@ func StorageDriverTestSamplesWithoutSample(driver TestStorageDriver, t *testing.
 	ref := info.ContainerReference{
 		Name: "container",
 	}
-	driver.AddStats(ref, trace[0])
+	err := driver.AddStats(storage.ContainerRefStatsPair{ref, trace})
+	if err != nil {
+		t.Fatal(err)
+	}
 	samples, err := driver.Samples(ref.Name, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -311,7 +314,10 @@ func StorageDriverTestPercentilesWithoutSample(driver TestStorageDriver, t *test
 	ref := info.ContainerReference{
 		Name: "container",
 	}
-	driver.AddStats(ref, trace[0])
+	err := driver.AddStats(storage.ContainerRefStatsPair{ref, trace})
+	if err != nil {
+		t.Fatal(err)
+	}
 	percentiles, err := driver.Percentiles(
 		ref.Name,
 		[]int{50},
@@ -340,8 +346,9 @@ func StorageDriverTestPercentiles(driver TestStorageDriver, t *testing.T) {
 	ref := info.ContainerReference{
 		Name: "container",
 	}
-	for _, stats := range trace {
-		driver.AddStats(ref, stats)
+	err := driver.AddStats(storage.ContainerRefStatsPair{ref, trace})
+	if err != nil {
+		t.Fatal(err)
 	}
 	percentages := []int{
 		80,
@@ -387,8 +394,9 @@ func StorageDriverTestRetrievePartialRecentStats(driver TestStorageDriver, t *te
 
 	trace := buildTrace(cpuTrace, memTrace, 1*time.Second)
 
-	for _, stats := range trace {
-		driver.AddStats(ref, stats)
+	err := driver.AddStats(storage.ContainerRefStatsPair{ref, trace})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	recentStats, err := driver.RecentStats(ref.Name, 10)
@@ -430,8 +438,9 @@ func StorageDriverTestRetrieveAllRecentStats(driver TestStorageDriver, t *testin
 
 	trace := buildTrace(cpuTrace, memTrace, 1*time.Second)
 
-	for _, stats := range trace {
-		driver.AddStats(ref, stats)
+	err := driver.AddStats(storage.ContainerRefStatsPair{ref, trace})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	recentStats, err := driver.RecentStats(ref.Name, -1)
@@ -511,9 +520,9 @@ func StorageDriverTestRetrieveZeroRecentStats(driver TestStorageDriver, t *testi
 	}
 
 	trace := buildTrace(cpuTrace, memTrace, 1*time.Second)
-
-	for _, stats := range trace {
-		driver.AddStats(ref, stats)
+	err := driver.AddStats(storage.ContainerRefStatsPair{ref, trace})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	recentStats, err := driver.RecentStats(ref.Name, 0)
@@ -541,8 +550,9 @@ func StorageDriverTestRetrieveZeroSamples(driver TestStorageDriver, t *testing.T
 
 	trace := buildTrace(cpuTrace, memTrace, 1*time.Second)
 
-	for _, stats := range trace {
-		driver.AddStats(ref, stats)
+	err := driver.AddStats(storage.ContainerRefStatsPair{ref, trace})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	samples, err := driver.Samples(ref.Name, 0)


### PR DESCRIPTION
This PR follows up the discussion on #200. It changes the StorageDriver interface so that `AddStats()` will accept multiple stats making the underlying implementation possible to do batch writes.
