### PR TITLE
Fix logic for deciding if Docker container was not found.

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -275,12 +275,11 @@ func (self *manager) DockerContainersInfo(containerName string, query *info.Cont
 				}
 			}
 		} else {
-			// Strip "/"
+			// Strip first "/"
 			containerName = strings.Trim(containerName, "/")
 
 			// Get the specified container (check all possible Docker names).
 			possibleNames := docker.FullDockerContainerNames(containerName)
-			found := false
 			for _, fullName := range possibleNames {
 				cont, ok := self.containers[fullName]
 				if ok {
@@ -288,7 +287,7 @@ func (self *manager) DockerContainersInfo(containerName string, query *info.Cont
 					break
 				}
 			}
-			if !found {
+			if len(containers) == 0 {
 				return fmt.Errorf("unable to find Docker container %q with full names %v", containerName, possibleNames)
 			}
 		}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -165,6 +165,29 @@ func TestSubcontainersInfo(t *testing.T) {
 	}
 }
 
+func TestDockerContainersInfo(t *testing.T) {
+	containers := []string{
+		"/docker/c1",
+	}
+
+	query := &info.ContainerInfoRequest{
+		NumStats: 2,
+	}
+
+	m, _, _ := expectManagerWithContainers(containers, query, t)
+
+	result, err := m.DockerContainersInfo("c1", query)
+	if err != nil {
+		t.Fatalf("expected to succeed: %s", err)
+	}
+	if len(result) != len(containers) {
+		t.Errorf("expected to received a containers %v, but received: %v", containers, result)
+	}
+	if result[0].Name != containers[0] {
+		t.Errorf("Unexpected container %q in result. Expected container %q", result[0].Name, containers[0])
+	}
+}
+
 func TestNew(t *testing.T) {
 	manager, err := New(&stest.MockStorageDriver{})
 	if err != nil {


### PR DESCRIPTION
This is currently broken for all searches of Docker containers.
