### PR TITLE
Ignore regular files in /sys/class/net directory.

### DIFF
--- a/utils/sysfs/fakesysfs/fake.go
+++ b/utils/sysfs/fakesysfs/fake.go
@@ -35,7 +35,7 @@ func (self *FileInfo) Size() int64 {
 }
 
 func (self *FileInfo) Mode() os.FileMode {
-	return 0
+	return os.ModeSymlink
 }
 
 func (self *FileInfo) ModTime() time.Time {

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -16,6 +16,7 @@ package sysinfo
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -91,6 +92,10 @@ func GetNetworkDevices(sysfs sysfs.SysFs) ([]info.NetInfo, error) {
 	}
 	netDevices := []info.NetInfo{}
 	for _, dev := range devs {
+		// Only consider directories and symlinks.
+		if dev.Mode()&(os.ModeSymlink|os.ModeDir) == 0 {
+			continue
+		}
 		name := dev.Name()
 		// Ignore docker, loopback, and veth devices.
 		ignoredDevices := []string{"lo", "veth", "docker"}


### PR DESCRIPTION
Only consider symlinks and directories as potential network devices.