### PR TITLE
Relax regex for kernel version string format in validator.

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -36,7 +36,7 @@ const Supported = "[Supported, but not recommended]"
 const Unsupported = "[Unsupported]"
 const Recommended = "[Supported and recommended]"
 const Unknown = "[Unknown]"
-const VersionFormat = "%d.%d.%s"
+const VersionFormat = "%d.%d%s"
 const OutputFormat = "%s: %s\n\t%s\n\n"
 
 func getMajorMinor(version string) (int, int, error) {


### PR DESCRIPTION
It now parses versions like major.minor-\* as used by some VMs.
