### PR TITLE
Add empty healthz test_utils to fix go build ./...

### DIFF
--- a/integration/tests/healthz/test_utils.go
+++ b/integration/tests/healthz/test_utils.go
@@ -1,0 +1,15 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthz


### PR DESCRIPTION
Without any .go file that doesn't end in _test, it fails:

no buildable Go source files in [...]/integration/tests/healthz

An empty source file works around this.