### PR TITLE
Add --docker_only flag to enable tracking for only docker containers & root.

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -134,17 +134,19 @@ func FullContainerName(dockerId string) string {
 }
 
 // Docker handles all containers under /docker
-func (self *dockerFactory) CanHandle(name string) (bool, error) {
+func (self *dockerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
+	// docker factory accepts all containers it can handle.
+	canAccept := true
 	// Check if the container is known to docker and it is active.
 	id := ContainerNameToDockerId(name)
 
 	// We assume that if Inspect fails then the container is not known to docker.
 	ctnr, err := self.client.InspectContainer(id)
 	if err != nil || !ctnr.State.Running {
-		return false, fmt.Errorf("error inspecting container: %v", err)
+		return false, canAccept, fmt.Errorf("error inspecting container: %v", err)
 	}
 
-	return true, nil
+	return true, canAccept, nil
 }
 
 func parseDockerVersion(full_version_string string) ([]int, error) {

--- a/manager/manager_mock.go
+++ b/manager/manager_mock.go
@@ -70,6 +70,11 @@ func (c *ManagerMock) GetRequestedContainersInfo(containerName string, options v
 	return args.Get(0).(map[string]*info.ContainerInfo), args.Error(1)
 }
 
+func (c *ManagerMock) Exists(name string) bool {
+	args := c.Called(name)
+	return args.Get(0).(bool)
+}
+
 func (c *ManagerMock) WatchForEvents(queryuest *events.Request, passedChannel chan *info.Event) error {
 	args := c.Called(queryuest, passedChannel)
 	return args.Error(0)

--- a/pages/containers.go
+++ b/pages/containers.go
@@ -216,6 +216,9 @@ func serveContainersPage(m manager.Manager, w http.ResponseWriter, u *url.URL) e
 	// Build the links for the subcontainers.
 	subcontainerLinks := make([]link, 0, len(cont.Subcontainers))
 	for _, sub := range cont.Subcontainers {
+		if !m.Exists(sub.Name) {
+			continue
+		}
 		subcontainerLinks = append(subcontainerLinks, link{
 			Text: getContainerDisplayName(sub),
 			Link: path.Join(ContainersPage, sub.Name),


### PR DESCRIPTION
This reduces unnecessary load on the system and also cleans up the UI clutter.
Currently defaulted to false.