### PR TITLE
Adding STDOUT new storage

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -42,7 +42,7 @@ import (
 // Housekeeping interval.
 var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
 
-var cgroupPathRegExp = regexp.MustCompile(".*:devices:(.*?),.*")
+var cgroupPathRegExp = regexp.MustCompile(".*devices:(.*?)[,;$].*")
 
 // Decay value used for load average smoothing. Interval length of 10 seconds is used.
 var loadDecay = math.Exp(float64(-1 * (*HousekeepingInterval).Seconds() / 10))

--- a/storage/stdout/stdout.go
+++ b/storage/stdout/stdout.go
@@ -1,0 +1,117 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stdout
+
+import (
+	"bytes"
+	"fmt"
+	info "github.com/google/cadvisor/info/v1"
+)
+
+type stdoutStorage struct {
+	Namespace string
+}
+
+const (
+	colCpuCumulativeUsage string = "cpu_cumulative_usage"
+	// Memory Usage
+	colMemoryUsage string = "memory_usage"
+	// Working set size
+	colMemoryWorkingSet string = "memory_working_set"
+	// Cumulative count of bytes received.
+	colRxBytes string = "rx_bytes"
+	// Cumulative count of receive errors encountered.
+	colRxErrors string = "rx_errors"
+	// Cumulative count of bytes transmitted.
+	colTxBytes string = "tx_bytes"
+	// Cumulative count of transmit errors encountered.
+	colTxErrors string = "tx_errors"
+	// Filesystem summary
+	colFsSummary = "fs_summary"
+	// Filesystem limit.
+	colFsLimit = "fs_limit"
+	// Filesystem usage.
+	colFsUsage = "fs_usage"
+)
+
+func (driver *stdoutStorage) containerStatsToValues(stats *info.ContainerStats) (series map[string]uint64) {
+	series = make(map[string]uint64)
+
+	// Cumulative Cpu Usage
+	series[colCpuCumulativeUsage] = stats.Cpu.Usage.Total
+
+	// Memory Usage
+	series[colMemoryUsage] = stats.Memory.Usage
+
+	// Working set size
+	series[colMemoryWorkingSet] = stats.Memory.WorkingSet
+
+	// Network stats.
+	series[colRxBytes] = stats.Network.RxBytes
+	series[colRxErrors] = stats.Network.RxErrors
+	series[colTxBytes] = stats.Network.TxBytes
+	series[colTxErrors] = stats.Network.TxErrors
+
+	return series
+}
+
+func (driver *stdoutStorage) containerFsStatsToValues(series *map[string]uint64, stats *info.ContainerStats) {
+	for _, fsStat := range stats.Filesystem {
+		// Summary stats.
+		(*series)[colFsSummary+"."+colFsLimit] += fsStat.Limit
+		(*series)[colFsSummary+"."+colFsUsage] += fsStat.Usage
+
+		// Per device stats.
+		(*series)[fsStat.Device+"."+colFsLimit] = fsStat.Limit
+		(*series)[fsStat.Device+"."+colFsUsage] = fsStat.Usage
+	}
+}
+
+func (driver *stdoutStorage) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+	if stats == nil {
+		return nil
+	}
+
+	var containerName string
+	if len(ref.Aliases) > 0 {
+		containerName = ref.Aliases[0]
+	} else {
+		containerName = ref.Name
+	}
+
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("cName=%s host=%s", containerName, driver.Namespace))
+
+	series := driver.containerStatsToValues(stats)
+	driver.containerFsStatsToValues(&series, stats)
+	for key, value := range series {
+		buffer.WriteString(fmt.Sprintf(" %s=%v", key, value))
+	}
+
+	fmt.Println(buffer.String())
+
+	return nil
+}
+
+func (driver *stdoutStorage) Close() error {
+	return nil
+}
+
+func New(namespace string) (*stdoutStorage, error) {
+	stdoutStorage := &stdoutStorage{
+		Namespace: namespace,
+	}
+	return stdoutStorage, nil
+}

--- a/storagedriver.go
+++ b/storagedriver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/cadvisor/storage/influxdb"
 	"github.com/google/cadvisor/storage/redis"
 	"github.com/google/cadvisor/storage/statsd"
+	"github.com/google/cadvisor/storage/stdout"
 )
 
 var argDbUsername = flag.String("storage_driver_user", "root", "database username")
@@ -92,6 +93,10 @@ func NewMemoryStorage(backendStorageName string) (*memory.InMemoryCache, error) 
 	case "statsd":
 		backendStorage, err = statsd.New(
 			*argDbName,
+			*argDbHost,
+		)
+	case "stdout":
+		backendStorage, err = stdout.New(
 			*argDbHost,
 		)
 	default:


### PR DESCRIPTION
Createed the feature proposed on issue 847
There are changes that could be made on how to write to STDOUT.

It needs besides the storage_driver=io, the storage_driver_host=$HOSTNAME that way you may associate the logs, perhaps this could be added in the same code, but it's done this way to make it flexible to the user.