### PR TITLE
Add instantaneous cpu metrics

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/golang/glog"
 	info "github.com/google/cadvisor/info/v1"
@@ -449,8 +450,63 @@ func (self *version2_0) HandleRequest(requestType string, request []string, m ma
 	}
 }
 
+func instCpuStats(last, cur *info.ContainerStats) (*v2.CpuInstStats, error) {
+	if last == nil {
+		return nil, nil
+	}
+	if !cur.Timestamp.After(last.Timestamp) {
+		return nil, fmt.Errorf("container stats move backwards in time")
+	}
+	if len(last.Cpu.Usage.PerCpu) != len(cur.Cpu.Usage.PerCpu) {
+		return nil, fmt.Errorf("different number of cpus")
+	}
+	timeDelta := cur.Timestamp.Sub(last.Timestamp)
+	if timeDelta <= 100*time.Millisecond {
+		return nil, fmt.Errorf("time delta unexpectedly small")
+	}
+	// Nanoseconds to gain precision and avoid having zero seconds if the
+	// difference between the timestamps is just under a second
+	timeDeltaNs := uint64(timeDelta.Nanoseconds())
+	convertToRate := func(lastValue, curValue uint64) (uint64, error) {
+		if curValue < lastValue {
+			return 0, fmt.Errorf("cumulative stats decrease")
+		}
+		valueDelta := curValue - lastValue
+		return (valueDelta * 1e9) / timeDeltaNs, nil
+	}
+	total, err := convertToRate(last.Cpu.Usage.Total, cur.Cpu.Usage.Total)
+	if err != nil {
+		return nil, err
+	}
+	percpu := make([]uint64, len(last.Cpu.Usage.PerCpu))
+	for i := range percpu {
+		var err error
+		percpu[i], err = convertToRate(last.Cpu.Usage.PerCpu[i], cur.Cpu.Usage.PerCpu[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	user, err := convertToRate(last.Cpu.Usage.User, cur.Cpu.Usage.User)
+	if err != nil {
+		return nil, err
+	}
+	system, err := convertToRate(last.Cpu.Usage.System, cur.Cpu.Usage.System)
+	if err != nil {
+		return nil, err
+	}
+	return &v2.CpuInstStats{
+		Usage: v2.CpuInstUsage{
+			Total:  total,
+			PerCpu: percpu,
+			User:   user,
+			System: system,
+		},
+	}, nil
+}
+
 func convertStats(cont *info.ContainerInfo) []v2.ContainerStats {
-	stats := []v2.ContainerStats{}
+	stats := make([]v2.ContainerStats, 0, len(cont.Stats))
+	var last *info.ContainerStats
 	for _, val := range cont.Stats {
 		stat := v2.ContainerStats{
 			Timestamp:        val.Timestamp,
@@ -463,6 +519,13 @@ func convertStats(cont *info.ContainerInfo) []v2.ContainerStats {
 		}
 		if stat.HasCpu {
 			stat.Cpu = val.Cpu
+			cpuInst, err := instCpuStats(last, val)
+			if err != nil {
+				glog.Warningf("Could not get instant cpu stats: %v", err)
+			} else {
+				stat.CpuInst = cpuInst
+			}
+			last = val
 		}
 		if stat.HasMemory {
 			stat.Memory = val.Memory

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -86,8 +86,11 @@ type ContainerStats struct {
 	// The time of this stat point.
 	Timestamp time.Time `json:"timestamp"`
 	// CPU statistics
-	HasCpu bool        `json:"has_cpu"`
-	Cpu    v1.CpuStats `json:"cpu,omitempty"`
+	HasCpu bool `json:"has_cpu"`
+	// In nanoseconds (aggregated)
+	Cpu v1.CpuStats `json:"cpu,omitempty"`
+	// In nanocores per second (instantaneous)
+	CpuInst *CpuInstStats `json:"cpu_inst,omitempty"`
 	// Disk IO statistics
 	HasDiskIo bool           `json:"has_diskio"`
 	DiskIo    v1.DiskIoStats `json:"diskio,omitempty"`
@@ -203,4 +206,28 @@ type ProcessInfo struct {
 type NetworkStats struct {
 	// Network stats by interface.
 	Interfaces []v1.InterfaceStats `json:"interfaces,omitempty"`
+}
+
+// Instantaneous CPU stats
+type CpuInstStats struct {
+	Usage CpuInstUsage `json:"usage"`
+}
+
+// CPU usage time statistics.
+type CpuInstUsage struct {
+	// Total CPU usage.
+	// Units: nanocores per second
+	Total uint64 `json:"total"`
+
+	// Per CPU/core usage of the container.
+	// Unit: nanocores per second
+	PerCpu []uint64 `json:"per_cpu_usage,omitempty"`
+
+	// Time spent in user space.
+	// Unit: nanocores per second
+	User uint64 `json:"user"`
+
+	// Time spent in kernel space.
+	// Unit: nanocores per second
+	System uint64 `json:"system"`
 }


### PR DESCRIPTION
They will be useful in kubelet, since we want to expose instantaneous data in cores instead of accumulated data in seconds.

CC @vishh @vmarmol @rjnagal 