### PR TITLE
Added iostats for partitions

### DIFF
--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -188,7 +188,20 @@ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 			return err
 		}
 		for _, fs := range filesystems {
-			stats.Filesystem = append(stats.Filesystem, info.FsStats{fs.Device, fs.Capacity, fs.Capacity - fs.Free})
+			stats.Filesystem = append(stats.Filesystem,
+				info.FsStats{fs.Device, fs.Capacity, fs.Capacity - fs.Free,
+					fs.DiskStats.ReadsMerged,
+					fs.DiskStats.WritesMerged,
+					fs.DiskStats.ReadsIssued,
+					fs.DiskStats.WritesIssued,
+					fs.DiskStats.SectorsRead,
+					fs.DiskStats.SectorsWritten,
+					fs.DiskStats.AvgRequestSize,
+					fs.DiskStats.AvgQueueLen,
+					fs.DiskStats.AvgWaitTime,
+					fs.DiskStats.AvgServiceTime,
+					fs.DiskStats.PercentUtil,
+				})
 		}
 	} else if len(self.externalMounts) > 0 {
 		var mountSet map[string]struct{}
@@ -201,7 +214,20 @@ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 			return err
 		}
 		for _, fs := range filesystems {
-			stats.Filesystem = append(stats.Filesystem, info.FsStats{fs.Device, fs.Capacity, fs.Capacity - fs.Free})
+			stats.Filesystem = append(stats.Filesystem,
+				info.FsStats{fs.Device, fs.Capacity, fs.Capacity - fs.Free,
+					fs.DiskStats.ReadsMerged,
+					fs.DiskStats.WritesMerged,
+					fs.DiskStats.ReadsIssued,
+					fs.DiskStats.WritesIssued,
+					fs.DiskStats.SectorsRead,
+					fs.DiskStats.SectorsWritten,
+					fs.DiskStats.AvgRequestSize,
+					fs.DiskStats.AvgQueueLen,
+					fs.DiskStats.AvgWaitTime,
+					fs.DiskStats.AvgServiceTime,
+					fs.DiskStats.PercentUtil,
+				})
 		}
 	}
 	return nil

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -12,6 +12,7 @@ import "C"
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -53,10 +54,11 @@ func NewFsInfo() (FsInfo, error) {
 func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error) {
 	filesystems := make([]Fs, 0)
 	deviceSet := make(map[string]struct{})
+
 	for device, partition := range self.partitions {
 		_, hasMount := mountSet[partition.mountpoint]
 		_, hasDevice := deviceSet[device]
-		if mountSet == nil ||  hasMount && !hasDevice {
+		if mountSet == nil || hasMount && !hasDevice {
 			total, free, err := getVfsStats(partition.mountpoint)
 			if err != nil {
 				glog.Errorf("Statvfs failed. Error: %v", err)
@@ -67,12 +69,60 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
 					Major:  uint(partition.major),
 					Minor:  uint(partition.minor),
 				}
-				fs := Fs{deviceInfo, total, free}
+				var diskStats DiskStats
+				out, err := exec.Command("iostat", "-d", "-x", device).CombinedOutput()
+				if err != nil {
+					glog.Errorf("iostat failed on device %s. Error: %v", device, err)
+				} else {
+					diskStats, err = getDiskStats(string(out))
+					if err != nil {
+						glog.Errorf("Error parsing iostat output %s", out)
+					}
+				}
+
+				fs := Fs{deviceInfo, total, free, diskStats}
 				filesystems = append(filesystems, fs)
 			}
 		}
 	}
 	return filesystems, nil
+}
+
+func getDiskStats(ioStatOutput string) (DiskStats, error) {
+	partitionRegex, _ := regexp.Compile("^sd[a-z]\\d\\s[\\d+\\.\\s+]+")
+	var diskStats DiskStats
+	for _, line := range strings.Split(ioStatOutput, "\n") {
+		if !partitionRegex.MatchString(line) {
+			continue
+		}
+		words := strings.Fields(line)
+
+		// 8      50 sdd2 40 0 280 223 7 0 22 108 0 330 330
+		offset := 1
+		wordLength := len(words)
+		var stats = make([]float64, wordLength-offset)
+		var error error
+		for i := offset; i < wordLength; i++ {
+			stats[i-offset], error = strconv.ParseFloat(words[i], 64)
+			if error != nil {
+				return diskStats, error
+			}
+		}
+		diskStats = DiskStats{
+			ReadsMerged:    stats[0],
+			WritesMerged:   stats[1],
+			ReadsIssued:    stats[2],
+			WritesIssued:   stats[3],
+			SectorsRead:    stats[4],
+			SectorsWritten: stats[5],
+			AvgRequestSize: stats[6],
+			AvgQueueLen:    stats[7],
+			AvgWaitTime:    stats[8],
+			AvgServiceTime: stats[9],
+			PercentUtil:    stats[10],
+		}
+	}
+	return diskStats, nil
 }
 
 func (self *RealFsInfo) GetGlobalFsInfo() ([]Fs, error) {

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,0 +1,33 @@
+package fs
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+)
+
+func TestGetDiskStatsMap(t *testing.T) {
+	dat, err := ioutil.ReadFile("test_resources/diskstats")
+	diskStats, err := getDiskStats(string(dat))
+	if err != nil {
+		t.Errorf("Error calling getDiskStats %s", err)
+	}
+
+	correctDiskStats := DiskStats{
+		ReadsMerged:    13.0,
+		WritesMerged:   33.0,
+		ReadsIssued:    0.89,
+		WritesIssued:   0.94,
+		SectorsRead:    37.01,
+		SectorsWritten: 79.43,
+		AvgRequestSize: 63.84,
+		AvgQueueLen:    3,
+		AvgWaitTime:    5,
+		AvgServiceTime: 6,
+		PercentUtil:    5,
+	}
+
+	if !reflect.DeepEqual(diskStats, correctDiskStats) {
+		t.Errorf("diskStats %s not valid", diskStats)
+	}
+}

