### PR TITLE
Also process /dev/xvd? partitions

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -39,7 +39,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var partitionRegex = regexp.MustCompile("sd[a-z]+\\d")
+var partitionRegex = regexp.MustCompile("(:?s|xv)d[a-z]+\\d")
 
 type partition struct {
 	mountpoint string


### PR DESCRIPTION
Filesystem stats are hardcoded to sd* devices. Make it work on EC2 too. Probably related to #376.