### PR TITLE
[WIP] Make storage table names configurable

### DIFF
--- a/storagedriver.go
+++ b/storagedriver.go
@@ -32,6 +32,7 @@ var argDbUsername = flag.String("storage_driver_user", "root", "database usernam
 var argDbPassword = flag.String("storage_driver_password", "root", "database password")
 var argDbHost = flag.String("storage_driver_host", "localhost:8086", "database host:port")
 var argDbName = flag.String("storage_driver_db", "cadvisor", "database name")
+var argDbTable = flag.String("storage_driver_table", "stats", "table name")
 var argDbIsSecure = flag.Bool("storage_driver_secure", false, "use secure connection with database")
 var argDbBufferDuration = flag.Duration("storage_driver_buffer_duration", 60*time.Second, "Writes in the storage driver will be buffered for this duration, and committed to the non memory backends as a single transaction")
 
@@ -59,7 +60,7 @@ func NewStorageDriver(driverName string) (*memory.InMemoryStorage, error) {
 
 		backendStorage, err = influxdb.New(
 			hostname,
-			"stats",
+			*argDbTable,
 			*argDbName,
 			*argDbUsername,
 			*argDbPassword,
@@ -75,7 +76,7 @@ func NewStorageDriver(driverName string) (*memory.InMemoryStorage, error) {
 		}
 		backendStorage, err = bigquery.New(
 			hostname,
-			"cadvisor",
+			*argDbTable,
 			*argDbName,
 		)
 


### PR DESCRIPTION
This aims to make table names which cAdvisor uses in it's storage drivers configurable. It will fix #360.

Note: This is still work in progress. I will add documentation as soon as options and their defaults are ready.
