### PR TITLE
Cache custom metrics

### DIFF
--- a/collector/collector_manager_test.go
+++ b/collector/collector_manager_test.go
@@ -38,7 +38,7 @@ func (fc *fakeCollector) Name() string {
 }
 
 func TestCollect(t *testing.T) {
-	cm := &collectorManager{}
+	cm := &GenericCollectorManager{}
 
 	firstTime := time.Now().Add(-time.Hour)
 	secondTime := time.Now().Add(time.Hour)

--- a/manager/container_test.go
+++ b/manager/container_test.go
@@ -41,7 +41,7 @@ func setupContainerData(t *testing.T, spec info.ContainerSpec) (*containerData, 
 		nil,
 	)
 	memoryCache := memory.New(60, nil)
-	ret, err := newContainerData(containerName, memoryCache, mockHandler, nil, false, &collector.FakeCollectorManager{})
+	ret, err := newContainerData(containerName, memoryCache, mockHandler, nil, false, &collector.GenericCollectorManager{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -53,7 +53,7 @@ func createManagerAndAddContainers(
 			spec,
 			nil,
 		).Once()
-		cont, err := newContainerData(name, memoryCache, mockHandler, nil, false, &collector.FakeCollectorManager{})
+		cont, err := newContainerData(name, memoryCache, mockHandler, nil, false, &collector.GenericCollectorManager{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
v1.ContainerStats structure is being used to cache stats. 
To include CustomMetrics [ ]v2.Metric (originally defined in v2/metric.go), metric.go was moved from v2 to v1.
Should v2.ContainerStats be used instead to cache and retrieve stats?  