### PR TITLE
Don't use state.json from libcontainer to get cgroup paths.

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -295,7 +295,7 @@ func (self *dockerContainerHandler) GetStats() (stats *info.ContainerStats, err 
 		return
 	}
 
-	stats, err = containerLibcontainer.GetStats(state)
+	stats, err = containerLibcontainer.GetStats(self.cgroupPaths, state)
 	if err != nil {
 		return
 	}

--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -73,12 +73,12 @@ var supportedSubsystems map[string]struct{} = map[string]struct{}{
 }
 
 // Get stats of the specified container
-func GetStats(state *libcontainer.State) (*info.ContainerStats, error) {
+func GetStats(cgroupPaths map[string]string, state *libcontainer.State) (*info.ContainerStats, error) {
 	// TODO(vmarmol): Use libcontainer's Stats() in the new API when that is ready.
 	stats := &libcontainer.ContainerStats{}
 
 	var err error
-	stats.CgroupStats, err = cgroupfs.GetStats(state.CgroupPaths)
+	stats.CgroupStats, err = cgroupfs.GetStats(cgroupPaths)
 	if err != nil {
 		return &info.ContainerStats{}, err
 	}

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -273,7 +273,7 @@ func (self *rawContainerHandler) GetStats() (*info.ContainerStats, error) {
 		}
 	}
 
-	stats, err := libcontainer.GetStats(&state)
+	stats, err := libcontainer.GetStats(self.cgroupPaths, &state)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This confuses cadvisor on systems where cadvisor doesn't see cgroup mounts at the same place as root namespace view.
