### PR TITLE
Handle initial zero value of lastError.

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -65,7 +65,7 @@ func (c *containerData) Stop() error {
 }
 
 func (c *containerData) allowErrorLogging() bool {
-	if !c.lastErrorTime.IsZero() && time.Since(c.lastErrorTime) > time.Hour {
+	if time.Since(c.lastErrorTime) > time.Minute {
 		c.lastErrorTime = time.Now()
 		return true
 	}


### PR DESCRIPTION
Also reduce logging to once every minute.