### PR TITLE
Map request for 'api/v1.2/docker/' to 'api/v1.2/docker'

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -188,6 +188,10 @@ func (self *version1_2) HandleRequest(requestType string, request []string, m ma
 		}
 
 		var containers map[string]info.ContainerInfo
+		// map requests for "docker/" to "docker"
+		if len(request) == 1 && len(request[0]) == 0 {
+			request = request[:0]
+		}
 		switch len(request) {
 		case 0:
 			// Get all Docker containers.


### PR DESCRIPTION
Presently, we just fail this request:
$ curl 0:8080/api/v1.2/docker/
failed to get Docker container "" with error: unable to find Docker container ""