### PR TITLE
Make network fields signed integers.

### DIFF
--- a/info/machine.go
+++ b/info/machine.go
@@ -106,10 +106,10 @@ type NetInfo struct {
 	MacAddress string `json:"mac_address"`
 
 	// Speed in MBits/s
-	Speed uint64 `json:"speed"`
+	Speed int64 `json:"speed"`
 
 	// Maximum Transmission Unit
-	Mtu uint64 `json:"mtu"`
+	Mtu int64 `json:"mtu"`
 }
 
 type MachineInfo struct {

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -112,7 +112,7 @@ func GetNetworkDevices(sysfs sysfs.SysFs) ([]info.NetInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		var mtu uint64
+		var mtu int64
 		n, err := fmt.Sscanf(mtuStr, "%d", &mtu)
 		if err != nil || n != 1 {
 			return nil, fmt.Errorf("could not parse mtu from %s for device %s", mtuStr, name)
@@ -125,7 +125,7 @@ func GetNetworkDevices(sysfs sysfs.SysFs) ([]info.NetInfo, error) {
 		speed, err := sysfs.GetNetworkSpeed(name)
 		// Some devices don't set speed.
 		if err == nil {
-			var s uint64
+			var s int64
 			n, err := fmt.Sscanf(speed, "%d", &s)
 			if err != nil || n != 1 {
 				return nil, fmt.Errorf("could not parse speed from %s for device %s", speed, name)


### PR DESCRIPTION
The kernel reports -1 in case of errors so it should be an allowable
returned value.

Fixes #454.