### PR TITLE
Add blkio cgroup to list of supported subsystems

### DIFF
--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -70,6 +70,7 @@ var supportedSubsystems map[string]struct{} = map[string]struct{}{
 	"cpuacct": {},
 	"memory":  {},
 	"cpuset":  {},
+	"blkio":   {},
 }
 
 // Get stats of the specified container


### PR DESCRIPTION
I'm not sure this is intended omission, so looks like blkio should be there?
https://groups.google.com/forum/#!topic/google-containers/OyX_B_Qu-4c
