### PR TITLE
Detect systemd with cgroup hierarchy.

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	"github.com/docker/libcontainer/cgroups"
-	"github.com/docker/libcontainer/cgroups/systemd"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 	"github.com/google/cadvisor/container"
@@ -55,16 +54,19 @@ var check = sync.Once{}
 
 func UseSystemd() bool {
 	check.Do(func() {
-		// run and initialize useSystemd
-		useSystemd = systemd.UseSystemd()
-		if !useSystemd {
-			// Second attempt at checking for systemd, check for a "name=systemd" cgroup.
-			mnt, err := cgroups.FindCgroupMountpoint("cpu")
+		useSystemd = false
+
+		// Check for system.slice in systemd and cpu cgroup.
+		for _, cgroupType := range []string{"name=systemd", "cpu"} {
+			mnt, err := cgroups.FindCgroupMountpoint(cgroupType)
 			if err == nil {
 				// systemd presence does not mean systemd controls cgroups.
 				// If system.slice cgroup exists, then systemd is taking control.
 				// This breaks if user creates system.slice manually :)
-				useSystemd = utils.FileExists(mnt + "/system.slice")
+				if utils.FileExists(path.Join(mnt, "system.slice")) {
+					useSystemd = true
+					break
+				}
 			}
 		}
 	})


### PR DESCRIPTION
The previous approach was brittle from within a container and was inconsistent.

Fixes #666 

/cc @rjnagal tested in an Ubuntu 15.04 box.