### PR TITLE
Add instant stat to derived result.

### DIFF
--- a/info/container.go
+++ b/info/container.go
@@ -464,9 +464,19 @@ type Usage struct {
 	Memory Percentiles `json:"memory"`
 }
 
+// latest sample collected for a container.
+type InstantUsage struct {
+	// cpu rate in cpu milliseconds/second.
+	Cpu uint64 `json:"cpu"`
+	// Memory usage in bytes.
+	Memory uint64 `json:"memory"`
+}
+
 type DerivedStats struct {
 	// Time of generation of these stats.
 	Timestamp time.Time `json:"timestamp"`
+	// Latest instantaneous sample.
+	LatestUsage InstantUsage `json:"latest_usage"`
 	// Percentiles in last observed minute.
 	MinuteUsage Usage `json:"minute_usage"`
 	// Percentile in last hour.


### PR DESCRIPTION
Before this change, we do not return anything meaningful till cadvisor has been up
for a minute. Also, having instant usage in the same stat gives a more complete
picture.