### PR TITLE
Reduce the level for a few common log messages

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -182,7 +182,7 @@ func (c *containerData) housekeeping() {
 	}
 
 	// Housekeep every second.
-	glog.Infof("Start housekeeping for container %q\n", c.info.Name)
+	glog.V(3).Infof("Start housekeeping for container %q\n", c.info.Name)
 	lastHousekeeping := time.Now()
 	for {
 		select {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -656,7 +656,7 @@ func (m *manager) createContainer(containerName string) error {
 	if alreadyExists {
 		return nil
 	}
-	glog.Infof("Added container: %q (aliases: %v, namespace: %q)", containerName, cont.info.Aliases, cont.info.Namespace)
+	glog.V(2).Infof("Added container: %q (aliases: %v, namespace: %q)", containerName, cont.info.Aliases, cont.info.Namespace)
 
 	contSpecs, err := cont.handler.GetSpec()
 	if err != nil {
@@ -714,7 +714,7 @@ func (m *manager) destroyContainer(containerName string) error {
 			Name:      alias,
 		})
 	}
-	glog.Infof("Destroyed container: %q (aliases: %v, namespace: %q)", containerName, cont.info.Aliases, cont.info.Namespace)
+	glog.V(2).Infof("Destroyed container: %q (aliases: %v, namespace: %q)", containerName, cont.info.Aliases, cont.info.Namespace)
 
 	contRef, err := cont.handler.ContainerReference()
 	if err != nil {


### PR DESCRIPTION
Following the Kubernetes convention of V(2) is normal verbosity (log
each request to a webserver).