### PR TITLE
Add image name to container spec & prometheus metrics

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -74,6 +74,9 @@ type dockerContainerHandler struct {
 
 	// The container PID used to switch namespaces as required
 	pid int
+
+	// Image name used for this container.
+	image string
 }
 
 func newDockerContainerHandler(
@@ -123,6 +126,7 @@ func newDockerContainerHandler(
 	handler.aliases = append(handler.aliases, strings.TrimPrefix(ctnr.Name, "/"))
 	handler.aliases = append(handler.aliases, id)
 	handler.labels = ctnr.Config.Labels
+	handler.image = ctnr.Config.Image
 
 	return handler, nil
 }
@@ -211,6 +215,7 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 		spec.HasFilesystem = true
 	}
 	spec.Labels = self.labels
+	spec.Image = self.image
 
 	return spec, err
 }

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -61,6 +61,9 @@ type ContainerSpec struct {
 
 	HasCustomMetrics bool         `json:"has_custom_metrics"`
 	CustomMetrics    []MetricSpec `json:"custom_metrics,omitempty"`
+
+	// Image name used for this container.
+	Image string `json:"image,omitempty"`
 }
 
 // Container reference contains enough information to uniquely identify a container

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -80,6 +80,9 @@ type ContainerSpec struct {
 	HasNetwork    bool `json:"has_network"`
 	HasFilesystem bool `json:"has_filesystem"`
 	HasDiskIo     bool `json:"has_diskio"`
+
+	// Image name used for this container.
+	Image string `json:"image,omitempty"`
 }
 
 type ContainerStats struct {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -380,6 +380,7 @@ func (self *manager) getV2Spec(cinfo *containerInfo) v2.ContainerSpec {
 		HasNetwork:       specV1.HasNetwork,
 		HasDiskIo:        specV1.HasDiskIo,
 		HasCustomMetrics: specV1.HasCustomMetrics,
+		Image:            specV1.Image,
 	}
 	if specV1.HasCpu {
 		specV2.Cpu.Limit = specV1.Cpu.Limit

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -61,7 +61,7 @@ type containerMetric struct {
 }
 
 func (cm *containerMetric) desc() *prometheus.Desc {
-	return prometheus.NewDesc(cm.name, cm.help, append([]string{"name", "id"}, cm.extraLabels...), nil)
+	return prometheus.NewDesc(cm.name, cm.help, append([]string{"name", "id", "image"}, cm.extraLabels...), nil)
 }
 
 // PrometheusCollector implements prometheus.Collector.
@@ -401,12 +401,13 @@ func (c *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
 		if len(container.Aliases) > 0 {
 			name = container.Aliases[0]
 		}
+		image := container.Spec.Image
 		stats := container.Stats[0]
 
 		for _, cm := range c.containerMetrics {
 			desc := cm.desc()
 			for _, metricValue := range cm.getValues(stats) {
-				ch <- prometheus.MustNewConstMetric(desc, cm.valueType, float64(metricValue.value), append([]string{name, id}, metricValue.labels...)...)
+				ch <- prometheus.MustNewConstMetric(desc, cm.valueType, float64(metricValue.value), append([]string{name, id, image}, metricValue.labels...)...)
 			}
 		}
 	}

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -34,6 +34,9 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 			ContainerReference: info.ContainerReference{
 				Name: "testcontainer",
 			},
+			Spec: info.ContainerSpec{
+				Image: "test",
+			},
 			Stats: []*info.ContainerStats{
 				{
 					Cpu: info.CpuStats{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -1,116 +1,116 @@
 # HELP container_cpu_system_seconds_total Cumulative system cpu time consumed in seconds.
 # TYPE container_cpu_system_seconds_total counter
-container_cpu_system_seconds_total{id="testcontainer",name="testcontainer"} 7e-09
+container_cpu_system_seconds_total{id="testcontainer",image="test",name="testcontainer"} 7e-09
 # HELP container_cpu_usage_seconds_total Cumulative cpu time consumed per cpu in seconds.
 # TYPE container_cpu_usage_seconds_total counter
-container_cpu_usage_seconds_total{cpu="cpu00",id="testcontainer",name="testcontainer"} 2e-09
-container_cpu_usage_seconds_total{cpu="cpu01",id="testcontainer",name="testcontainer"} 3e-09
-container_cpu_usage_seconds_total{cpu="cpu02",id="testcontainer",name="testcontainer"} 4e-09
-container_cpu_usage_seconds_total{cpu="cpu03",id="testcontainer",name="testcontainer"} 5e-09
+container_cpu_usage_seconds_total{cpu="cpu00",id="testcontainer",image="test",name="testcontainer"} 2e-09
+container_cpu_usage_seconds_total{cpu="cpu01",id="testcontainer",image="test",name="testcontainer"} 3e-09
+container_cpu_usage_seconds_total{cpu="cpu02",id="testcontainer",image="test",name="testcontainer"} 4e-09
+container_cpu_usage_seconds_total{cpu="cpu03",id="testcontainer",image="test",name="testcontainer"} 5e-09
 # HELP container_cpu_user_seconds_total Cumulative user cpu time consumed in seconds.
 # TYPE container_cpu_user_seconds_total counter
-container_cpu_user_seconds_total{id="testcontainer",name="testcontainer"} 6e-09
+container_cpu_user_seconds_total{id="testcontainer",image="test",name="testcontainer"} 6e-09
 # HELP container_fs_io_current Number of I/Os currently in progress
 # TYPE container_fs_io_current gauge
-container_fs_io_current{device="sda1",id="testcontainer",name="testcontainer"} 42
-container_fs_io_current{device="sda2",id="testcontainer",name="testcontainer"} 47
+container_fs_io_current{device="sda1",id="testcontainer",image="test",name="testcontainer"} 42
+container_fs_io_current{device="sda2",id="testcontainer",image="test",name="testcontainer"} 47
 # HELP container_fs_io_time_seconds_total Cumulative count of seconds spent doing I/Os
 # TYPE container_fs_io_time_seconds_total counter
-container_fs_io_time_seconds_total{device="sda1",id="testcontainer",name="testcontainer"} 4.3e-08
-container_fs_io_time_seconds_total{device="sda2",id="testcontainer",name="testcontainer"} 4.8e-08
+container_fs_io_time_seconds_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 4.3e-08
+container_fs_io_time_seconds_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 4.8e-08
 # HELP container_fs_io_time_weighted_seconds_total Cumulative weighted I/O time in seconds
 # TYPE container_fs_io_time_weighted_seconds_total counter
-container_fs_io_time_weighted_seconds_total{device="sda1",id="testcontainer",name="testcontainer"} 4.4e-08
-container_fs_io_time_weighted_seconds_total{device="sda2",id="testcontainer",name="testcontainer"} 4.9e-08
+container_fs_io_time_weighted_seconds_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 4.4e-08
+container_fs_io_time_weighted_seconds_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 4.9e-08
 # HELP container_fs_limit_bytes Number of bytes that can be consumed by the container on this filesystem.
 # TYPE container_fs_limit_bytes gauge
-container_fs_limit_bytes{device="sda1",id="testcontainer",name="testcontainer"} 22
-container_fs_limit_bytes{device="sda2",id="testcontainer",name="testcontainer"} 37
+container_fs_limit_bytes{device="sda1",id="testcontainer",image="test",name="testcontainer"} 22
+container_fs_limit_bytes{device="sda2",id="testcontainer",image="test",name="testcontainer"} 37
 # HELP container_fs_read_seconds_total Cumulative count of seconds spent reading
 # TYPE container_fs_read_seconds_total counter
-container_fs_read_seconds_total{device="sda1",id="testcontainer",name="testcontainer"} 2.7e-08
-container_fs_read_seconds_total{device="sda2",id="testcontainer",name="testcontainer"} 4.2e-08
+container_fs_read_seconds_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 2.7e-08
+container_fs_read_seconds_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 4.2e-08
 # HELP container_fs_reads_merged_total Cumulative count of reads merged
 # TYPE container_fs_reads_merged_total counter
-container_fs_reads_merged_total{device="sda1",id="testcontainer",name="testcontainer"} 25
-container_fs_reads_merged_total{device="sda2",id="testcontainer",name="testcontainer"} 40
+container_fs_reads_merged_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 25
+container_fs_reads_merged_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 40
 # HELP container_fs_reads_total Cumulative count of reads completed
 # TYPE container_fs_reads_total counter
-container_fs_reads_total{device="sda1",id="testcontainer",name="testcontainer"} 24
-container_fs_reads_total{device="sda2",id="testcontainer",name="testcontainer"} 39
+container_fs_reads_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 24
+container_fs_reads_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 39
 # HELP container_fs_sector_reads_total Cumulative count of sector reads completed
 # TYPE container_fs_sector_reads_total counter
-container_fs_sector_reads_total{device="sda1",id="testcontainer",name="testcontainer"} 26
-container_fs_sector_reads_total{device="sda2",id="testcontainer",name="testcontainer"} 41
+container_fs_sector_reads_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 26
+container_fs_sector_reads_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 41
 # HELP container_fs_sector_writes_total Cumulative count of sector writes completed
 # TYPE container_fs_sector_writes_total counter
-container_fs_sector_writes_total{device="sda1",id="testcontainer",name="testcontainer"} 40
-container_fs_sector_writes_total{device="sda2",id="testcontainer",name="testcontainer"} 45
+container_fs_sector_writes_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 40
+container_fs_sector_writes_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 45
 # HELP container_fs_usage_bytes Number of bytes that are consumed by the container on this filesystem.
 # TYPE container_fs_usage_bytes gauge
-container_fs_usage_bytes{device="sda1",id="testcontainer",name="testcontainer"} 23
-container_fs_usage_bytes{device="sda2",id="testcontainer",name="testcontainer"} 38
+container_fs_usage_bytes{device="sda1",id="testcontainer",image="test",name="testcontainer"} 23
+container_fs_usage_bytes{device="sda2",id="testcontainer",image="test",name="testcontainer"} 38
 # HELP container_fs_write_seconds_total Cumulative count of seconds spent writing
 # TYPE container_fs_write_seconds_total counter
-container_fs_write_seconds_total{device="sda1",id="testcontainer",name="testcontainer"} 4.1e-08
-container_fs_write_seconds_total{device="sda2",id="testcontainer",name="testcontainer"} 4.6e-08
+container_fs_write_seconds_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 4.1e-08
+container_fs_write_seconds_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 4.6e-08
 # HELP container_fs_writes_merged_total Cumulative count of writes merged
 # TYPE container_fs_writes_merged_total counter
-container_fs_writes_merged_total{device="sda1",id="testcontainer",name="testcontainer"} 39
-container_fs_writes_merged_total{device="sda2",id="testcontainer",name="testcontainer"} 44
+container_fs_writes_merged_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 39
+container_fs_writes_merged_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 44
 # HELP container_fs_writes_total Cumulative count of writes completed
 # TYPE container_fs_writes_total counter
-container_fs_writes_total{device="sda1",id="testcontainer",name="testcontainer"} 28
-container_fs_writes_total{device="sda2",id="testcontainer",name="testcontainer"} 43
+container_fs_writes_total{device="sda1",id="testcontainer",image="test",name="testcontainer"} 28
+container_fs_writes_total{device="sda2",id="testcontainer",image="test",name="testcontainer"} 43
 # HELP container_last_seen Last time a container was seen by the exporter
 # TYPE container_last_seen gauge
-container_last_seen{id="testcontainer",name="testcontainer"} 1.426203694e+09
+container_last_seen{id="testcontainer",image="test",name="testcontainer"} 1.426203694e+09
 # HELP container_memory_failures_total Cumulative count of memory allocation failures.
 # TYPE container_memory_failures_total counter
-container_memory_failures_total{id="testcontainer",name="testcontainer",scope="container",type="pgfault"} 10
-container_memory_failures_total{id="testcontainer",name="testcontainer",scope="container",type="pgmajfault"} 11
-container_memory_failures_total{id="testcontainer",name="testcontainer",scope="hierarchy",type="pgfault"} 12
-container_memory_failures_total{id="testcontainer",name="testcontainer",scope="hierarchy",type="pgmajfault"} 13
+container_memory_failures_total{id="testcontainer",image="test",name="testcontainer",scope="container",type="pgfault"} 10
+container_memory_failures_total{id="testcontainer",image="test",name="testcontainer",scope="container",type="pgmajfault"} 11
+container_memory_failures_total{id="testcontainer",image="test",name="testcontainer",scope="hierarchy",type="pgfault"} 12
+container_memory_failures_total{id="testcontainer",image="test",name="testcontainer",scope="hierarchy",type="pgmajfault"} 13
 # HELP container_memory_usage_bytes Current memory usage in bytes.
 # TYPE container_memory_usage_bytes gauge
-container_memory_usage_bytes{id="testcontainer",name="testcontainer"} 8
+container_memory_usage_bytes{id="testcontainer",image="test",name="testcontainer"} 8
 # HELP container_memory_working_set_bytes Current working set in bytes.
 # TYPE container_memory_working_set_bytes gauge
-container_memory_working_set_bytes{id="testcontainer",name="testcontainer"} 9
+container_memory_working_set_bytes{id="testcontainer",image="test",name="testcontainer"} 9
 # HELP container_network_receive_bytes_total Cumulative count of bytes received
 # TYPE container_network_receive_bytes_total counter
-container_network_receive_bytes_total{id="testcontainer",name="testcontainer"} 14
+container_network_receive_bytes_total{id="testcontainer",image="test",name="testcontainer"} 14
 # HELP container_network_receive_errors_total Cumulative count of errors encountered while receiving
 # TYPE container_network_receive_errors_total counter
-container_network_receive_errors_total{id="testcontainer",name="testcontainer"} 16
+container_network_receive_errors_total{id="testcontainer",image="test",name="testcontainer"} 16
 # HELP container_network_receive_packets_dropped_total Cumulative count of packets dropped while receiving
 # TYPE container_network_receive_packets_dropped_total counter
-container_network_receive_packets_dropped_total{id="testcontainer",name="testcontainer"} 17
+container_network_receive_packets_dropped_total{id="testcontainer",image="test",name="testcontainer"} 17
 # HELP container_network_receive_packets_total Cumulative count of packets received
 # TYPE container_network_receive_packets_total counter
-container_network_receive_packets_total{id="testcontainer",name="testcontainer"} 15
+container_network_receive_packets_total{id="testcontainer",image="test",name="testcontainer"} 15
 # HELP container_network_transmit_bytes_total Cumulative count of bytes transmitted
 # TYPE container_network_transmit_bytes_total counter
-container_network_transmit_bytes_total{id="testcontainer",name="testcontainer"} 18
+container_network_transmit_bytes_total{id="testcontainer",image="test",name="testcontainer"} 18
 # HELP container_network_transmit_errors_total Cumulative count of errors encountered while transmitting
 # TYPE container_network_transmit_errors_total counter
-container_network_transmit_errors_total{id="testcontainer",name="testcontainer"} 20
+container_network_transmit_errors_total{id="testcontainer",image="test",name="testcontainer"} 20
 # HELP container_network_transmit_packets_dropped_total Cumulative count of packets dropped while transmitting
 # TYPE container_network_transmit_packets_dropped_total counter
-container_network_transmit_packets_dropped_total{id="testcontainer",name="testcontainer"} 21
+container_network_transmit_packets_dropped_total{id="testcontainer",image="test",name="testcontainer"} 21
 # HELP container_network_transmit_packets_total Cumulative count of packets transmitted
 # TYPE container_network_transmit_packets_total counter
-container_network_transmit_packets_total{id="testcontainer",name="testcontainer"} 19
+container_network_transmit_packets_total{id="testcontainer",image="test",name="testcontainer"} 19
 # HELP container_scrape_error 1 if there was an error while getting container metrics, 0 otherwise
 # TYPE container_scrape_error gauge
 container_scrape_error 0
 # HELP container_tasks_state Number of tasks in given state
 # TYPE container_tasks_state gauge
-container_tasks_state{id="testcontainer",name="testcontainer",state="iowaiting"} 54
-container_tasks_state{id="testcontainer",name="testcontainer",state="running"} 51
-container_tasks_state{id="testcontainer",name="testcontainer",state="sleeping"} 50
-container_tasks_state{id="testcontainer",name="testcontainer",state="stopped"} 52
-container_tasks_state{id="testcontainer",name="testcontainer",state="uninterruptible"} 53
+container_tasks_state{id="testcontainer",image="test",name="testcontainer",state="iowaiting"} 54
+container_tasks_state{id="testcontainer",image="test",name="testcontainer",state="running"} 51
+container_tasks_state{id="testcontainer",image="test",name="testcontainer",state="sleeping"} 50
+container_tasks_state{id="testcontainer",image="test",name="testcontainer",state="stopped"} 52
+container_tasks_state{id="testcontainer",image="test",name="testcontainer",state="uninterruptible"} 53
 # HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
 # TYPE http_request_duration_microseconds summary
 http_request_duration_microseconds{handler="prometheus",quantile="0.5"} 0


### PR DESCRIPTION
Fixes #848 

As discussed in https://github.com/google/cadvisor/pull/780#issuecomment-134657301, this just exports the image name as this has most immediate value. We can discuss docker labels separately perhaps?