### PR TITLE
Put client inside its own package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // TODO(cAdvisor): Package comment.
-package cadvisor
+package client
 
 import (
 	"bytes"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cadvisor
+package client
 
 import (
 	"encoding/json"


### PR DESCRIPTION
This will let me do things like import "github.com/google/cadvisor/client" without needing to include all of cadvisor in my project.
