### PR TITLE
Make the listen IP address configurable

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/cadvisor/pages/static"
 )
 
+var argIp = flag.String("listen_ip", "", "IP to listen on, defaults to all IPs")
 var argPort = flag.Int("port", 8080, "port to listen")
 var maxProcs = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores).")
 
@@ -105,7 +106,7 @@ func main() {
 
 	glog.Infof("Starting cAdvisor version: %q on port %d", info.VERSION, *argPort)
 
-	addr := fmt.Sprintf(":%v", *argPort)
+	addr := fmt.Sprintf("%s:%d", *argIp, *argPort)
 	glog.Fatal(http.ListenAndServe(addr, nil))
 }
 


### PR DESCRIPTION
When running cAdvisor in a container the listen IP is not really important.  Since cAdvisor is still just a simple go program you can easily run it outside of a container in the host OS.  When running cAdvisor in the host OS it is nice to be able to specify which IP cAdvisor listens on, for example 127.0.0.1.
