### PR TITLE
cAdvisor 0.10.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0 (2015-02-24)
+- Adding Start and End time for ContainerInfoRequest.
+- Various misc fixes.
+
 ## 0.9.0 (2015-02-06)
 - Support for more network devices (all non-eth).
 - Support for more partition types (btrfs, device-mapper, whole-disk).

--- a/info/version.go
+++ b/info/version.go
@@ -15,4 +15,4 @@
 package info
 
 // Version of cAdvisor.
-const VERSION = "0.9.0"
+const VERSION = "0.10.0"


### PR DESCRIPTION
Left out some work that is in progress (summary stats) as well as the 2.0 API (since we don't want that used just yet).