### PR TITLE
Lowering log level for frequent events.

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -197,7 +197,7 @@ func (c *containerData) housekeeping() {
 			// Log if housekeeping took too long.
 			duration := time.Since(start)
 			if duration >= longHousekeeping {
-				glog.V(2).Infof("[%s] Housekeeping took %s", c.info.Name, duration)
+				glog.V(3).Infof("[%s] Housekeeping took %s", c.info.Name, duration)
 			}
 		}
 

--- a/summary/percentiles.go
+++ b/summary/percentiles.go
@@ -172,10 +172,10 @@ func GetMinutePercentiles(stats []*secondSample) info.Usage {
 		if !lastSample.Timestamp.IsZero() {
 			cpuRate, err := getCpuRate(*stat, lastSample)
 			if err != nil {
-				glog.V(2).Infof("Skipping sample, %v", err)
+				glog.V(3).Infof("Skipping sample, %v", err)
 				continue
 			}
-			glog.V(2).Infof("Adding cpu rate sample : %d", cpuRate)
+			glog.V(3).Infof("Adding cpu rate sample : %d", cpuRate)
 			cpu.AddSample(cpuRate)
 			memory.AddSample(stat.Memory)
 		} else {

--- a/utils/cpuload/netlink/reader.go
+++ b/utils/cpuload/netlink/reader.go
@@ -73,6 +73,6 @@ func (self *NetlinkReader) GetCpuLoad(name string, path string) (info.LoadStats,
 	if err != nil {
 		return info.LoadStats{}, err
 	}
-	glog.V(1).Infof("Task stats for %q: %+v", path, stats)
+	glog.V(3).Infof("Task stats for %q: %+v", path, stats)
 	return stats, nil
 }


### PR DESCRIPTION
Lowering all frequent normal logs to v=3. Kubelet runs by default on
debug of v=2 and we don't want to log these events in that case.