### PR TITLE
Fix typo in InfluxDB docs

### DIFF
--- a/docs/influxdb.md
+++ b/docs/influxdb.md
@@ -14,7 +14,7 @@ Specify what InfluxDB instance to push data to:
  # The *ip:port* of the database. Default is 'localhost:8086'
  -storage_driver_host=ip:port
  # database name. Uses db 'cadvisor' by default
- -storage_driver_name
+ -storage_driver_db
  # database username. Default is 'root'
  -storage_driver_user
  # database password. Default is 'root'


### PR DESCRIPTION
The InfluxDB docs refer to an argument `storage_driver_name` which is actually called `storage_driver_db`. See [storagedriver.go](https://github.com/google/cadvisor/blob/0acabf64c2a78d023fb0297fc54788617a7b9ec4/storagedriver.go#L34)
