### PR TITLE
Return all stats by default.

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -164,11 +164,7 @@ func streamResults(results chan *events.Event, w http.ResponseWriter, r *http.Re
 }
 
 func getContainerInfoRequest(body io.ReadCloser) (*info.ContainerInfoRequest, error) {
-	var query info.ContainerInfoRequest
-
-	// Default stats and samples is 64.
-	query.NumStats = 64
-
+	query := info.DefaultContainerInfoRequest()
 	decoder := json.NewDecoder(body)
 	err := decoder.Decode(&query)
 	if err != nil && err != io.EOF {

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -81,7 +81,9 @@ func (self ContainerReferenceSlice) Less(i, j int) bool { return self[i].Name < 
 // ContainerInfoQuery is used when users check a container info from the REST api.
 // It specifies how much data users want to get about a container
 type ContainerInfoRequest struct {
-	// Max number of stats to return.
+	// Max number of stats to return. Specify -1 for all stats currently available.
+	// If start and end time are specified this limit is ignored.
+	// Default: 60
 	NumStats int `json:"num_stats,omitempty"`
 
 	// Start time for which to query information.
@@ -91,6 +93,13 @@ type ContainerInfoRequest struct {
 	// End time for which to query information.
 	// If ommitted, current time is assumed.
 	End time.Time `json:"end,omitempty"`
+}
+
+// Returns a ContainerInfoRequest with all default values specified.
+func DefaultContainerInfoRequest() ContainerInfoRequest {
+	return ContainerInfoRequest{
+		NumStats: 60,
+	}
 }
 
 func (self *ContainerInfoRequest) Equals(other ContainerInfoRequest) bool {

--- a/storage/memory/stats_buffer.go
+++ b/storage/memory/stats_buffer.go
@@ -47,11 +47,17 @@ func (self *StatsBuffer) Add(item *info.ContainerStats) {
 }
 
 // Returns up to maxResult elements in the specified time period (inclusive).
-// Results are from first to last. maxResults of -1 means no limit.
+// Results are from first to last. maxResults of -1 means no limit. When first
+// and last are specified, maxResults is ignored.
 func (self *StatsBuffer) InTimeRange(start, end time.Time, maxResults int) []*info.ContainerStats {
 	// No stats, return empty.
 	if self.size == 0 {
 		return []*info.ContainerStats{}
+	}
+
+	// Return all results in a time range if specified.
+	if !start.IsZero() && !end.IsZero() {
+		maxResults = -1
 	}
 
 	// NOTE: Since we store the elments in descending timestamp order "start" will

--- a/storage/memory/stats_buffer_test.go
+++ b/storage/memory/stats_buffer_test.go
@@ -161,6 +161,9 @@ func TestInTimeRange(t *testing.T) {
 	expectElements(t, sb.InTimeRange(createTime(3), createTime(5), 10), []int32{3, 4})
 	assert.Empty(sb.InTimeRange(createTime(5), createTime(5), 10))
 
+	// Start and end time ignores maxResults.
+	expectElements(t, sb.InTimeRange(createTime(1), createTime(5), 1), []int32{1, 2, 3, 4})
+
 	// No start time.
 	expectElements(t, sb.InTimeRange(empty, createTime(5), 10), []int32{1, 2, 3, 4})
 	expectElements(t, sb.InTimeRange(empty, createTime(4), 10), []int32{1, 2, 3, 4})


### PR DESCRIPTION
Rather than relying on 64 being a "big enough" value.