### PR TITLE
Don't use screen to run cAdvisor in the background.

### DIFF
--- a/integration/common/gce.go
+++ b/integration/common/gce.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/GoogleCloudPlatform/gcloud-golang/compute/metadata"
+)
+
+var gceInternalIpRegexp = regexp.MustCompile(" +ip +\\| +([0-9.:]+) +")
+var gceExternalIpRegexp = regexp.MustCompile("external-ip +\\| +([0-9.:]+) +")
+
+// Gets the IP of the specified GCE instance.
+func GetGceIp(hostname string) (string, error) {
+	if hostname == "localhost" {
+		return "127.0.0.1", nil
+	}
+
+	out, err := exec.Command("gcutil", "getinstance", hostname).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	// Use the internal IP within GCE and the external one outside.
+	var matches []string
+	if metadata.OnGCE() {
+		matches = gceInternalIpRegexp.FindStringSubmatch(string(out))
+	} else {
+		matches = gceExternalIpRegexp.FindStringSubmatch(string(out))
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("failed to find IP from output %q", string(out))
+	}
+	return matches[1], nil
+}

--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -17,15 +17,21 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/google/cadvisor/integration/common"
 )
 
 const cadvisorBinary = "cadvisor"
+
+var cadvisorTimeout = flag.Duration("cadvisor_timeout", 15*time.Second, "Time to wait for cAdvisor to come up on the remote host")
+var port = flag.Int("port", 8080, "Port in which to start cAdvisor in the remote host")
 
 func RunCommand(cmd string, args ...string) error {
 	output, err := exec.Command(cmd, args...).CombinedOutput()
@@ -78,12 +84,16 @@ func Run() error {
 	}
 
 	// TODO(vmarmol): Get logs in case of failures.
-	// Start it.
+	// Start cAdvisor.
 	glog.Infof("Running cAdvisor on the remote host...")
-	err = RunCommand("gcutil", "ssh", host, "sudo", "screen", "-d", "-m", path.Join(testDir, cadvisorBinary), "--logtostderr", "&>", "/dev/null")
-	if err != nil {
-		return err
-	}
+	portStr := strconv.Itoa(*port)
+	errChan := make(chan error)
+	go func() {
+		err = RunCommand("gcutil", "ssh", host, "sudo", path.Join(testDir, cadvisorBinary), "--port", portStr, "--logtostderr", "&>", "/dev/null")
+		if err != nil {
+			errChan <- err
+		}
+	}()
 	defer func() {
 		err := RunCommand("gcutil", "ssh", host, "sudo", "killall", cadvisorBinary)
 		if err != nil {
@@ -91,9 +101,35 @@ func Run() error {
 		}
 	}()
 
+	ipAddress, err := common.GetGceIp(host)
+	if err != nil {
+		return err
+	}
+
+	// Wait for cAdvisor to come up.
+	endTime := time.Now().Add(*cadvisorTimeout)
+	done := false
+	for endTime.After(time.Now()) && !done {
+		select {
+		case err := <-errChan:
+			// Quit early if there was an error.
+			return err
+		case <-time.After(500 * time.Millisecond):
+			// Stop waiting when cAdvisor is healthy..
+			resp, err := http.Get(fmt.Sprintf("http://%s:%s/healthz", ipAddress, portStr))
+			if err == nil && resp.StatusCode == http.StatusOK {
+				done = true
+				break
+			}
+		}
+	}
+	if !done {
+		return fmt.Errorf("timed out waiting for cAdvisor to come up at host %q", host)
+	}
+
 	// Run the tests.
 	glog.Infof("Running integration tests targeting remote host...")
-	err = RunCommand("godep", "go", "test", "github.com/google/cadvisor/integration/tests/...", "--host", host)
+	err = RunCommand("godep", "go", "test", "github.com/google/cadvisor/integration/tests/...", "--host", host, "--port", portStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some distros don't have screen. Here we wait for cAdvisor to come up
before continuing.