### PR TITLE
Make explicit the use of InMemoryStorage in Manager.

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -61,7 +61,7 @@ func main() {
 
 	setMaxProcs()
 
-	storageDriver, err := NewStorageDriver(*argDbDriver)
+	memoryStorage, err := NewMemoryStorage(*argDbDriver)
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}
@@ -71,7 +71,7 @@ func main() {
 		glog.Fatalf("Failed to create a system interface: %s", err)
 	}
 
-	containerManager, err := manager.New(storageDriver, sysFs)
+	containerManager, err := manager.New(memoryStorage, sysFs)
 	if err != nil {
 		glog.Fatalf("Failed to create a Container Manager: %s", err)
 	}


### PR DESCRIPTION
The current structure is a remnant of when the in memory storage was one
of the options for backing store. Today, we always have the memory
storage with an optional "backend storage" plugin. This commit makes the
InMemoryStorage use explicit.