### PR TITLE
Handle root network device names other than eth.

### DIFF
--- a/utils/sysfs/fakesysfs/fake.go
+++ b/utils/sysfs/fakesysfs/fake.go
@@ -69,7 +69,6 @@ func (self *FakeSysFs) GetBlockDeviceNumbers(name string) (string, error) {
 }
 
 func (self *FakeSysFs) GetNetworkDevices() ([]os.FileInfo, error) {
-	self.info.EntryName = "eth0"
 	return []os.FileInfo{&self.info}, nil
 }
 
@@ -100,4 +99,8 @@ func (self *FakeSysFs) GetCacheInfo(cpu int, cache string) (sysfs.CacheInfo, err
 
 func (self *FakeSysFs) SetCacheInfo(cache sysfs.CacheInfo) {
 	self.cache = cache
+}
+
+func (self *FakeSysFs) SetEntryName(name string) {
+	self.info.EntryName = name
 }

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -77,8 +77,16 @@ func GetNetworkDevices(sysfs sysfs.SysFs) ([]info.NetInfo, error) {
 	netDevices := []info.NetInfo{}
 	for _, dev := range devs {
 		name := dev.Name()
-		// Only consider ethernet devices for now.
-		if !strings.HasPrefix(name, "eth") {
+		// Ignore docker, loopback, and veth devices.
+		ignoredDevices := []string{"lo", "veth", "docker"}
+		ignored := false
+		for _, prefix := range ignoredDevices {
+			if strings.HasPrefix(name, prefix) {
+				ignored = true
+				break
+			}
+		}
+		if ignored {
 			continue
 		}
 		address, err := sysfs.GetNetworkAddress(name)

--- a/utils/sysinfo/sysinfo_test.go
+++ b/utils/sysinfo/sysinfo_test.go
@@ -47,6 +47,7 @@ func TestGetBlockDeviceInfo(t *testing.T) {
 
 func TestGetNetworkDevices(t *testing.T) {
 	fakeSys := fakesysfs.FakeSysFs{}
+	fakeSys.SetEntryName("eth0")
 	devs, err := GetNetworkDevices(&fakeSys)
 	if err != nil {
 		t.Errorf("expected call to GetNetworkDevices() to succeed. Failed with %s", err)
@@ -66,6 +67,21 @@ func TestGetNetworkDevices(t *testing.T) {
 	}
 	if eth.MacAddress != "42:01:02:03:04:f4" {
 		t.Errorf("expected mac address to be '42:01:02:03:04:f4'. Found %q", eth.MacAddress)
+	}
+}
+
+func TestIgnoredNetworkDevices(t *testing.T) {
+	fakeSys := fakesysfs.FakeSysFs{}
+	ignoredDevices := []string{"veth1234", "lo", "docker0"}
+	for _, name := range ignoredDevices {
+		fakeSys.SetEntryName(name)
+		devs, err := GetNetworkDevices(&fakeSys)
+		if err != nil {
+			t.Errorf("expected call to GetNetworkDevices() to succeed. Failed with %s", err)
+		}
+		if len(devs) != 0 {
+			t.Errorf("expected dev %s to be ignored, but got info %+v", name, devs)
+		}
 	}
 }
 


### PR DESCRIPTION
New logic ignores veth, docker, and loopback devices.