### PR TITLE
Added a version flag to print the version of cAdvisor per #329.

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -40,7 +40,7 @@ var argPort = flag.Int("port", 8080, "port to listen")
 var maxProcs = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores).")
 
 var argDbDriver = flag.String("storage_driver", "", "storage driver to use. Empty means none. Options are: <empty> (default), bigquery, and influxdb")
-var versionFlag = flag.Bool("version", false, "print cAdvisor version")
+var versionFlag = flag.Bool("version", false, "print cAdvisor version and exit")
 
 func main() {
 	defer glog.Flush()


### PR DESCRIPTION
Added a version flag to print the version of cAdvisor.

```
> cadvisor -version
cAdvisor version 0.6.2
>
```
