### PR TITLE
Add stubs for non-Linux builds of statvfs and netlink.

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -12,16 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux
-
 // Provides Filesystem Stats
 package fs
-
-/*
- extern int getBytesFree(const char *path, unsigned long long *bytes);
- extern int getBytesTotal(const char *path, unsigned long long *bytes);
-*/
-import "C"
 
 import (
 	"bufio"
@@ -33,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"unsafe"
 
 	"github.com/docker/docker/pkg/mount"
 	"github.com/golang/glog"
@@ -191,20 +182,4 @@ func (self *RealFsInfo) GetDirUsage(dir string) (uint64, error) {
 		return 0, fmt.Errorf("cannot parse 'du' output %s - %s", out, err)
 	}
 	return usageInKb * 1024, nil
-}
-
-func getVfsStats(path string) (total uint64, free uint64, err error) {
-	_p0, err := syscall.BytePtrFromString(path)
-	if err != nil {
-		return 0, 0, err
-	}
-	res, err := C.getBytesFree((*C.char)(unsafe.Pointer(_p0)), (*_Ctype_ulonglong)(unsafe.Pointer(&free)))
-	if res != 0 {
-		return 0, 0, err
-	}
-	res, err = C.getBytesTotal((*C.char)(unsafe.Pointer(_p0)), (*_Ctype_ulonglong)(unsafe.Pointer(&total)))
-	if res != 0 {
-		return 0, 0, err
-	}
-	return total, free, nil
 }

--- a/fs/statvfs_linux.go
+++ b/fs/statvfs_linux.go
@@ -1,0 +1,44 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build cgo,linux
+
+package fs
+
+/*
+ extern int getBytesFree(const char *path, unsigned long long *bytes);
+ extern int getBytesTotal(const char *path, unsigned long long *bytes);
+*/
+import "C"
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func getVfsStats(path string) (total uint64, free uint64, err error) {
+	_p0, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	res, err := C.getBytesFree((*C.char)(unsafe.Pointer(_p0)), (*_Ctype_ulonglong)(unsafe.Pointer(&free)))
+	if res != 0 {
+		return 0, 0, err
+	}
+	res, err = C.getBytesTotal((*C.char)(unsafe.Pointer(_p0)), (*_Ctype_ulonglong)(unsafe.Pointer(&total)))
+	if res != 0 {
+		return 0, 0, err
+	}
+	return total, free, nil
+}

--- a/fs/statvfs_stub.go
+++ b/fs/statvfs_stub.go
@@ -1,0 +1,24 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !cgo,!linux
+
+package fs
+
+import "fmt"
+
+// Stub for unsupported builds.
+func getVfsStats(path string) (total uint64, free uint64, err error) {
+	return 0, 0, fmt.Errorf("vfsstats unsupported")
+}

--- a/utils/cpuload/netlink/defs_linux.go
+++ b/utils/cpuload/netlink/defs_linux.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build cgo,linux
+
 package netlink
 
 /*

--- a/utils/cpuload/netlink/defs_stub.go
+++ b/utils/cpuload/netlink/defs_stub.go
@@ -1,0 +1,26 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !cgo,!linux
+
+package netlink
+
+// Stubs for netlink definitions in unsupported builds.
+
+type TaskStats struct {
+}
+
+const (
+	__TASKSTATS_CMD_MAX = iota
+)


### PR DESCRIPTION
This will allow the code to build when cross-compiled. The existing
functionality will be missing and we will degrade gracefully.