### PR TITLE
Start() exits gracefully when there are no factories.

### DIFF
--- a/container/factory.go
+++ b/container/factory.go
@@ -48,6 +48,14 @@ func RegisterContainerHandlerFactory(factory ContainerHandlerFactory) {
 	factories = append(factories, factory)
 }
 
+// Returns whether there are any container handler factories registered.
+func HasFactories() bool {
+	factoriesLock.Lock()
+	defer factoriesLock.Unlock()
+
+	return len(factories) != 0
+}
+
 // Create a new ContainerHandler for the specified container.
 func NewContainerHandler(name string) (ContainerHandler, error) {
 	factoriesLock.RLock()


### PR DESCRIPTION
This allows us to handle the case where there are no factories as
happens when testing in a non-container environment. We will still serve
the machine information that is available.