### PR TITLE
Only show network statistics for containers with bridge network

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -167,7 +167,7 @@ func libcontainerConfigToContainerSpec(config *libcontainerConfigs.Config, mi *i
 	}
 	spec.Cpu.Mask = utils.FixCpuMask(config.Cgroups.CpusetCpus, mi.NumCores)
 
-	spec.HasNetwork = true
+	spec.HasNetwork = len(config.Networks) > 0
 	spec.HasDiskIo = true
 
 	return spec


### PR DESCRIPTION
Victor mentioned that there was a 1 line modification that solves the problem, but I couldn't find it. I'm still very new to the cAdvisor code base and to Docker - it took me pretty long to figure out where the specs were stored, and how to extract configuration information from Docker, so I certainly could be doing this in a sub-optimal way. Let me know!