### PR TITLE
Make EventData a concrete type.

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -479,14 +479,17 @@ func calculateCpuUsage(prev, cur uint64) uint64 {
 // differentiated by the EventType field of Event.
 type Event struct {
 	// the absolute container name for which the event occurred
-	ContainerName string
+	ContainerName string `json:"container_name"`
+
 	// the time at which the event occurred
-	Timestamp time.Time
+	Timestamp time.Time `json:"timestamp"`
+
 	// the type of event. EventType is an enumerated type
-	EventType EventType
+	EventType EventType `json:"event_type"`
+
 	// the original event object and all of its extraneous data, ex. an
 	// OomInstance
-	EventData EventDataInterface
+	EventData EventData `json:"event_data,omitempty"`
 }
 
 // EventType is an enumerated type which lists the categories under which
@@ -499,7 +502,26 @@ const (
 	EventContainerDeletion
 )
 
-// a general interface which populates the Event field EventData. The actual
-// object, such as an OomInstance, is set as an Event's EventData
-type EventDataInterface interface {
+// Extra information about an event. Only one type will be set.
+type EventData struct {
+	// Information about a container creation event.
+	Created *CreatedEventData `json:"created,omitempty"`
+
+	// Information about an OOM event.
+	Oom *OomEventData `json:"oom,omitempty"`
+}
+
+// Information related to a container creation event.
+type CreatedEventData struct {
+	// Spec of the container at creation.
+	Spec ContainerSpec `json:"spec"`
+}
+
+// Information related to an OOM kill instance
+type OomEventData struct {
+	// process id of the killed process
+	Pid int `json:"pid"`
+
+	// The name of the killed process
+	ProcessName string `json:"process_name"`
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -660,12 +660,12 @@ func (m *manager) createContainer(containerName string) error {
 	}
 	glog.V(2).Infof("Added container: %q (aliases: %v, namespace: %q)", containerName, cont.info.Aliases, cont.info.Namespace)
 
-	contSpecs, err := cont.handler.GetSpec()
+	contSpec, err := cont.handler.GetSpec()
 	if err != nil {
 		return err
 	}
 
-	if contSpecs.CreationTime.After(m.startupTime) {
+	if contSpec.CreationTime.After(m.startupTime) {
 		contRef, err := cont.handler.ContainerReference()
 		if err != nil {
 			return err
@@ -673,9 +673,13 @@ func (m *manager) createContainer(containerName string) error {
 
 		newEvent := &info.Event{
 			ContainerName: contRef.Name,
-			EventData:     contSpecs,
-			Timestamp:     contSpecs.CreationTime,
+			Timestamp:     contSpec.CreationTime,
 			EventType:     info.EventContainerCreation,
+			EventData: info.EventData{
+				Created: &info.CreatedEventData{
+					Spec: contSpec,
+				},
+			},
 		}
 		err = m.eventHandler.AddEvent(newEvent)
 		if err != nil {
@@ -878,7 +882,12 @@ func (self *manager) watchForNewOoms() error {
 				ContainerName: oomInstance.ContainerName,
 				Timestamp:     oomInstance.TimeOfDeath,
 				EventType:     info.EventOom,
-				EventData:     oomInstance,
+				EventData: info.EventData{
+					Oom: &info.OomEventData{
+						Pid:         oomInstance.Pid,
+						ProcessName: oomInstance.ProcessName,
+					},
+				},
 			}
 			glog.V(1).Infof("Created an oom event: %v", newEvent)
 			err := self.eventHandler.AddEvent(newEvent)


### PR DESCRIPTION
Having this as an interface was giving us a lot of problems with
unmarshaling. Made into a union of concrete types.