### PR TITLE
Avoid compiling cadvisor statically for the docker image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,11 +1,8 @@
-FROM scratch
-MAINTAINER dengnan@google.com vmarmol@google.com
-
-# NOTE: Run prepare.sh before building this Docker image.
+FROM progrium/busybox
+MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com
 
 # Grab cadvisor from the staging directory.
 ADD cadvisor /usr/bin/cadvisor
 
 EXPOSE 8080
-ENTRYPOINT ["/usr/bin/cadvisor"] 
-CMD ["-log_dir", "/"]
+ENTRYPOINT ["/usr/bin/cadvisor"]

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+set -x
+
+godep go build -a github.com/google/cadvisor
+
+sudo docker build -t google/cadvisor:test .

--- a/deploy/prepare.sh
+++ b/deploy/prepare.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-set -x
-
-# Statically build cAdvisor from source and stage it.
-godep go build -a --ldflags '-extldflags "-static"' github.com/google/cadvisor

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/golang/glog"
 	"github.com/google/cadvisor/info"
 	"github.com/google/cadvisor/storage"
 )
@@ -104,7 +105,9 @@ func (self *InMemoryStorage) AddStats(ref info.ContainerReference, stats *info.C
 		// TODO(monnand): To deal with long delay write operations, we
 		// may want to start a pool of goroutines to do write
 		// operations.
-		self.backend.AddStats(ref, stats)
+		if err := self.backend.AddStats(ref, stats); err != nil {
+			glog.Error(err)
+		}
 	}
 	return cstore.AddStats(stats)
 }


### PR DESCRIPTION
This change does the following:
1. Derive cadvisor image from a stripped down busybox image. This is done to support DNS lookup. The image size is now ~20MB.
2. Log failures encountered while dumping to influxdb.
3. Handle critical failures in cadvisor gracefully without getting stuck.
