### PR TITLE
Fix incorrect use of metadata library, correct typo

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -125,7 +125,7 @@ type InstanceType string
 
 const (
 	NoInstance      InstanceType = "None"
-	UnknownInstance              = "Uknown"
+	UnknownInstance              = "Unknown"
 )
 
 type MachineInfo struct {

--- a/utils/cloudinfo/gce.go
+++ b/utils/cloudinfo/gce.go
@@ -26,7 +26,7 @@ func onGCE() bool {
 }
 
 func getGceInstanceType() info.InstanceType {
-	machineType, err := metadata.Get("machine-type")
+	machineType, err := metadata.Get("instance/machine-type")
 	if err != nil {
 		return info.UnknownInstance
 	}


### PR DESCRIPTION
Sorry, I thought I tested my cloud-provider-info code on GCE, but I must have tested the version of the code before Victor's code review (I probably wasn't checked into the right branch, or didn't rebase my changes, when testing on a GCE instance). I've tested this code on my desktop, and on a GCE n1-standard-1 instance.

So when I execute "curl http://localhost:8080/api/v2.0/machine"
Locally, I get: "cloud_provider":"Unknown","instance_type":"Unknown"
On the n1-standard-1 instance, I get: "cloud_provider":"GCE","instance_type":"n1-standard-1"

All integration tests pass except TestDockerContainerNetworkStats. We might want to look at this test again, since I thought Victor's PR last Wednesday should fix this test.