### PR TITLE
Ignore update errors for dead containers.

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -60,6 +60,7 @@ func RegisterHandlers(m manager.Manager) error {
 
 func handleRequest(m manager.Manager, w http.ResponseWriter, r *http.Request) error {
 	start := time.Now()
+	defer glog.V(2).Infof("Request took %s", time.Since(start))
 
 	request := r.URL.Path
 	requestElements := strings.Split(r.URL.Path, "/")
@@ -195,7 +196,6 @@ func handleRequest(m manager.Manager, w http.ResponseWriter, r *http.Request) er
 		return fmt.Errorf("unknown API request type %q", requestType)
 	}
 
-	glog.V(2).Infof("Request took %s", time.Since(start))
 	return nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -154,7 +154,7 @@ func (self *Client) httpGetJsonData(data, postData interface{}, url, infoName st
 		return err
 	}
 	if err = json.Unmarshal(body, data); err != nil {
-		err = fmt.Errorf("unable to unmarshal %q (%v): %v", infoName, string(body), err)
+		err = fmt.Errorf("unable to unmarshal %q (Body: %q) with error: %v", infoName, string(body), err)
 		return err
 	}
 	return nil

--- a/container/container.go
+++ b/container/container.go
@@ -46,12 +46,30 @@ type SubcontainerEvent struct {
 
 // Interface for container operation handlers.
 type ContainerHandler interface {
+	// Returns the ContainerReference
 	ContainerReference() (info.ContainerReference, error)
+
+	// Returns container's isolation spec.
 	GetSpec() (info.ContainerSpec, error)
+
+	// Returns the current stats values of the container.
 	GetStats() (*info.ContainerStats, error)
+
+	// Returns the subcontainers of this container.
 	ListContainers(listType ListType) ([]info.ContainerReference, error)
+
+	// Returns the threads inside this container.
 	ListThreads(listType ListType) ([]int, error)
+
+	// Returns the processes inside this container.
 	ListProcesses(listType ListType) ([]int, error)
+
+	// Registers a channel to listen for events affecting subcontainers (recursively).
 	WatchSubcontainers(events chan SubcontainerEvent) error
+
+	// Stops watching for subcontainer changes.
 	StopWatchingSubcontainers() error
+
+	// Returns whether the container still exists.
+	Exists() bool
 }

--- a/container/mock.go
+++ b/container/mock.go
@@ -85,6 +85,11 @@ func (self *MockContainerHandler) StopWatchingSubcontainers() error {
 	return args.Error(0)
 }
 
+func (self *MockContainerHandler) Exists() bool {
+	args := self.Called()
+	return args.Get(0).(bool)
+}
+
 type FactoryForMockContainerHandler struct {
 	Name                        string
 	PrepareContainerHandlerFunc func(name string, handler *MockContainerHandler)

--- a/container/raw/factory.go
+++ b/container/raw/factory.go
@@ -25,9 +25,11 @@ import (
 
 type cgroupSubsystems struct {
 	// Cgroup subsystem mounts.
+	// e.g.: "/sys/fs/cgroup/cpu" -> ["cpu", "cpuacct"]
 	mounts []cgroups.Mount
 
 	// Cgroup subsystem to their mount location.
+	// e.g.: "cpu" -> "/sys/fs/cgroup/cpu"
 	mountPoints map[string]string
 }
 

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(cAdvisor): Package comment.
+// Handler for "raw" containers.
 package raw
 
 import (
@@ -477,4 +477,14 @@ func (self *rawContainerHandler) StopWatchingSubcontainers() error {
 	// Rendezvous with the watcher thread.
 	self.stopWatcher <- nil
 	return <-self.stopWatcher
+}
+
+func (self *rawContainerHandler) Exists() bool {
+	// If any cgroup exists, the container is still alive.
+	for _, subsystem := range self.cgroupSubsystems.mounts {
+		if utils.FileExists(path.Join(subsystem.Mountpoint, self.name)) {
+			return true
+		}
+	}
+	return false
 }

--- a/manager/container.go
+++ b/manager/container.go
@@ -118,11 +118,11 @@ func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Tim
 				if self.housekeepingInterval > *maxHousekeepingInterval {
 					self.housekeepingInterval = *maxHousekeepingInterval
 				}
-				glog.V(2).Infof("Raising housekeeping interval for %q to %v", self.info.Name, self.housekeepingInterval)
+				glog.V(3).Infof("Raising housekeeping interval for %q to %v", self.info.Name, self.housekeepingInterval)
 			} else if self.housekeepingInterval != *HousekeepingInterval {
 				// Lower interval back to the baseline.
 				self.housekeepingInterval = *HousekeepingInterval
-				glog.V(1).Infof("Lowering housekeeping interval for %q to %v", self.info.Name, self.housekeepingInterval)
+				glog.V(3).Infof("Lowering housekeeping interval for %q to %v", self.info.Name, self.housekeepingInterval)
 			}
 		}
 	}
@@ -193,6 +193,10 @@ func (c *containerData) housekeepingTick() {
 func (c *containerData) updateSpec() error {
 	spec, err := c.handler.GetSpec()
 	if err != nil {
+		// Ignore errors if the container is dead.
+		if !c.handler.Exists() {
+			return nil
+		}
 		return err
 	}
 	c.lock.Lock()
@@ -204,6 +208,10 @@ func (c *containerData) updateSpec() error {
 func (c *containerData) updateStats() error {
 	stats, err := c.handler.GetStats()
 	if err != nil {
+		// Ignore errors if the container is dead.
+		if !c.handler.Exists() {
+			return nil
+		}
 		return err
 	}
 	if stats == nil {
@@ -211,6 +219,10 @@ func (c *containerData) updateStats() error {
 	}
 	ref, err := c.handler.ContainerReference()
 	if err != nil {
+		// Ignore errors if the container is dead.
+		if !c.handler.Exists() {
+			return nil
+		}
 		return err
 	}
 	err = c.storageDriver.AddStats(ref, stats)
@@ -223,6 +235,10 @@ func (c *containerData) updateStats() error {
 func (c *containerData) updateSubcontainers() error {
 	subcontainers, err := c.handler.ListContainers(container.ListSelf)
 	if err != nil {
+		// Ignore errors if the container is dead.
+		if !c.handler.Exists() {
+			return nil
+		}
 		return err
 	}
 	c.lock.Lock()


### PR DESCRIPTION
This adds an Exists() interface to detect when the container is dead.
Before reporting an update error we check is Exists() is true.

Some documentation was added as well.
