### PR TITLE
Fix networking stats by switching Tx and Rx stats.

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -255,6 +255,19 @@ func (self *dockerContainerHandler) GetStats() (*info.ContainerStats, error) {
 		return stats, err
 	}
 
+	// TODO(rjnagal): Remove the conversion when network stats are read from libcontainer.
+	net := stats.Network
+	// Ingress for host veth is from the container.
+	// Hence tx_bytes stat on the host veth is actually number of bytes received by the container.
+	stats.Network.RxBytes = net.TxBytes
+	stats.Network.RxPackets = net.TxPackets
+	stats.Network.RxErrors = net.TxErrors
+	stats.Network.RxDropped = net.TxDropped
+	stats.Network.TxBytes = net.RxBytes
+	stats.Network.TxPackets = net.RxPackets
+	stats.Network.TxErrors = net.RxErrors
+	stats.Network.TxDropped = net.RxDropped
+
 	// Get filesystem stats.
 	err = self.getFsStats(stats)
 	if err != nil {

--- a/integration/tests/api/docker_test.go
+++ b/integration/tests/api/docker_test.go
@@ -261,7 +261,7 @@ func TestDockerContainerNetworkStats(t *testing.T) {
 
 	// Checks for NetworkStats.
 	stat := containerInfo.Stats[0]
-	assert.NotEqual(t, 0, stat.Network.TxBytes, "Network tx bytes should not bet zero")
-	assert.NotEqual(t, 0, stat.Network.TxPackets, "Network tx packets should not bet zero")
+	assert.NotEqual(t, 0, stat.Network.TxBytes, "Network tx bytes should not be zero")
+	assert.NotEqual(t, 0, stat.Network.TxPackets, "Network tx packets should not be zero")
 	// TODO(vmarmol): Can probably do a better test with two containers pinging each other.
 }


### PR DESCRIPTION
A better fix is to directly use stats collected by libcontainer.