### PR TITLE
Expose a minimal 2.0 API with the first summary endpoint.

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -100,6 +100,13 @@ func (c *containerData) GetInfo() (*containerInfo, error) {
 	return &c.info, nil
 }
 
+func (c *containerData) DerivedStats() (info.DerivedStats, error) {
+	if c.summaryReader == nil {
+		return info.DerivedStats{}, fmt.Errorf("derived stats not enabled for container %q", c.info.Name)
+	}
+	return c.summaryReader.DerivedStats()
+}
+
 func newContainerData(containerName string, driver storage.StorageDriver, handler container.ContainerHandler, loadReader cpuload.CpuLoadReader, logUsage bool) (*containerData, error) {
 	if driver == nil {
 		return nil, fmt.Errorf("nil storage driver")

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -57,6 +57,7 @@ type StatsSummary struct {
 // stats are updated.
 func (s *StatsSummary) AddSample(stat info.ContainerStats) error {
 	sample := secondSample{}
+	sample.Timestamp = stat.Timestamp
 	if s.available.Cpu {
 		sample.Cpu = stat.Cpu.Usage.Total
 	}
@@ -119,7 +120,7 @@ func (s *StatsSummary) getDerivedUsage(n int) (info.Usage, error) {
 	// We generate derived stats even with partial data.
 	usage := GetDerivedPercentiles(samples)
 	// Assumes we have equally placed minute samples.
-	usage.PercentComplete = int32(numSamples / n)
+	usage.PercentComplete = int32(numSamples * 100 / n)
 	return usage, nil
 }
 


### PR DESCRIPTION
Right now, we just do raw container name. More types to follow.
We'll re-do the older endpoint in 2.0 before we publish it.