### PR TITLE
Add task load stats to containers.

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -70,6 +70,9 @@ type ContainerHandler interface {
 	// Stops watching for subcontainer changes.
 	StopWatchingSubcontainers() error
 
+	// Returns absolute cgroup path for the requested resource.
+	GetCgroupPath(resource string) (string, error)
+
 	// Returns whether the container still exists.
 	Exists() bool
 }

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -341,6 +341,14 @@ func (self *dockerContainerHandler) ListContainers(listType container.ListType) 
 	return ret, nil
 }
 
+func (self *dockerContainerHandler) GetCgroupPath(resource string) (string, error) {
+	path, ok := self.cgroupPaths[resource]
+	if !ok {
+		return "", fmt.Errorf("could not find path for resource %q for container %q\n", resource, self.name)
+	}
+	return path, nil
+}
+
 func (self *dockerContainerHandler) ListThreads(listType container.ListType) ([]int, error) {
 	return nil, nil
 }

--- a/container/mock.go
+++ b/container/mock.go
@@ -90,6 +90,11 @@ func (self *MockContainerHandler) Exists() bool {
 	return args.Get(0).(bool)
 }
 
+func (self *MockContainerHandler) GetCgroupPath(path string) (string, error) {
+	args := self.Called(path)
+	return args.Get(0).(string), args.Error(1)
+}
+
 type FactoryForMockContainerHandler struct {
 	Name                        string
 	PrepareContainerHandlerFunc func(name string, handler *MockContainerHandler)

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -322,6 +322,14 @@ func (self *rawContainerHandler) GetStats() (*info.ContainerStats, error) {
 	return stats, nil
 }
 
+func (self *rawContainerHandler) GetCgroupPath(resource string) (string, error) {
+	path, ok := self.cgroupPaths[resource]
+	if !ok {
+		return "", fmt.Errorf("could not find path for resource %q for container %q\n", resource, self.name)
+	}
+	return path, nil
+}
+
 // Lists all directories under "path" and outputs the results as children of "parent".
 func listDirectories(dirpath string, parent string, recursive bool, output map[string]struct{}) error {
 	// Ignore if this hierarchy does not exist.

--- a/info/container.go
+++ b/info/container.go
@@ -157,6 +157,24 @@ func (self *ContainerInfo) StatsEndTime() time.Time {
 	return ret
 }
 
+// This mirrors kernel internal structure.
+type LoadStats struct {
+	// Number of sleeping tasks.
+	NrSleeping uint64 `json:"nr_sleeping"`
+
+	// Number of running tasks.
+	NrRunning uint64 `json:"nr_running"`
+
+	// Number of tasks in stopped state
+	NrStopped uint64 `json:"nr_stopped"`
+
+	// Number of tasks in uninterruptible state
+	NrUinterruptible uint64 `json:"nr_uninterruptible"`
+
+	// Number of tasks waiting on IO
+	NrIoWait uint64 `json:"nr_io_wait"`
+}
+
 // All CPU usage metrics are cumulative from the creation of the container
 type CpuStats struct {
 	Usage struct {
@@ -310,6 +328,9 @@ type ContainerStats struct {
 
 	// Filesystem statistics
 	Filesystem []FsStats `json:"filesystem,omitempty"`
+
+	// Task load stats
+	TaskStats LoadStats `json:"task_stats,omitempty"`
 }
 
 func timeEq(t1, t2 time.Time, tolerance time.Duration) bool {

--- a/manager/container_test.go
+++ b/manager/container_test.go
@@ -35,7 +35,7 @@ const containerName = "/container"
 func newTestContainerData(t *testing.T) (*containerData, *container.MockContainerHandler, *stest.MockStorageDriver) {
 	mockHandler := container.NewMockContainerHandler(containerName)
 	mockDriver := &stest.MockStorageDriver{}
-	ret, err := newContainerData(containerName, mockDriver, mockHandler, false)
+	ret, err := newContainerData(containerName, mockDriver, mockHandler, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -50,7 +50,7 @@ func createManagerAndAddContainers(
 	if ret, ok := mif.(*manager); ok {
 		for _, name := range containers {
 			mockHandler := container.NewMockContainerHandler(name)
-			cont, err := newContainerData(name, driver, mockHandler, false)
+			cont, err := newContainerData(name, driver, mockHandler, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/utils/cpuload/netlink.go
+++ b/utils/cpuload/netlink.go
@@ -19,6 +19,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"syscall"
+
+	"github.com/google/cadvisor/info"
 )
 
 const (
@@ -60,7 +62,7 @@ func (self netlinkMessage) toRawMsg() (rawmsg syscall.NetlinkMessage) {
 type loadStatsResp struct {
 	Header    syscall.NlMsghdr
 	GenHeader genMsghdr
-	Stats     LoadStats
+	Stats     info.LoadStats
 }
 
 // Return required padding to align 'size' to 'alignment'.
@@ -216,21 +218,21 @@ func verifyHeader(msg syscall.NetlinkMessage) error {
 // id: family id for taskstats.
 // fd: fd to path to the cgroup directory under cpu hierarchy.
 // conn: open netlink connection used to communicate with kernel.
-func getLoadStats(id uint16, fd uintptr, conn *Connection) (LoadStats, error) {
+func getLoadStats(id uint16, fd uintptr, conn *Connection) (info.LoadStats, error) {
 	msg := prepareCmdMessage(id, fd)
 	err := conn.WriteMessage(msg.toRawMsg())
 	if err != nil {
-		return LoadStats{}, err
+		return info.LoadStats{}, err
 	}
 
 	resp, err := conn.ReadMessage()
 	if err != nil {
-		return LoadStats{}, err
+		return info.LoadStats{}, err
 	}
 
 	parsedmsg, err := parseLoadStatsResp(resp)
 	if err != nil {
-		return LoadStats{}, err
+		return info.LoadStats{}, err
 	}
 	return parsedmsg.Stats, nil
 }


### PR DESCRIPTION
The stats are only populated when cAdvisor is running outside network namespaces.
We'll add a different backend to retrieve the same data from within namespaces.