### PR TITLE
Fix detection of AUFS layers.

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -111,7 +111,7 @@ func newDockerContainerHandler(
 		usesAufsDriver: usesAufsDriver,
 		fsInfo:         fsInfo,
 	}
-	handler.storageDirs = append(handler.storageDirs, path.Join(dockerRootDir, pathToAufsDir, path.Base(name)))
+	handler.storageDirs = append(handler.storageDirs, path.Join(dockerRootDir, pathToAufsDir, id))
 
 	// We assume that if Inspect fails then the container is not known to docker.
 	ctnr, err := client.InspectContainer(id)


### PR DESCRIPTION
We were using the container name instead of the Docker ID which breaks
in systemd systems.

Fixes #475.