### PR TITLE
Move StatsBuffer to be time-based

### DIFF
--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -2,6 +2,14 @@
 
 This document describes a set of runtime flags available in cAdvisor.
 
+## Local Storage Duration
+
+cAdvisor stores the latest historical data in memory. How long of a history it stores can be configured with the `--storage_duration` flag.
+
+```
+--storage_duration: How long to store data.
+```
+
 ## Housekeeping
 
 Housekeeping is the periodic actions cAdvisor takes. During these actions, cAdvisor will gather container stats. These flags control how and when cAdvisor performs housekeeping.

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -81,7 +81,7 @@ func expectManagerWithContainers(containers []string, query *info.ContainerInfoR
 		infosMap[container] = itest.GenerateRandomContainerInfo(container, 4, query, 1*time.Second)
 	}
 
-	memoryStorage := memory.New(query.NumStats, nil)
+	memoryStorage := memory.New(time.Duration(query.NumStats)*time.Second, nil)
 	sysfs := &fakesysfs.FakeSysFs{}
 	m := createManagerAndAddContainers(
 		memoryStorage,

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -47,7 +47,7 @@ func getRecentStats(t *testing.T, memoryStorage *InMemoryStorage, numStats int) 
 }
 
 func TestAddStats(t *testing.T) {
-	memoryStorage := New(60, nil)
+	memoryStorage := New(60*time.Second, nil)
 
 	assert := assert.New(t)
 	assert.Nil(memoryStorage.AddStats(containerRef, makeStat(0)))
@@ -70,7 +70,7 @@ func TestRecentStatsNoRecentStats(t *testing.T) {
 
 // Make an instance of InMemoryStorage with n stats.
 func makeWithStats(n int) *InMemoryStorage {
-	memoryStorage := New(60, nil)
+	memoryStorage := New(60*time.Second, nil)
 
 	for i := 0; i < n; i++ {
 		memoryStorage.AddStats(containerRef, makeStat(i))

--- a/storage/memory/stats_buffer_test.go
+++ b/storage/memory/stats_buffer_test.go
@@ -53,18 +53,22 @@ func expectAllElements(t *testing.T, sb *StatsBuffer, expected []int32) {
 	expectElements(t, els, expected)
 }
 
+func getActualElements(actual []*info.ContainerStats) string {
+	actualElements := make([]string, len(actual))
+	for i, element := range actual {
+		actualElements[i] = strconv.Itoa(int(element.Cpu.LoadAverage))
+	}
+	return strings.Join(actualElements, ",")
+}
+
 func expectElements(t *testing.T, actual []*info.ContainerStats, expected []int32) {
 	if len(actual) != len(expected) {
-		t.Errorf("Expected elements %v, got %v", expected, actual)
+		t.Errorf("Expected elements %v, got %v", expected, getActualElements(actual))
 		return
 	}
 	for i, el := range actual {
 		if el.Cpu.LoadAverage != expected[i] {
-			actualElements := make([]string, len(actual))
-			for i, element := range actual {
-				actualElements[i] = strconv.Itoa(int(element.Cpu.LoadAverage))
-			}
-			t.Errorf("Expected elements %v, got %v", expected, strings.Join(actualElements, ","))
+			t.Errorf("Expected elements %v, got %v", expected, getActualElements(actual))
 			return
 		}
 	}
@@ -77,12 +81,12 @@ func expectElement(t *testing.T, stat *info.ContainerStats, expected int32) {
 }
 
 func TestAdd(t *testing.T) {
-	sb := NewStatsBuffer(5)
+	sb := NewStatsBuffer(5 * time.Second)
 
 	// Add 1.
-	sb.Add(createStats(1))
+	sb.Add(createStats(0))
 	expectSize(t, sb, 1)
-	expectAllElements(t, sb, []int32{1})
+	expectAllElements(t, sb, []int32{0})
 
 	// Fill the buffer.
 	for i := 1; i <= 5; i++ {
@@ -106,7 +110,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	sb := NewStatsBuffer(5)
+	sb := NewStatsBuffer(5 * time.Second)
 	sb.Add(createStats(1))
 	sb.Add(createStats(2))
 	sb.Add(createStats(3))
@@ -118,7 +122,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestInTimeRange(t *testing.T) {
-	sb := NewStatsBuffer(5)
+	sb := NewStatsBuffer(5 * time.Second)
 	assert := assert.New(t)
 
 	var empty time.Time
@@ -195,7 +199,7 @@ func TestInTimeRange(t *testing.T) {
 }
 
 func TestInTimeRangeWithLimit(t *testing.T) {
-	sb := NewStatsBuffer(5)
+	sb := NewStatsBuffer(5 * time.Second)
 	sb.Add(createStats(1))
 	sb.Add(createStats(2))
 	sb.Add(createStats(3))

--- a/storagedriver.go
+++ b/storagedriver.go
@@ -92,6 +92,6 @@ func NewMemoryStorage(backendStorageName string) (*memory.InMemoryStorage, error
 		glog.Infof("No backend storage selected")
 	}
 	glog.Infof("Caching %d stats in memory", statsToCache)
-	storageDriver = memory.New(statsToCache, backendStorage)
+	storageDriver = memory.New(time.Duration(statsToCache)*time.Second, backendStorage)
 	return storageDriver, nil
 }

--- a/storagedriver.go
+++ b/storagedriver.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/storage"
 	"github.com/google/cadvisor/storage/bigquery"
 	"github.com/google/cadvisor/storage/influxdb"
@@ -35,20 +34,13 @@ var argDbName = flag.String("storage_driver_db", "cadvisor", "database name")
 var argDbTable = flag.String("storage_driver_table", "stats", "table name")
 var argDbIsSecure = flag.Bool("storage_driver_secure", false, "use secure connection with database")
 var argDbBufferDuration = flag.Duration("storage_driver_buffer_duration", 60*time.Second, "Writes in the storage driver will be buffered for this duration, and committed to the non memory backends as a single transaction")
-
-const statsRequestedByUI = 60
+var storageDuration = flag.Duration("storage_duration", 2*time.Minute, "How long to keep data stored (Default: 2min).")
 
 // Creates a memory storage with an optional backend storage option.
 func NewMemoryStorage(backendStorageName string) (*memory.InMemoryStorage, error) {
 	var storageDriver *memory.InMemoryStorage
 	var backendStorage storage.StorageDriver
 	var err error
-	// TODO(vmarmol): We shouldn't need the housekeeping interval here and it shouldn't be public.
-	statsToCache := int(*argDbBufferDuration / *manager.HousekeepingInterval)
-	if statsToCache < statsRequestedByUI {
-		// The UI requests the most recent 60 stats by default.
-		statsToCache = statsRequestedByUI
-	}
 	switch backendStorageName {
 	case "":
 		backendStorage = nil
@@ -91,7 +83,7 @@ func NewMemoryStorage(backendStorageName string) (*memory.InMemoryStorage, error
 	} else {
 		glog.Infof("No backend storage selected")
 	}
-	glog.Infof("Caching %d stats in memory", statsToCache)
-	storageDriver = memory.New(time.Duration(statsToCache)*time.Second, backendStorage)
+	glog.Infof("Caching stats in memory for %v", *storageDuration)
+	storageDriver = memory.New(*storageDuration, backendStorage)
 	return storageDriver, nil
 }


### PR DESCRIPTION
This is the first step in making StatsBuffer non-stats specific and usable elsewhere. There are some further simplifications we can make to the code which I will do in future PRs.