### PR TITLE
Add units and data type to spec for custom metrics.

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -35,8 +35,12 @@ type MetricConfig struct {
 	//enum type for the metric type
 	MetricType v1.MetricType `json:"metric_type"`
 
-	//data type of the metric (eg: integer, string)
+	// metric units to display on UI and in storage (eg: MB, cores)
+	// this is only used for display.
 	Units string `json:"units"`
+
+	//data type of the metric (eg: int, float)
+	DataType v1.DataType `json:"data_type"`
 
 	//the frequency at which the metric should be collected
 	PollingFrequency time.Duration `json:"polling_frequency"`

--- a/collector/config/sample_config.json
+++ b/collector/config/sample_config.json
@@ -3,25 +3,29 @@
 	"metrics_config"  : [
 		{ "name" : "activeConnections",  
 		  "metric_type" : "gauge",
-		  "units" : "integer",
+		  "units" : "number of active connections",
+		  "data_type" : "int",
 		  "polling_frequency" : 10,
 		  "regex" : "Active connections: ([0-9]+)"			
 		},
 		{ "name" : "reading",
 		  "metric_type" : "gauge", 
-		  "units" : "integer",
+		  "units" : "number of reading connections",
+		  "data_type" : "int",
 		  "polling_frequency" : 10,
 		  "regex" : "Reading: ([0-9]+) .*"	
 		},
 		{ "name" : "writing",
                   "metric_type" : "gauge",
-                  "units" : "integer",
+                  "data_type" : "int",
+		  "units" : "number of writing connections",
                   "polling_frequency" : 10,
                   "regex" : ".*Writing: ([0-9]+).*"
                 },
 		{ "name" : "waiting",
                   "metric_type" : "gauge",
-                  "units" : "integer",
+                  "units" : "number of waiting connections",
+		  "data_type" : "int",
                   "polling_frequency" : 10,
                   "regex" : ".*Waiting: ([0-9]+)"
                 }

--- a/collector/generic_collector.go
+++ b/collector/generic_collector.go
@@ -99,8 +99,10 @@ func (collector *GenericCollector) Name() string {
 
 func (collector *GenericCollector) configToSpec(config MetricConfig) v1.MetricSpec {
 	return v1.MetricSpec{
-		Name: config.Name,
-		Type: config.MetricType,
+		Name:   config.Name,
+		Type:   config.MetricType,
+		Format: config.DataType,
+		Units:  config.Units,
 	}
 }
 
@@ -135,7 +137,7 @@ func (collector *GenericCollector) Collect(metrics map[string]v1.MetricVal) (tim
 	for ind, metricConfig := range collector.configFile.MetricsConfig {
 		matchString := collector.info.regexps[ind].FindStringSubmatch(string(pageContent))
 		if matchString != nil {
-			if metricConfig.Units == "float" {
+			if metricConfig.DataType == v1.FloatType {
 				regVal, err := strconv.ParseFloat(strings.TrimSpace(matchString[1]), 64)
 				if err != nil {
 					errorSlice = append(errorSlice, err)
@@ -143,7 +145,7 @@ func (collector *GenericCollector) Collect(metrics map[string]v1.MetricVal) (tim
 				metrics[metricConfig.Name] = v1.MetricVal{
 					FloatValue: regVal, Timestamp: currentTime,
 				}
-			} else if metricConfig.Units == "integer" || metricConfig.Units == "int" {
+			} else if metricConfig.DataType == v1.IntType {
 				regVal, err := strconv.ParseInt(strings.TrimSpace(matchString[1]), 10, 64)
 				if err != nil {
 					errorSlice = append(errorSlice, err)
@@ -153,7 +155,7 @@ func (collector *GenericCollector) Collect(metrics map[string]v1.MetricVal) (tim
 				}
 
 			} else {
-				errorSlice = append(errorSlice, fmt.Errorf("Unexpected value of 'units' for metric '%v' in config ", metricConfig.Name))
+				errorSlice = append(errorSlice, fmt.Errorf("Unexpected value of 'data_type' for metric '%v' in config ", metricConfig.Name))
 			}
 		} else {
 			errorSlice = append(errorSlice, fmt.Errorf("No match found for regexp: %v for metric '%v' in config", metricConfig.Regex, metricConfig.Name))

--- a/collector/generic_collector_test.go
+++ b/collector/generic_collector_test.go
@@ -60,7 +60,7 @@ func TestConfigWithErrors(t *testing.T) {
 			{
 				 "name" : "activeConnections,  
 		  		 "metric_type" : "gauge",
-		 	 	 "units" : "integer",
+		 	 	 "data_type" : "int",
 		  		 "polling_frequency" : 10,
 		    		 "regex" : "Active connections: ([0-9]+)"			
 			}
@@ -90,14 +90,14 @@ func TestConfigWithRegexErrors(t *testing.T) {
                         {
                                  "name" : "activeConnections",
                                  "metric_type" : "gauge",
-                                 "units" : "integer",
+                                 "data_type" : "int",
                                  "polling_frequency" : 10,
                                  "regex" : "Active connections: (+)"
                         },
                         {
                                  "name" : "reading",
                                  "metric_type" : "gauge",
-                                 "units" : "integer",
+                                 "data_type" : "int",
                                  "polling_frequency" : 10,
                                  "regex" : "Reading: ([0-9]+) .*"
                         }

--- a/info/v1/metric.go
+++ b/info/v1/metric.go
@@ -32,6 +32,14 @@ const (
 	MetricDelta = "delta"
 )
 
+// DataType for metric being exported.
+type DataType string
+
+const (
+	IntType   DataType = "int"
+	FloatType          = "float"
+)
+
 // Spec for custom metric.
 type MetricSpec struct {
 	// The name of the metric.
@@ -39,6 +47,12 @@ type MetricSpec struct {
 
 	// Type of the metric.
 	Type MetricType `json:"type"`
+
+	// Data Type for the stats.
+	Format DataType `json:"format"`
+
+	// Display Units for the stats.
+	Units string `json:"units"`
 }
 
 // An exported metric.


### PR DESCRIPTION
Renamed units to data_type in collector config.
Use units for actual display units eg MB/s, "number of connections".