### PR TITLE
Adding the pprof HTTP service to cAdvisor.

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"runtime"
 
 	"github.com/golang/glog"


### PR DESCRIPTION
This does not consume any resources unless the resources are queried.
