### PR TITLE
Add flag -k to journalctl show only kernel messages

### DIFF
--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -164,7 +164,7 @@ func (self *OomParser) StreamOoms(outStream chan *OomInstance) {
 }
 
 func callJournalctl() (io.ReadCloser, error) {
-	cmd := exec.Command("journalctl", "-f")
+	cmd := exec.Command("journalctl", "-k", "-f")
 	readcloser, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi guys,

I have a problem when my application sends many logs for journald, the command "journalctl -f" generates a high consumption of CPU. In some cases killing the journald.

I added the flag -k in journalctl to show only the kernel logs.

Do you see any problem in this change?

Thanks