### PR TITLE
Make housekeeping interval dynamic, fist signal is resource usage.

### DIFF
--- a/info/container.go
+++ b/info/container.go
@@ -330,6 +330,11 @@ func (a *ContainerStats) Eq(b *ContainerStats) bool {
 	if !timeEq(a.Timestamp, b.Timestamp, timePrecision) {
 		return false
 	}
+	return a.StatsEq(b)
+}
+
+// Checks equality of the stats values.
+func (a *ContainerStats) StatsEq(b *ContainerStats) bool {
 	if !reflect.DeepEqual(a.Cpu, b.Cpu) {
 		return false
 	}


### PR DESCRIPTION
If no resources are used by the container since the last housekeeping,
we double the housekeeping interval until --max_housekeeping_interval.
If usage was detected, we drop it back to the baseline
(--housekeeping_interval).

From my tests this reduces CPU usage in CoreOS from ~8% to ~3% with no
real loss of accuracy.

Fixes #159
