### PR TITLE
Add free number of bytes to filesystem stats of machine api

### DIFF
--- a/info/machine.go
+++ b/info/machine.go
@@ -17,9 +17,10 @@ package info
 type FsInfo struct {
 	// Block device associated with the filesystem.
 	Device string `json:"device"`
-
 	// Total number of bytes available on the filesystem.
 	Capacity uint64 `json:"capacity"`
+	// Free number of bytes available on the filesystem.
+	Free uint64 `json:"free"`
 }
 
 type Node struct {

--- a/manager/machine.go
+++ b/manager/machine.go
@@ -256,7 +256,7 @@ func getMachineInfo(sysFs sysfs.SysFs) (*info.MachineInfo, error) {
 	}
 
 	for _, fs := range filesystems {
-		machineInfo.Filesystems = append(machineInfo.Filesystems, info.FsInfo{Device: fs.Device, Capacity: fs.Capacity})
+		machineInfo.Filesystems = append(machineInfo.Filesystems, info.FsInfo{Device: fs.Device, Capacity: fs.Capacity, Free: fs.Free})
 	}
 
 	return machineInfo, nil


### PR DESCRIPTION
Probably some tests should be added or changes, but at least it now matches UI output that is able to display filesystem free space.