### PR TITLE
Add an item limit to TimedStore

### DIFF
--- a/events/handler.go
+++ b/events/handler.go
@@ -262,7 +262,7 @@ func (self *events) updateEventStore(e *info.Event) {
 	self.eventsLock.Lock()
 	defer self.eventsLock.Unlock()
 	if _, ok := self.eventStore[e.EventType]; !ok {
-		self.eventStore[e.EventType] = utils.NewTimedStore(self.maxAge)
+		self.eventStore[e.EventType] = utils.NewTimedStore(self.maxAge, -1)
 	}
 	self.eventStore[e.EventType].Add(e.Timestamp, e)
 }

--- a/events/handler_test.go
+++ b/events/handler_test.go
@@ -47,7 +47,7 @@ func initializeScenario(t *testing.T) (*events, *Request, *info.Event, *info.Eve
 	fakeEvent := makeEvent(createOldTime(t), "/")
 	fakeEvent2 := makeEvent(time.Now(), "/")
 
-	return NewEventManager(time.Hour), NewRequest(), fakeEvent, fakeEvent2
+	return NewEventManager(time.Hour, -1), NewRequest(), fakeEvent, fakeEvent2
 }
 
 func checkNumberOfEvents(t *testing.T, numEventsExpected int, numEventsReceived int) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -137,7 +137,7 @@ func New(memoryStorage *memory.InMemoryStorage, sysfs sysfs.SysFs) (Manager, err
 	glog.Infof("Version: %+v", newManager.versionInfo)
 
 	// TODO(vmarmol): Make configurable.
-	newManager.eventHandler = events.NewEventManager(24 * time.Hour)
+	newManager.eventHandler = events.NewEventManager(24*time.Hour, 100000)
 
 	// Register Docker container factory.
 	err = docker.Register(newManager, fsInfo)

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -57,7 +57,7 @@ func (self *containerStorage) RecentStats(start, end time.Time, maxStats int) ([
 func newContainerStore(ref info.ContainerReference, maxAge time.Duration) *containerStorage {
 	return &containerStorage{
 		ref:         ref,
-		recentStats: utils.NewTimedStore(maxAge),
+		recentStats: utils.NewTimedStore(maxAge, -1),
 		maxAge:      maxAge,
 	}
 }


### PR DESCRIPTION
Made the default limit 100,000 elements which is a little over 1 event per second for a day and assuming 250 bytes per event it would take up ~24MiB per event type.

/cc @rjnagal 