### PR TITLE
Register container handler factories in manager.New().

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -27,8 +27,6 @@ import (
 	auth "github.com/abbot/go-http-auth"
 	"github.com/golang/glog"
 	"github.com/google/cadvisor/api"
-	"github.com/google/cadvisor/container/docker"
-	"github.com/google/cadvisor/container/raw"
 	"github.com/google/cadvisor/healthz"
 	"github.com/google/cadvisor/info"
 	"github.com/google/cadvisor/manager"
@@ -74,16 +72,6 @@ func main() {
 	containerManager, err := manager.New(memoryStorage, sysFs)
 	if err != nil {
 		glog.Fatalf("Failed to create a Container Manager: %s", err)
-	}
-
-	// Register Docker.
-	if err := docker.Register(containerManager); err != nil {
-		glog.Errorf("Docker registration failed: %v.", err)
-	}
-
-	// Register the raw driver.
-	if err := raw.Register(containerManager); err != nil {
-		glog.Fatalf("Raw registration failed: %v.", err)
 	}
 
 	// Basic health handler.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/docker"
+	"github.com/google/cadvisor/container/raw"
 	"github.com/google/cadvisor/events"
 	"github.com/google/cadvisor/info"
 	"github.com/google/cadvisor/storage/memory"
@@ -114,6 +115,18 @@ func New(memoryStorage *memory.InMemoryStorage, sysfs sysfs.SysFs) (Manager, err
 	glog.Infof("Version: %+v", newManager.versionInfo)
 
 	newManager.eventHandler = events.NewEventManager()
+
+	// Register Docker container factory.
+	err = docker.Register(newManager)
+	if err != nil {
+		glog.Errorf("Docker container factory registration failed: %v.", err)
+	}
+
+	// Register the raw driver.
+	err = raw.Register(newManager)
+	if err != nil {
+		return nil, fmt.Errorf("registration of the raw container factory failed: %v", err)
+	}
 
 	return newManager, nil
 }


### PR DESCRIPTION
This lets us simplify the startup of the manager.