### PR TITLE
Add /storage endpoint to 2.0 API.

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -33,6 +33,7 @@ const (
 	summaryApi       = "summary"
 	specApi          = "spec"
 	eventsApi        = "events"
+	storageApi       = "storage"
 )
 
 // Interface for a cAdvisor API version
@@ -322,6 +323,24 @@ func (self *version2_0) HandleRequest(requestType string, request []string, m ma
 		}
 		specV2 := convertSpec(spec)
 		return writeResult(specV2, w)
+	case storageApi:
+		var err error
+		fi := []v2.FsInfo{}
+		label := r.URL.Query().Get("label")
+		if len(label) == 0 {
+			// Get all global filesystems info.
+			fi, err = m.GetFsInfo("")
+			if err != nil {
+				return err
+			}
+		} else {
+			// Get a specific label.
+			fi, err = m.GetFsInfo(label)
+			if err != nil {
+				return err
+			}
+		}
+		return writeResult(fi, w)
 	default:
 		return self.baseVersion.HandleRequest(requestType, request, m, w, r)
 	}

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -82,16 +82,11 @@ func newDockerContainerHandler(
 	client *docker.Client,
 	name string,
 	machineInfoFactory info.MachineInfoFactory,
+	fsInfo fs.FsInfo,
 	dockerRootDir string,
 	usesAufsDriver bool,
 	cgroupSubsystems *containerLibcontainer.CgroupSubsystems,
 ) (container.ContainerHandler, error) {
-	// TODO(vmarmol): Get from factory.
-	fsInfo, err := fs.NewFsInfo()
-	if err != nil {
-		return nil, err
-	}
-
 	// Create the cgroup paths.
 	cgroupPaths := make(map[string]string, len(cgroupSubsystems.MountPoints))
 	for key, val := range cgroupSubsystems.MountPoints {

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -71,18 +71,13 @@ type rawContainerHandler struct {
 	externalMounts []mount
 }
 
-func newRawContainerHandler(name string, cgroupSubsystems *libcontainer.CgroupSubsystems, machineInfoFactory info.MachineInfoFactory) (container.ContainerHandler, error) {
+func newRawContainerHandler(name string, cgroupSubsystems *libcontainer.CgroupSubsystems, machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo) (container.ContainerHandler, error) {
 	// Create the cgroup paths.
 	cgroupPaths := make(map[string]string, len(cgroupSubsystems.MountPoints))
 	for key, val := range cgroupSubsystems.MountPoints {
 		cgroupPaths[key] = path.Join(val, name)
 	}
 
-	// TODO(vmarmol): Get from factory.
-	fsInfo, err := fs.NewFsInfo()
-	if err != nil {
-		return nil, err
-	}
 	cHints, err := getContainerHintsFromFile(*argContainerHints)
 	if err != nil {
 		return nil, err

--- a/fs/types.go
+++ b/fs/types.go
@@ -53,4 +53,13 @@ type FsInfo interface {
 
 	// Returns the block device info of the filesystem on which 'dir' resides.
 	GetDirFsDevice(dir string) (*DeviceInfo, error)
+
+	// Returns the device name associated with a particular label.
+	GetDeviceForLabel(label string) (string, error)
+
+	// Returns all labels associated with a particular device name.
+	GetLabelsForDevice(device string) ([]string, error)
+
+	// Returns the mountpoint associated with a particular device.
+	GetMountpointForDevice(device string) (string, error)
 }

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -97,3 +97,20 @@ type DerivedStats struct {
 	// Percentile in last day.
 	DayUsage Usage `json:"day_usage"`
 }
+
+type FsInfo struct {
+	// The block device name associated with the filesystem.
+	Device string `json:"device"`
+
+	// Path where the filesystem is mounted.
+	Mountpoint string `json:"mountpoint"`
+
+	// Filesystem usage in bytes.
+	Capacity uint64 `json:"capacity"`
+
+	// Number of bytes used on this filesystem.
+	Usage uint64 `json:"usage"`
+
+	// Labels associated with this filesystem.
+	Labels []string `json:"labels"`
+}

--- a/manager/machine.go
+++ b/manager/machine.go
@@ -223,7 +223,7 @@ func getMachineID() string {
 	return ""
 }
 
-func getMachineInfo(sysFs sysfs.SysFs) (*info.MachineInfo, error) {
+func getMachineInfo(sysFs sysfs.SysFs, fsInfo fs.FsInfo) (*info.MachineInfo, error) {
 	cpuinfo, err := ioutil.ReadFile("/proc/cpuinfo")
 	clockSpeed, err := getClockSpeed(cpuinfo)
 	if err != nil {
@@ -241,10 +241,6 @@ func getMachineInfo(sysFs sysfs.SysFs) (*info.MachineInfo, error) {
 		return nil, err
 	}
 
-	fsInfo, err := fs.NewFsInfo()
-	if err != nil {
-		return nil, err
-	}
 	filesystems, err := fsInfo.GetGlobalFsInfo()
 	if err != nil {
 		return nil, err

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/cadvisor/container/docker"
 	"github.com/google/cadvisor/container/raw"
 	"github.com/google/cadvisor/events"
+	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/storage/memory"
@@ -74,6 +75,10 @@ type Manager interface {
 	// Get version information about different components we depend on.
 	GetVersionInfo() (*info.VersionInfo, error)
 
+	// Get filesystem information for a given label.
+	// Returns information for all global filesystems if label is empty.
+	GetFsInfo(label string) ([]v2.FsInfo, error)
+
 	// Get events streamed through passedChannel that fit the request.
 	WatchForEvents(request *events.Request, passedChannel chan *events.Event) error
 
@@ -94,15 +99,21 @@ func New(memoryStorage *memory.InMemoryStorage, sysfs sysfs.SysFs) (Manager, err
 	}
 	glog.Infof("cAdvisor running in container: %q", selfContainer)
 
+	context := fs.Context{DockerRoot: docker.RootDir()}
+	fsInfo, err := fs.NewFsInfo(context)
+	if err != nil {
+		return nil, err
+	}
 	newManager := &manager{
 		containers:        make(map[namespacedContainerName]*containerData),
 		quitChannels:      make([]chan error, 0, 2),
 		memoryStorage:     memoryStorage,
+		fsInfo:            fsInfo,
 		cadvisorContainer: selfContainer,
 		startupTime:       time.Now(),
 	}
 
-	machineInfo, err := getMachineInfo(sysfs)
+	machineInfo, err := getMachineInfo(sysfs, fsInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -119,13 +130,13 @@ func New(memoryStorage *memory.InMemoryStorage, sysfs sysfs.SysFs) (Manager, err
 	newManager.eventHandler = events.NewEventManager()
 
 	// Register Docker container factory.
-	err = docker.Register(newManager)
+	err = docker.Register(newManager, fsInfo)
 	if err != nil {
 		glog.Errorf("Docker container factory registration failed: %v.", err)
 	}
 
 	// Register the raw driver.
-	err = raw.Register(newManager)
+	err = raw.Register(newManager, fsInfo)
 	if err != nil {
 		return nil, fmt.Errorf("registration of the raw container factory failed: %v", err)
 	}
@@ -146,6 +157,7 @@ type manager struct {
 	containers             map[namespacedContainerName]*containerData
 	containersLock         sync.RWMutex
 	memoryStorage          *memory.InMemoryStorage
+	fsInfo                 fs.FsInfo
 	machineInfo            info.MachineInfo
 	versionInfo            info.VersionInfo
 	quitChannels           []chan error
@@ -437,6 +449,45 @@ func (self *manager) GetContainerDerivedStats(containerName string) (v2.DerivedS
 		return v2.DerivedStats{}, fmt.Errorf("unknown container %q", containerName)
 	}
 	return cont.DerivedStats()
+}
+
+func (self *manager) GetFsInfo(label string) ([]v2.FsInfo, error) {
+	var empty time.Time
+	// Get latest data from filesystems hanging off root container.
+	stats, err := self.memoryStorage.RecentStats("/", empty, empty, 1)
+	if err != nil {
+		return nil, err
+	}
+	dev := ""
+	if len(label) != 0 {
+		dev, err = self.fsInfo.GetDeviceForLabel(label)
+		if err != nil {
+			return nil, err
+		}
+	}
+	fsInfo := []v2.FsInfo{}
+	for _, fs := range stats[0].Filesystem {
+		if len(label) != 0 && fs.Device != dev {
+			continue
+		}
+		mountpoint, err := self.fsInfo.GetMountpointForDevice(fs.Device)
+		if err != nil {
+			return nil, err
+		}
+		labels, err := self.fsInfo.GetLabelsForDevice(fs.Device)
+		if err != nil {
+			return nil, err
+		}
+		fi := v2.FsInfo{
+			Device:     fs.Device,
+			Mountpoint: mountpoint,
+			Capacity:   fs.Limit,
+			Usage:      fs.Usage,
+			Labels:     labels,
+		}
+		fsInfo = append(fsInfo, fi)
+	}
+	return fsInfo, nil
 }
 
 func (m *manager) GetMachineInfo() (*info.MachineInfo, error) {

--- a/manager/manager_mock.go
+++ b/manager/manager_mock.go
@@ -84,3 +84,8 @@ func (c *ManagerMock) GetVersionInfo() (*info.VersionInfo, error) {
 	args := c.Called()
 	return args.Get(0).(*info.VersionInfo), args.Error(1)
 }
+
+func (c *ManagerMock) GetFsInfo() ([]v2.FsInfo, error) {
+	args := c.Called()
+	return args.Get(0).([]v2.FsInfo), args.Error(1)
+}


### PR DESCRIPTION
/storage returns {device, mountpoint, capacity, usage} for all filesystems.
In addition, it also detect and applies label for each filesystem - currently two - "root", "docker-images".

/storage/<label> returns info about the filesystem with specific label. eg. /storage/root returns info for root filesystem.