### PR TITLE
Add scheduler type to disk info.

### DIFF
--- a/info/machine.go
+++ b/info/machine.go
@@ -93,6 +93,9 @@ type DiskInfo struct {
 
 	// Size in bytes
 	Size uint64 `json:"size"`
+
+	// I/O Scheduler - one of "none", "noop", "cfq", "deadline"
+	Scheduler string `json:"scheduler"`
 }
 
 type NetInfo struct {

--- a/utils/sysfs/fakesysfs/fake.go
+++ b/utils/sysfs/fakesysfs/fake.go
@@ -64,6 +64,10 @@ func (self *FakeSysFs) GetBlockDeviceSize(name string) (string, error) {
 	return "1234567", nil
 }
 
+func (self *FakeSysFs) GetBlockDeviceScheduler(name string) (string, error) {
+	return "noop deadline [cfq]", nil
+}
+
 func (self *FakeSysFs) GetBlockDeviceNumbers(name string) (string, error) {
 	return "8:0\n", nil
 }

--- a/utils/sysfs/sysfs.go
+++ b/utils/sysfs/sysfs.go
@@ -45,6 +45,8 @@ type SysFs interface {
 	GetBlockDevices() ([]os.FileInfo, error)
 	// Get Size of a given block device.
 	GetBlockDeviceSize(string) (string, error)
+	// Get scheduler type for the block device.
+	GetBlockDeviceScheduler(string) (string, error)
 	// Get device major:minor number string.
 	GetBlockDeviceNumbers(string) (string, error)
 
@@ -76,6 +78,14 @@ func (self *realSysFs) GetBlockDeviceNumbers(name string) (string, error) {
 		return "", err
 	}
 	return string(dev), nil
+}
+
+func (self *realSysFs) GetBlockDeviceScheduler(name string) (string, error) {
+	sched, err := ioutil.ReadFile(path.Join(blockDir, name, "/queue/scheduler"))
+	if err != nil {
+		return "", err
+	}
+	return string(sched), nil
 }
 
 func (self *realSysFs) GetBlockDeviceSize(name string) (string, error) {

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -16,12 +16,15 @@ package sysinfo
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/google/cadvisor/info"
 	"github.com/google/cadvisor/utils/sysfs"
 )
+
+var schedulerRegExp = regexp.MustCompile(".*\\[(.*)\\].*")
 
 // Get information about block devices present on the system.
 // Uses the passed in system interface to retrieve the low level OS information.
@@ -62,6 +65,18 @@ func GetBlockDeviceInfo(sysfs sysfs.SysFs) (map[string]info.DiskInfo, error) {
 		// size is in 512 bytes blocks.
 		disk_info.Size = size * 512
 
+		sched, err := sysfs.GetBlockDeviceScheduler(name)
+		if err != nil {
+			sched = "none"
+		} else {
+			matches := schedulerRegExp.FindSubmatch([]byte(sched))
+			if len(matches) < 2 {
+				sched = "none"
+			} else {
+				sched = string(matches[1])
+			}
+		}
+		disk_info.Scheduler = sched
 		device := fmt.Sprintf("%d:%d", disk_info.Major, disk_info.Minor)
 		diskMap[device] = disk_info
 	}

--- a/utils/sysinfo/sysinfo_test.go
+++ b/utils/sysinfo/sysinfo_test.go
@@ -43,6 +43,9 @@ func TestGetBlockDeviceInfo(t *testing.T) {
 	if disk.Size != size {
 		t.Errorf("expected to get disk size of %d. Got %d", size, disk.Size)
 	}
+	if disk.Scheduler != "cfq" {
+		t.Errorf("expected to get scheduler type of cfq. Got %q", disk.Scheduler)
+	}
 }
 
 func TestGetNetworkDevices(t *testing.T) {


### PR DESCRIPTION
Type can be one of "none", "noop", "deadline", "cfq".
For block devices that don't use scheduler (like dm), the type will be "none".
We'll also report "none" for partitions when we start reporting those.