### PR TITLE
Update documentation on running integration tests.

### DIFF
--- a/docs/integration_testing.md
+++ b/docs/integration_testing.md
@@ -3,10 +3,10 @@
 The cAdvisor integration tests can be found in `integration/tests`. These run queries on a running cAdvisor. To run these tests:
 
 ```
-$ godep go run integration/runner/runner.go -host=HOST -port=PORT
+$ godep go run integration/runner/runner.go -port=PORT <hosts to test>
 ```
 
-this will build a cAdvisor from the current repository and start it on the target machine before running the tests. Note that `HOST` and `PORT` default to `localhost` and `8080` respectively.
+This will build a cAdvisor from the current repository and start it on the target machine before running the tests.
 
 To simply run the tests against an existing cAdvisor:
 
@@ -14,4 +14,5 @@ To simply run the tests against an existing cAdvisor:
 $ godep go test github.com/google/cadvisor/integration/tests/... -host=HOST -port=PORT
 ```
 
+Note that `HOST` and `PORT` default to `localhost` and `8080` respectively.
 Today We only support remote execution in Google Compute Engine since that is where we run our continuous builds.


### PR DESCRIPTION

runner.go doesn't work on localhost as it tries to ssh to the local machine :)