### PR TITLE
Refactoring and fixes of /docker API endpoint.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -57,7 +57,7 @@ func cadvisorTestClient(path string, expectedPostObj, expectedPostObjEmpty, repl
 			}
 			encoder := json.NewEncoder(w)
 			encoder.Encode(replyObj)
-		} else if r.URL.Path == "/api/v1.1/machine" {
+		} else if r.URL.Path == "/api/v1.2/machine" {
 			fmt.Fprint(w, `{"num_cores":8,"memory_capacity":31625871360}`)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
@@ -79,7 +79,7 @@ func TestGetMachineinfo(t *testing.T) {
 		NumCores:       8,
 		MemoryCapacity: 31625871360,
 	}
-	client, server, err := cadvisorTestClient("/api/v1.1/machine", nil, nil, minfo, t)
+	client, server, err := cadvisorTestClient("/api/v1.2/machine", nil, nil, minfo, t)
 	if err != nil {
 		t.Fatalf("unable to get a client %v", err)
 	}
@@ -101,7 +101,7 @@ func TestGetContainerInfo(t *testing.T) {
 	}
 	containerName := "/some/container"
 	cinfo := itest.GenerateRandomContainerInfo(containerName, 4, query, 1*time.Second)
-	client, server, err := cadvisorTestClient(fmt.Sprintf("/api/v1.1/containers%v", containerName), query, &info.ContainerInfoRequest{}, cinfo, t)
+	client, server, err := cadvisorTestClient(fmt.Sprintf("/api/v1.2/containers%v", containerName), query, &info.ContainerInfoRequest{}, cinfo, t)
 	if err != nil {
 		t.Fatalf("unable to get a client %v", err)
 	}
@@ -129,7 +129,7 @@ func TestGetSubcontainersInfo(t *testing.T) {
 		*cinfo1,
 		*cinfo2,
 	}
-	client, server, err := cadvisorTestClient(fmt.Sprintf("/api/v1.1/subcontainers%v", containerName), query, &info.ContainerInfoRequest{}, response, t)
+	client, server, err := cadvisorTestClient(fmt.Sprintf("/api/v1.2/subcontainers%v", containerName), query, &info.ContainerInfoRequest{}, response, t)
 	if err != nil {
 		t.Fatalf("unable to get a client %v", err)
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -190,15 +190,12 @@ func TestDockerContainersInfo(t *testing.T) {
 
 	m, _, _ := expectManagerWithContainers(containers, query, t)
 
-	result, err := m.DockerContainersInfo("c1", query)
+	result, err := m.DockerContainer("c1", query)
 	if err != nil {
 		t.Fatalf("expected to succeed: %s", err)
 	}
-	if len(result) != len(containers) {
-		t.Errorf("expected to received a containers %v, but received: %v", containers, result)
-	}
-	if result[0].Name != containers[0] {
-		t.Errorf("Unexpected container %q in result. Expected container %q", result[0].Name, containers[0])
+	if result.Name != containers[0] {
+		t.Errorf("Unexpected container %q in result. Expected container %q", result.Name, containers[0])
 	}
 }
 

--- a/pages/docker.go
+++ b/pages/docker.go
@@ -27,7 +27,7 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) error
 		reqParams := info.ContainerInfoRequest{
 			NumStats: 0,
 		}
-		conts, err := m.DockerContainersInfo("/", &reqParams)
+		conts, err := m.AllDockerContainers(&reqParams)
 		if err != nil {
 			return fmt.Errorf("Failed to get container %q with error: %v", containerName, err)
 		}
@@ -54,14 +54,10 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) error
 		reqParams := info.ContainerInfoRequest{
 			NumStats: 60,
 		}
-		conts, err := m.DockerContainersInfo(containerName, &reqParams)
+		cont, err := m.DockerContainer(containerName, &reqParams)
 		if err != nil {
 			return fmt.Errorf("failed to get container %q with error: %v", containerName, err)
 		}
-		if len(conts) != 1 {
-			return fmt.Errorf("received unexpected container for %q: %v", conts)
-		}
-		cont := conts[0]
 		displayName := getContainerDisplayName(cont.ContainerReference)
 
 		// Make a list of the parent containers and their links


### PR DESCRIPTION
This canges the output of the Docker endpoint to be a map so that it is
more consistent from single to multiple returns. It also refactors
internally how we handle both types of requests.

Without this PR the /docker API endpoint is broken completely so this
change in format has no effect anyways.

These changes are tested by the upcoming integration tests.
