### PR TITLE
Adding Hostname from the server and not as a parameter for stdout

### DIFF
--- a/storage/stdout/stdout.go
+++ b/storage/stdout/stdout.go
@@ -108,7 +108,7 @@ func (driver *stdoutStorage) Close() error {
 	return nil
 }
 
-func New(hostname, namespace string) (*stdoutStorage, error) {
+func New(hostname string) (*stdoutStorage, error) {
 	stdoutStorage := &stdoutStorage{
 		Hostname: hostname,
 	}

--- a/storage/stdout/stdout.go
+++ b/storage/stdout/stdout.go
@@ -22,7 +22,7 @@ import (
 )
 
 type stdoutStorage struct {
-	Namespace string
+	Hostname string
 }
 
 const (
@@ -91,7 +91,7 @@ func (driver *stdoutStorage) AddStats(ref info.ContainerReference, stats *info.C
 	}
 
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("cName=%s host=%s", containerName, driver.Namespace))
+	buffer.WriteString(fmt.Sprintf("cName=%s host=%s", containerName, driver.Hostname))
 
 	series := driver.containerStatsToValues(stats)
 	driver.containerFsStatsToValues(&series, stats)
@@ -108,9 +108,9 @@ func (driver *stdoutStorage) Close() error {
 	return nil
 }
 
-func New(namespace string) (*stdoutStorage, error) {
+func New(hostname, namespace string) (*stdoutStorage, error) {
 	stdoutStorage := &stdoutStorage{
-		Namespace: namespace,
+		Hostname: hostname,
 	}
 	return stdoutStorage, nil
 }

--- a/storagedriver.go
+++ b/storagedriver.go
@@ -44,16 +44,16 @@ func NewMemoryStorage(backendStorageName string) (*memory.InMemoryCache, error) 
 	var storageDriver *memory.InMemoryCache
 	var backendStorage storage.StorageDriver
 	var err error
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
 	switch backendStorageName {
 	case "":
 		backendStorage = nil
 	case "influxdb":
-		var hostname string
-		hostname, err = os.Hostname()
-		if err != nil {
-			return nil, err
-		}
-
 		backendStorage, err = influxdb.New(
 			hostname,
 			*argDbTable,
@@ -65,11 +65,6 @@ func NewMemoryStorage(backendStorageName string) (*memory.InMemoryCache, error) 
 			*argDbBufferDuration,
 		)
 	case "bigquery":
-		var hostname string
-		hostname, err = os.Hostname()
-		if err != nil {
-			return nil, err
-		}
 		backendStorage, err = bigquery.New(
 			hostname,
 			*argDbTable,
@@ -79,13 +74,8 @@ func NewMemoryStorage(backendStorageName string) (*memory.InMemoryCache, error) 
 		//machineName: We use os.Hostname as the machineName (A unique identifier to identify the host that runs the current cAdvisor)
 		//argDbName: the key for redis's data
 		//argDbHost: the redis's server host
-		var machineName string
-		machineName, err = os.Hostname()
-		if err != nil {
-			return nil, err
-		}
 		backendStorage, err = redis.New(
-			machineName,
+			hostname,
 			*argDbName,
 			*argDbHost,
 			*argDbBufferDuration,
@@ -97,10 +87,10 @@ func NewMemoryStorage(backendStorageName string) (*memory.InMemoryCache, error) 
 		)
 	case "stdout":
 		backendStorage, err = stdout.New(
-			*argDbHost,
+			hostname,
 		)
 	default:
-		err = fmt.Errorf("unknown backend storage driver: %v", *argDbDriver)
+		err = fmt.Errorf("unknown backend storage driver in %s: %v", hostname, *argDbDriver)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cleaning the stdout code a bit, making the hostname not a parameter from stdin but using the one from storagedriver.
Cleaning storagedriver to remove duplicate code lines for the hostname.