### PR TITLE
Return partial topology information if cache info is not available.

### DIFF
--- a/manager/machine.go
+++ b/manager/machine.go
@@ -187,7 +187,8 @@ func getTopology(sysFs sysfs.SysFs, cpuinfo string) ([]info.Node, int, error) {
 	for idx, node := range nodes {
 		caches, err := sysinfo.GetCacheInfo(sysFs, node.Cores[0].Threads[0])
 		if err != nil {
-			return nil, -1, fmt.Errorf("failed to get cache information for node %d: %v", node.Id, err)
+			glog.Errorf("failed to get cache information for node %d: %v", node.Id, err)
+			continue
 		}
 		numThreadsPerCore := len(node.Cores[0].Threads)
 		numThreadsPerNode := len(node.Cores) * numThreadsPerCore


### PR DESCRIPTION
Everything other than cache information is available through /proc/cpuinfo.