### PR TITLE
Reduce the amount of bad Docker.inspects when using docker_only flag in combination with Systemd

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -44,7 +44,7 @@ var dockerRunDir = flag.String("docker_run", "/var/run/docker", "Absolute path t
 
 // Regexp that identifies docker cgroups, containers started with
 // --cgroup-parent have another prefix than 'docker'
-var dockerCgroupRegexp = regexp.MustCompile(`[A-z]+-([a-z0-9]+)\.scope`)
+var dockerCgroupRegexp = regexp.MustCompile(`.+-([a-z0-9]{64})\.scope$`)
 
 // TODO(vmarmol): Export run dir too for newer Dockers.
 // Directory holding Docker container state information.

--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -131,14 +131,20 @@ func ContainerNameToDockerId(name string) string {
 	return id
 }
 
+func isContainerName(name string) bool {
+	if UseSystemd() {
+		return dockerCgroupRegexp.MatchString(path.Base(name))
+	}
+	return true
+}
+
 // Docker handles all containers under /docker
 func (self *dockerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	// docker factory accepts all containers it can handle.
 	canAccept := true
 
-	// When using Systemd all docker containers have a .scope suffix
-	if UseSystemd() && !strings.HasSuffix(path.Base(name), ".scope") {
-		return false, canAccept, nil
+	if !isContainerName(name) {
+		return false, canAccept, fmt.Errorf("invalid container name")
 	}
 
 	// Check if the container is known to docker and it is active.

--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -131,16 +131,6 @@ func ContainerNameToDockerId(name string) string {
 	return id
 }
 
-// Returns a full container name for the specified Docker ID.
-func FullContainerName(dockerId string) string {
-	// Add the full container name.
-	if UseSystemd() {
-		return path.Join("/system.slice", fmt.Sprintf("docker-%s.scope", dockerId))
-	} else {
-		return path.Join("/docker", dockerId)
-	}
-}
-
 // Docker handles all containers under /docker
 func (self *dockerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	// docker factory accepts all containers it can handle.

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -294,32 +294,8 @@ func (self *dockerContainerHandler) GetStats() (*info.ContainerStats, error) {
 }
 
 func (self *dockerContainerHandler) ListContainers(listType container.ListType) ([]info.ContainerReference, error) {
-	if self.name != "/docker" {
-		return []info.ContainerReference{}, nil
-	}
-	opt := docker.ListContainersOptions{
-		All: true,
-	}
-	containers, err := self.client.ListContainers(opt)
-	if err != nil {
-		return nil, err
-	}
-
-	ret := make([]info.ContainerReference, 0, len(containers)+1)
-	for _, c := range containers {
-		if !strings.HasPrefix(c.Status, "Up ") {
-			continue
-		}
-
-		ref := info.ContainerReference{
-			Name:      FullContainerName(c.ID),
-			Aliases:   append(c.Names, c.ID),
-			Namespace: DockerNamespace,
-		}
-		ret = append(ret, ref)
-	}
-
-	return ret, nil
+	// No-op for Docker driver.
+	return []info.ContainerReference{}, nil
 }
 
 func (self *dockerContainerHandler) GetCgroupPath(resource string) (string, error) {


### PR DESCRIPTION
When running with the `docker_only` flag, the manager will keep trying to find a handler for the "ignored" raw containers during the housekeeping (every minute.) Each time a container is passed to the docker driver it will send an inspect request to the Docker daemon, resulting in loads of log messages:

```log
Jul 18 19:18:45 hactar docker[1024]: time="2015-07-18T19:18:45+02:00" level=info msg="+job container_inspect(rsyslog.service)"
Jul 18 19:18:45 hactar docker[1024]: no such id: rsyslog.service
Jul 18 19:18:45 hactar docker[1024]: time="2015-07-18T19:18:45+02:00" level=info msg="-job container_inspect(rsyslog.service) = ERR (1)"
Jul 18 19:18:45 hactar docker[1024]: time="2015-07-18T19:18:45+02:00" level=error msg="Handler for GET /containers/{name:.*}/json returned error: no such id: rsyslog.service"
Jul 18 19:18:45 hactar docker[1024]: time="2015-07-18T19:18:45+02:00" level=error msg="HTTP Error: statusCode=404 no such id: rsyslog.service"
```

This PR adds an extra check in the CanHandleAndAccept method of the Docker driver to filter out non-Docker containers when using Systemd before doing a Docker inspect. 