### PR TITLE
Use mux to register HTTP handlers.

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -32,20 +32,21 @@ import (
 	"github.com/google/cadvisor/events"
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/manager"
+	"github.com/google/cadvisor/utils"
 )
 
 const (
 	apiResource = "/api/"
 )
 
-func RegisterHandlers(m manager.Manager) error {
+func RegisterHandlers(mux utils.Mux, m manager.Manager) error {
 	apiVersions := getApiVersions()
 	supportedApiVersions := make(map[string]ApiVersion, len(apiVersions))
 	for _, v := range apiVersions {
 		supportedApiVersions[v.Version()] = v
 	}
 
-	http.HandleFunc(apiResource, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(apiResource, func(w http.ResponseWriter, r *http.Request) {
 		err := handleRequest(supportedApiVersions, m, w, r)
 		if err != nil {
 			http.Error(w, err.Error(), 500)

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/manager"
+	"github.com/google/cadvisor/utils"
 )
 
 var pageTemplate *template.Template
@@ -97,26 +98,26 @@ func dockerHandler(containerManager manager.Manager) auth.AuthenticatedHandlerFu
 }
 
 // Register http handlers
-func RegisterHandlersDigest(containerManager manager.Manager, authenticator *auth.DigestAuth) error {
+func RegisterHandlersDigest(mux utils.Mux, containerManager manager.Manager, authenticator *auth.DigestAuth) error {
 	// Register the handler for the containers page.
 	if authenticator != nil {
-		http.HandleFunc(ContainersPage, authenticator.Wrap(containerHandler(containerManager)))
-		http.HandleFunc(DockerPage, authenticator.Wrap(dockerHandler(containerManager)))
+		mux.HandleFunc(ContainersPage, authenticator.Wrap(containerHandler(containerManager)))
+		mux.HandleFunc(DockerPage, authenticator.Wrap(dockerHandler(containerManager)))
 	} else {
-		http.HandleFunc(ContainersPage, containerHandlerNoAuth(containerManager))
-		http.HandleFunc(DockerPage, dockerHandlerNoAuth(containerManager))
+		mux.HandleFunc(ContainersPage, containerHandlerNoAuth(containerManager))
+		mux.HandleFunc(DockerPage, dockerHandlerNoAuth(containerManager))
 	}
 	return nil
 }
 
-func RegisterHandlersBasic(containerManager manager.Manager, authenticator *auth.BasicAuth) error {
+func RegisterHandlersBasic(mux utils.Mux, containerManager manager.Manager, authenticator *auth.BasicAuth) error {
 	// Register the handler for the containers and docker age.
 	if authenticator != nil {
-		http.HandleFunc(ContainersPage, authenticator.Wrap(containerHandler(containerManager)))
-		http.HandleFunc(DockerPage, authenticator.Wrap(dockerHandler(containerManager)))
+		mux.HandleFunc(ContainersPage, authenticator.Wrap(containerHandler(containerManager)))
+		mux.HandleFunc(DockerPage, authenticator.Wrap(dockerHandler(containerManager)))
 	} else {
-		http.HandleFunc(ContainersPage, containerHandlerNoAuth(containerManager))
-		http.HandleFunc(DockerPage, dockerHandlerNoAuth(containerManager))
+		mux.HandleFunc(ContainersPage, containerHandlerNoAuth(containerManager))
+		mux.HandleFunc(DockerPage, dockerHandlerNoAuth(containerManager))
 	}
 	return nil
 }

--- a/utils/mux.go
+++ b/utils/mux.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All Rights Reserved.
+// Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package healthz
+package utils
 
 import (
 	"net/http"
-
-	"github.com/google/cadvisor/utils"
 )
 
-func handleHealthz(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok"))
-}
-
-// Register simple HTTP /healthz handler to return "ok".
-func RegisterHandler(mux utils.Mux) error {
-	mux.HandleFunc("/healthz", handleHealthz)
-	return nil
+// Mux interface expected by cAdvisor components.
+type Mux interface {
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	Handler(r *http.Request) (http.Handler, string)
 }


### PR DESCRIPTION
This will allow us to register handlers on the non-default HTTP handler.