### PR TITLE
Improve approximation of container creation time.

### DIFF
--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -177,7 +177,11 @@ func (self *rawContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	now := time.Now()
 	lowestTime := now
 	for _, cgroupPath := range self.cgroupPaths {
-		// The modified time of the cgroup directory is when the container was created.
+		// The modified time of the cgroup directory changes whenever a subcontainer is created.
+		// eg. /docker will have creation time matching the creation of latest docker container.
+		// Use clone_children as a workaround as it isn't usually modified. It is only likely changed
+		// immediately after creating a container.
+		cgroupPath = path.Join(cgroupPath, "cgroup.clone_children")
 		fi, err := os.Stat(cgroupPath)
 		if err == nil && fi.ModTime().Before(lowestTime) {
 			lowestTime = fi.ModTime()


### PR DESCRIPTION
Containers with subcontainers always report creation time to be same as the time
of creation of the latest subcontainer.

Still not an ideal solution, but accurate for most practical purposes.