### PR TITLE
Two small fixes to custom metric collection.

### DIFF
--- a/collector/generic_collector.go
+++ b/collector/generic_collector.go
@@ -100,7 +100,7 @@ func (collector *GenericCollector) Name() string {
 //Returns collected metrics and the next collection time of the collector
 func (collector *GenericCollector) Collect() (time.Time, []v1.Metric, error) {
 	currentTime := time.Now()
-	nextCollectionTime := currentTime.Add(time.Duration(collector.info.minPollingFrequency * time.Second))
+	nextCollectionTime := currentTime.Add(time.Duration(collector.info.minPollingFrequency))
 
 	uri := collector.configFile.Endpoint
 	response, err := http.Get(uri)

--- a/manager/container.go
+++ b/manager/container.go
@@ -486,8 +486,8 @@ func (c *containerData) updateStats() error {
 		}
 	}
 	var customStatsErr error
-	if c.collectorManager != nil {
-		cm := c.collectorManager.(*collector.GenericCollectorManager)
+	cm := c.collectorManager.(*collector.GenericCollectorManager)
+	if len(cm.Collectors) > 0 {
 		if cm.NextCollectionTime.Before(time.Now()) {
 			customStats, err := c.updateCustomStats()
 			if customStats != nil {


### PR DESCRIPTION
- a typo in minPollingFrequency multiplies it with time.Second twice.
- Updating custom metrics is unnecessarily called for all containers.