### PR TITLE
Add recursive and type options (raw/docker) to spec and summary endpoints.

### DIFF
--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -22,6 +22,11 @@ import (
 	"github.com/google/cadvisor/info/v1"
 )
 
+const (
+	TypeName   = "name"
+	TypeDocker = "docker"
+)
+
 type CpuSpec struct {
 	// Requested cpu shares. Default is 1024.
 	Limit uint64 `json:"limit"`
@@ -150,7 +155,7 @@ type FsInfo struct {
 	Labels []string `json:"labels"`
 }
 
-type StatsRequest struct {
+type RequestOptions struct {
 	// Type of container identifier specified - "name", "dockerid", dockeralias"
 	IdType string `json:"type"`
 	// Number of stats to return

--- a/manager/manager_mock.go
+++ b/manager/manager_mock.go
@@ -55,14 +55,19 @@ func (c *ManagerMock) DockerContainer(name string, query *info.ContainerInfoRequ
 	return args.Get(0).(info.ContainerInfo), args.Error(1)
 }
 
-func (c *ManagerMock) GetContainerSpec(containerName string) (info.ContainerSpec, error) {
-	args := c.Called(containerName)
-	return args.Get(0).(info.ContainerSpec), args.Error(1)
+func (c *ManagerMock) GetContainerSpec(containerName string, options v2.RequestOptions) (map[string]v2.ContainerSpec, error) {
+	args := c.Called(containerName, options)
+	return args.Get(0).(map[string]v2.ContainerSpec), args.Error(1)
 }
 
-func (c *ManagerMock) GetContainerDerivedStats(containerName string) (v2.DerivedStats, error) {
-	args := c.Called(containerName)
-	return args.Get(0).(v2.DerivedStats), args.Error(1)
+func (c *ManagerMock) GetDerivedStats(containerName string, options v2.RequestOptions) (map[string]v2.DerivedStats, error) {
+	args := c.Called(containerName, options)
+	return args.Get(0).(map[string]v2.DerivedStats), args.Error(1)
+}
+
+func (c *ManagerMock) GetRequestedContainersInfo(containerName string, options v2.RequestOptions) (map[string]*info.ContainerInfo, error) {
+	args := c.Called(containerName, options)
+	return args.Get(0).(map[string]*info.ContainerInfo), args.Error(1)
 }
 
 func (c *ManagerMock) WatchForEvents(queryuest *events.Request, passedChannel chan *events.Event) error {


### PR DESCRIPTION

spec, stats, and summary now all support the same options (except count,
which is only parsed for stats).