### PR TITLE
Let the raw driver handle the /docker container.

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -117,10 +117,7 @@ func FullContainerName(dockerId string) string {
 
 // Docker handles all containers under /docker
 func (self *dockerFactory) CanHandle(name string) (bool, error) {
-	if name == "/docker" {
-		// We need the docker driver to handle /docker. Otherwise the aggregation at the API level will break.
-		return true, nil
-	} else if !IsDockerContainerName(name) {
+	if !IsDockerContainerName(name) {
 		return false, nil
 	}
 
@@ -203,6 +200,7 @@ func Register(factory info.MachineInfoFactory) error {
 		}
 	}
 
+	glog.Infof("Registering Docker factory")
 	f := &dockerFactory{
 		machineInfoFactory: factory,
 		client:             client,

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -82,9 +82,6 @@ func newDockerContainerHandler(
 		fsInfo:         fsInfo,
 	}
 	handler.storageDirs = append(handler.storageDirs, path.Join(dockerRootDir, pathToAufsDir, path.Base(name)))
-	if handler.isDockerRoot() {
-		return handler, nil
-	}
 	id := ContainerNameToDockerId(name)
 	handler.id = id
 	ctnr, err := client.InspectContainer(id)
@@ -106,10 +103,6 @@ func (self *dockerContainerHandler) ContainerReference() (info.ContainerReferenc
 		Aliases:   self.aliases,
 		Namespace: DockerNamespace,
 	}, nil
-}
-
-func (self *dockerContainerHandler) isDockerRoot() bool {
-	return self.name == "/docker"
 }
 
 // TODO(vmarmol): Switch to getting this from libcontainer once we have a solid API.
@@ -201,9 +194,6 @@ func libcontainerConfigToContainerSpec(config *libcontainer.Config, mi *info.Mac
 }
 
 func (self *dockerContainerHandler) GetSpec() (spec info.ContainerSpec, err error) {
-	if self.isDockerRoot() {
-		return info.ContainerSpec{}, nil
-	}
 	mi, err := self.machineInfoFactory.GetMachineInfo()
 	if err != nil {
 		return
@@ -266,9 +256,6 @@ func (self *dockerContainerHandler) getFsStats(stats *info.ContainerStats) error
 }
 
 func (self *dockerContainerHandler) GetStats() (stats *info.ContainerStats, err error) {
-	if self.isDockerRoot() {
-		return &info.ContainerStats{}, nil
-	}
 	state, err := self.readLibcontainerState()
 	if err != nil {
 		if err == fileNotFound {


### PR DESCRIPTION
This will give us stats on this container and since the /docker UI
endpoint, it no longer serves the purpose it once did.
