### PR TITLE
Include custom metrics in ContainerStats structure

### DIFF
--- a/collector/collector_manager.go
+++ b/collector/collector_manager.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/info/v1"
 )
 
 type collectorManager struct {
@@ -48,12 +48,12 @@ func (cm *collectorManager) RegisterCollector(collector Collector) error {
 	return nil
 }
 
-func (cm *collectorManager) Collect() (time.Time, []v2.Metric, error) {
+func (cm *collectorManager) Collect() (time.Time, []v1.Metric, error) {
 	var errors []error
 
 	// Collect from all collectors that are ready.
 	var next time.Time
-	var metrics []v2.Metric
+	var metrics []v1.Metric
 	for _, c := range cm.collectors {
 		if c.nextCollectionTime.Before(time.Now()) {
 			nextCollection, newMetrics, err := c.collector.Collect()

--- a/collector/collector_manager_test.go
+++ b/collector/collector_manager_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,9 +28,9 @@ type fakeCollector struct {
 	collectedFrom      int
 }
 
-func (fc *fakeCollector) Collect() (time.Time, []v2.Metric, error) {
+func (fc *fakeCollector) Collect() (time.Time, []v1.Metric, error) {
 	fc.collectedFrom++
-	return fc.nextCollectionTime, []v2.Metric{}, fc.err
+	return fc.nextCollectionTime, []v1.Metric{}, fc.err
 }
 
 func (fc *fakeCollector) Name() string {

--- a/collector/fakes.go
+++ b/collector/fakes.go
@@ -17,7 +17,7 @@ package collector
 import (
 	"time"
 
-	"github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/info/v1"
 )
 
 type FakeCollectorManager struct {
@@ -27,7 +27,7 @@ func (fkm *FakeCollectorManager) RegisterCollector(collector Collector) error {
 	return nil
 }
 
-func (fkm *FakeCollectorManager) Collect() (time.Time, []v2.Metric, error) {
+func (fkm *FakeCollectorManager) Collect() (time.Time, []v1.Metric, error) {
 	var zero time.Time
-	return zero, []v2.Metric{}, nil
+	return zero, []v1.Metric{}, nil
 }

--- a/collector/generic_collector.go
+++ b/collector/generic_collector.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/info/v1"
 )
 
 type GenericCollector struct {
@@ -56,7 +56,7 @@ func (collector *GenericCollector) Name() string {
 }
 
 //Returns collected metrics and the next collection time of the collector
-func (collector *GenericCollector) Collect() (time.Time, []v2.Metric, error) {
+func (collector *GenericCollector) Collect() (time.Time, []v1.Metric, error) {
 	//TO BE IMPLEMENTED
 	return time.Now(), nil, nil
 }

--- a/collector/types.go
+++ b/collector/types.go
@@ -15,7 +15,7 @@
 package collector
 
 import (
-	"github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/info/v1"
 	"time"
 )
 
@@ -27,7 +27,7 @@ type Collector interface {
 	// Returns the next time this collector should be collected from.
 	// Next collection time is always returned, even when an error occurs.
 	// A collection time of zero means no more collection.
-	Collect() (time.Time, []v2.Metric, error)
+	Collect() (time.Time, []v1.Metric, error)
 
 	// Name of this collector.
 	Name() string
@@ -42,5 +42,5 @@ type CollectorManager interface {
 	// at which a collector will be ready to collect from.
 	// Next collection time is always returned, even when an error occurs.
 	// A collection time of zero means no more collection.
-	Collect() (time.Time, []v2.Metric, error)
+	Collect() (time.Time, []v1.Metric, error)
 }

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -419,6 +419,9 @@ type ContainerStats struct {
 
 	// Task load stats
 	TaskStats LoadStats `json:"task_stats,omitempty"`
+
+	//Custom metrics from all collectors
+	CustomMetrics []Metric `json:"custom_metrics,omitempty"`
 }
 
 func timeEq(t1, t2 time.Time, tolerance time.Duration) bool {

--- a/info/v1/metric.go
+++ b/info/v1/metric.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v2
+package v1
 
 import (
 	"time"


### PR DESCRIPTION
v1.ContainerStats structure is being used to cache stats. 
To include CustomMetrics [ ]v2.Metric (originally defined in v2/metric.go), metric.go was moved from v2 to v1.