### PR TITLE
Disable cpu load tracking temporarily.

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -125,22 +125,25 @@ type manager struct {
 
 // Start the container manager.
 func (self *manager) Start() error {
-	// Create cpu load reader.
-	cpuLoadReader, err := cpuload.New()
-	if err != nil {
-		// TODO(rjnagal): Promote to warning once we support cpu load inside namespaces.
-		glog.Infof("Could not initialize cpu load reader: %s", err)
-	} else {
-		err = cpuLoadReader.Start()
+	// TODO(rjnagal): Skip creating cpu load reader while we improve resource usage and accuracy.
+	if false {
+		// Create cpu load reader.
+		cpuLoadReader, err := cpuload.New()
 		if err != nil {
-			glog.Warning("Could not start cpu load stat collector: %s", err)
+			// TODO(rjnagal): Promote to warning once we support cpu load inside namespaces.
+			glog.Infof("Could not initialize cpu load reader: %s", err)
 		} else {
-			self.loadReader = cpuLoadReader
+			err = cpuLoadReader.Start()
+			if err != nil {
+				glog.Warning("Could not start cpu load stat collector: %s", err)
+			} else {
+				self.loadReader = cpuLoadReader
+			}
 		}
 	}
 
 	// Create root and then recover all containers.
-	err = self.createContainer("/")
+	err := self.createContainer("/")
 	if err != nil {
 		return err
 	}

--- a/pages/containers_html.go
+++ b/pages/containers_html.go
@@ -116,8 +116,8 @@ const containersHtmlTemplate = `
           <div class="panel-body">
             <h4>Total Usage</h4>
 	    <div id="cpu-total-usage-chart"></div>
-            <h4>CPU Load Average</h4>
-	    <div id="cpu-load-chart"></div>
+	    <!-- <h4>CPU Load Average</h4>
+	    <div id="cpu-load-chart"></div> -->
             <h4>Usage per Core</h4>
 	    <div id="cpu-per-core-usage-chart"></div>
             <h4>Usage Breakdown</h4>

--- a/pages/static/containers_js.go
+++ b/pages/static/containers_js.go
@@ -1851,9 +1851,10 @@ function drawCharts(machineInfo, containerInfo) {
 		steps.push(function() {
 			drawCpuTotalUsage("cpu-total-usage-chart", machineInfo, containerInfo);
 		});
-		steps.push(function() {
-			drawCpuLoad("cpu-load-chart", machineInfo, containerInfo);
-		});
+		// TODO(rjnagal): Re-enable CPU Load after understanding resource usage. 
+		// steps.push(function() {
+		// 	drawCpuLoad("cpu-load-chart", machineInfo, containerInfo);
+		// });
 		steps.push(function() {
 			drawCpuPerCoreUsage("cpu-per-core-usage-chart", machineInfo, containerInfo);
 		});


### PR DESCRIPTION
I'd like to understand its resource usage and improve accuracy
before we ship it in an official release.