### PR TITLE
Add Docker's hostname as one of the cAdvisor aliases for the container

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -116,7 +116,7 @@ func newDockerContainerHandler(
 	// Add the name and bare ID as aliases of the container.
 	handler.aliases = append(handler.aliases, strings.TrimPrefix(ctnr.Name, "/"))
 	handler.aliases = append(handler.aliases, id)
-    handler.aliases = append(handler.aliases, ctnr.Config.Hostname)
+	handler.aliases = append(handler.aliases, ctnr.Config.Hostname)
 
 	return handler, nil
 }

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -116,6 +116,7 @@ func newDockerContainerHandler(
 	// Add the name and bare ID as aliases of the container.
 	handler.aliases = append(handler.aliases, strings.TrimPrefix(ctnr.Name, "/"))
 	handler.aliases = append(handler.aliases, id)
+    handler.aliases = append(handler.aliases, ctnr.Config.Hostname)
 
 	return handler, nil
 }


### PR DESCRIPTION
What's the "right" way to take metadata from "docker inspect" and put it into cAdvisor?

We really need the hostname to help identify the statistics provided by Cadvisor. This 1-line patch fixes the problem.