### PR TITLE
Always to a live lookup of version info instead of caching.

### DIFF
--- a/integration/framework/framework.go
+++ b/integration/framework/framework.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/cadvisor/client"
+	"github.com/google/cadvisor/client/v2"
 	"github.com/google/cadvisor/integration/common"
 )
 
@@ -123,12 +124,14 @@ type ShellActions interface {
 type CadvisorActions interface {
 	// Returns a cAdvisor client to the machine being tested.
 	Client() *client.Client
+	ClientV2() *v2.Client
 }
 
 type realFramework struct {
-	hostname       HostnameInfo
-	t              *testing.T
-	cadvisorClient *client.Client
+	hostname         HostnameInfo
+	t                *testing.T
+	cadvisorClient   *client.Client
+	cadvisorClientV2 *v2.Client
 
 	shellActions  shellActions
 	dockerActions dockerActions
@@ -193,6 +196,18 @@ func (self *realFramework) Client() *client.Client {
 		self.cadvisorClient = cadvisorClient
 	}
 	return self.cadvisorClient
+}
+
+// Gets a v2 client to the cAdvisor being tested.
+func (self *realFramework) ClientV2() *v2.Client {
+	if self.cadvisorClientV2 == nil {
+		cadvisorClientV2, err := v2.NewClient(self.Hostname().FullHostname())
+		if err != nil {
+			self.t.Fatalf("Failed to instantiate the cAdvisor client: %v", err)
+		}
+		self.cadvisorClientV2 = cadvisorClientV2
+	}
+	return self.cadvisorClientV2
 }
 
 func (self dockerActions) RunPause() string {

--- a/integration/tests/api/attributes_test.go
+++ b/integration/tests/api/attributes_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/google/cadvisor/integration/framework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttributeInformationIsReturned(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	attributes, err := fm.Cadvisor().ClientV2().Attributes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vp := `\d+\.\d+\.\d+`
+	assert.True(t, assert.Regexp(t, vp, attributes.DockerVersion),
+		"Expected %s to match %s", attributes.DockerVersion, vp)
+}


### PR DESCRIPTION
This PR changes how VersionInfo is served
old: lookup/create and cache the version info at manager creation time
new: lookup/create the version info each time it is requested

This is necessary to correctly report the VersionInfo in the event that the docker daemon is not running at the time the manager is created.  This case may be encountered when cAdvisor is started in the same program that initializes the docker daemon / container bridge.