### PR TITLE
Add support for parsing CPU speed from /proc/cpuinfo on Power (ppc64) systems

### DIFF
--- a/manager/machine.go
+++ b/manager/machine.go
@@ -62,7 +62,12 @@ func getClockSpeed(procInfo []byte) (uint64, error) {
 	// Fall back to /proc/cpuinfo
 	matches := CpuClockSpeedMHz.FindSubmatch(procInfo)
 	if len(matches) != 2 {
-		return 0, fmt.Errorf("could not detect clock speed from output: %q", string(procInfo))
+		//Check if we are running on Power systems which have a different format
+		CpuClockSpeedMHz, _ = regexp.Compile("clock\\t*: +([0-9]+.[0-9]+)MHz")
+		matches = CpuClockSpeedMHz.FindSubmatch(procInfo)
+		if len(matches) != 2 {
+			return 0, fmt.Errorf("could not detect clock speed from output: %q", string(procInfo))
+		}
 	}
 	speed, err := strconv.ParseFloat(string(matches[1]), 64)
 	if err != nil {


### PR DESCRIPTION
Add support for parsing CPU speed from /proc/cpuinfo on Power (ppc64) systems

/proc/cpuinfo format varies between architectures. For example

On Intel the cpu speed is shown like the following
cpu MHz		: 3000

whereas on Power systems its shown like the following
clock		: 3000MHz

This patch enables support for /proc/cpuinfo parsing on Power systems

Signed-off-by: Pradipta Kr. Banerjee <bpradip@in.ibm.com>