### PR TITLE
glog.Warning -> glog.Warningf

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -221,7 +221,7 @@ func (self *manager) Start() error {
 		} else {
 			err = cpuLoadReader.Start()
 			if err != nil {
-				glog.Warning("Could not start cpu load stat collector: %s", err)
+				glog.Warningf("Could not start cpu load stat collector: %s", err)
 			} else {
 				self.loadReader = cpuLoadReader
 			}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -392,7 +392,7 @@ func (c *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
 	containers, err := c.infoProvider.SubcontainersInfo("/", &info.ContainerInfoRequest{NumStats: 1})
 	if err != nil {
 		c.errors.Set(1)
-		glog.Warning("Couldn't get containers: %s", err)
+		glog.Warningf("Couldn't get containers: %s", err)
 		return
 	}
 	for _, container := range containers {


### PR DESCRIPTION
Fix two places where `glog.Warning` is used with a formatted string.