### PR TITLE
Change storage of custom metrics

### DIFF
--- a/collector/generic_collector_test.go
+++ b/collector/generic_collector_test.go
@@ -152,7 +152,7 @@ func TestMetricCollection(t *testing.T) {
 	assert.NoError(errMetric)
 	assert.Equal(metrics[0].Name, "activeConnections")
 	assert.Equal(metrics[0].Type, v1.MetricGauge)
-	assert.Nil(metrics[0].FloatPoints)
+	assert.Equal(len(metrics[0].FloatPoints), 0)
 	assert.Equal(metrics[1].Name, "reading")
 	assert.Equal(metrics[2].Name, "writing")
 	assert.Equal(metrics[3].Name, "waiting")

--- a/collector/generic_collector_test.go
+++ b/collector/generic_collector_test.go
@@ -152,11 +152,12 @@ func TestMetricCollection(t *testing.T) {
 	assert.NoError(errMetric)
 	assert.Equal(metrics[0].Name, "activeConnections")
 	assert.Equal(metrics[0].Type, v1.MetricGauge)
-	assert.Equal(len(metrics[0].FloatPoints), 0)
 	assert.Equal(metrics[1].Name, "reading")
 	assert.Equal(metrics[2].Name, "writing")
 	assert.Equal(metrics[3].Name, "waiting")
 
+	metricsMap, metricsMapErr := fakeCollector.GetMetrics()
+	assert.NoError(metricsMapErr)
 	//Assert: Number of active connections = Number of connections reading + Number of connections writing + Number of connections waiting
-	assert.Equal(metrics[0].IntPoints[0].Value, (metrics[1].IntPoints[0].Value)+(metrics[2].IntPoints[0].Value)+(metrics[3].IntPoints[0].Value))
+	assert.Equal(metricsMap["activeConnections"][0].Value.(int64), (metricsMap["reading"][0].Value.(int64))+(metricsMap["writing"][0].Value.(int64))+(metricsMap["waiting"][0].Value.(int64)))
 }

--- a/info/v1/metric.go
+++ b/info/v1/metric.go
@@ -15,6 +15,8 @@
 package v1
 
 import (
+	"github.com/google/cadvisor/utils"
+	"sync"
 	"time"
 )
 
@@ -43,27 +45,16 @@ type Metric struct {
 	// Metadata associated with this metric.
 	Labels map[string]string
 
-	// Value of the metric. Only one of these values will be
-	// available according to the output type of the metric.
+	// Value of the metric.
 	// If no values are available, there are no data points.
-	IntPoints   []IntPoint   `json:"int_points,omitempty"`
-	FloatPoints []FloatPoint `json:"float_points,omitempty"`
+	DataPoints *utils.TimedStore `json:"data_points,omitempty"`
+	Lock       sync.RWMutex
 }
 
-// An integer metric data point.
-type IntPoint struct {
+type DataPoint struct {
 	// Time at which the metric was queried
 	Timestamp time.Time `json:"timestamp"`
 
 	// The value of the metric at this point.
-	Value int64 `json:"value"`
-}
-
-// A float metric data point.
-type FloatPoint struct {
-	// Time at which the metric was queried
-	Timestamp time.Time `json:"timestamp"`
-
-	// The value of the metric at this point.
-	Value float64 `json:"value"`
+	Value interface{} `json:"value"`
 }

--- a/manager/container.go
+++ b/manager/container.go
@@ -488,8 +488,8 @@ func (c *containerData) updateStats() error {
 		}
 	}
 	var customStatsErr error
-	if c.collectorManager != nil {
-		cm := c.collectorManager.(*collector.GenericCollectorManager)
+	cm := c.collectorManager.(*collector.GenericCollectorManager)
+	if len(cm.Collectors) > 0 {
 		if cm.NextCollectionTime.Before(time.Now()) {
 			customStats, err := c.updateCustomStats()
 			if customStats != nil {


### PR DESCRIPTION
@rjnagal @vmarmol 

Would this be something we are interested in ?
We are using the same storage structure in a slightly different way.
Each metric will have  metric name, type, labels, a slice of intPoints(timestamp+value), a slice of floatPoints. Either intpoints or floatPoints will be empty for each metric. Collect function only updates intPoints or floatPoints.