--- a/fs/test_resources/diskstats
+++ b/fs/test_resources/diskstats
@@ -1,0 +1,4 @@
+Linux 3.15.5-15.alti6.x86_64 (203-13-02.sc1.verticloud.com) 	10/23/2014 	_x86_64_	(24 CPU)
+
+Device:         rrqm/s   wrqm/s     r/s     w/s   rsec/s   wsec/s avgrq-sz avgqu-sz   await  svctm  %util
+sdc1               13.00     33.00    0.89    0.94    37.01    79.43    63.84     3.00    5.00   6.00   5.00

--- a/fs/types.go
+++ b/fs/types.go
@@ -8,8 +8,23 @@ type DeviceInfo struct {
 
 type Fs struct {
 	DeviceInfo
-	Capacity uint64
-	Free     uint64
+	Capacity  uint64
+	Free      uint64
+	DiskStats DiskStats
+}
+
+type DiskStats struct {
+	ReadsMerged    float64
+	WritesMerged   float64
+	ReadsIssued    float64
+	WritesIssued   float64
+	SectorsRead    float64
+	SectorsWritten float64
+	AvgRequestSize float64
+	AvgQueueLen    float64
+	AvgWaitTime    float64
+	AvgServiceTime float64
+	PercentUtil    float64
 }
 
 type FsInfo interface {

--- a/info/container.go
+++ b/info/container.go
@@ -240,6 +240,45 @@ type FsStats struct {
 
 	// Number of bytes that is consumed by the container on this filesystem.
 	Usage uint64 `json:"usage"`
+
+	// The number of read requests merged per second that were queued to the device.
+	ReadsMerged float64 `json:"reads_merged"`
+
+	// The number of write requests merged per second that were queued to the device
+	WritesMerged float64 `json:"writes_merged"`
+
+	// The number of read requests that were issued to the device per second.
+	ReadsIssued float64 `json:"reads_issued"`
+
+	// The number of write requests that were issued to the device per second.
+	WritesIssued float64 `json:"writes_issued"`
+
+	// The number of sectors read to the device per second.
+	SectorsRead float64 `json:"sectors_read"`
+
+	// The number of sectors written to the device per second.
+	SectorsWritten float64 `json:"sectors_written"`
+
+	// The average size (in sectors) of the requests that were issued to the device.
+	AvgRequestSize float64 `json:"avg_request_size"`
+
+	// The average queue length of the requests that were issued to the device.
+	AvgQueueLen float64 `json:"avg_queue_length"`
+
+	// The  average  time  (in  milliseconds)  for  I/O  requests issued to the
+	// device to be served. This includes the time spent by the requests in queue
+	// and the time spent servicing them
+	AvgWaitTime float64 `json:"avg_wait_time"`
+
+	// The  average  service time (in milliseconds) for I/O requests that were issued to
+	// the device. Warning! Do not trust this field any more. This field will be removed
+	// in a future iostat version
+	AvgServiceTime float64 `json:"avg_service_time"`
+
+	//Percentage of CPU time during which I/O requests were issued to the device
+	// (bandwidth utilization for the device). Device saturation occurs when this
+	// value is close to 100%.
+	PercentUtil float64 `json:"avg_service_time"`
 }
 
 type ContainerStats struct {


### PR DESCRIPTION
Read disk io information from iostats.
This will allow the user who provides partition container hints to get partition-specific io (blkio provides io for the container, but at the disk device level).
