### PR TITLE
Make getCgroupPath work in case of named or multi- hierarchies

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -42,7 +42,7 @@ import (
 // Housekeeping interval.
 var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
 
-var cgroupPathRegExp = regexp.MustCompile(".*devices:(.*?)[,;$].*")
+var cgroupPathRegExp = regexp.MustCompile(".*devices.*:(.*?)[,;$].*")
 
 // Decay value used for load average smoothing. Interval length of 10 seconds is used.
 var loadDecay = math.Exp(float64(-1 * (*HousekeepingInterval).Seconds() / 10))


### PR DESCRIPTION
In case we have devices hierarchies mounted in named cgroup
or together with other hierarchy regexp parse will fail.
So after "devices" and before ":" can be name of cgroup or
other hierarchies names.

E.g.:
1) remount cgroups:
umount /sys/fs/cgroup/devices
mkdir /sys/fs/cgroup/named_cgroup
mount -n -t cgroup -o devices,name=named_cgroup cgroup
/sys/fs/cgroup/named_cgroup

2) add some task to nested device cgroup and check ps output
mkdir /sys/fs/cgroup/named_cgroup/test.slice
sleep 1000 &
[1] 22734
echo 22734 > /sys/fs/cgroup/named_cgroup/test.slice/tasks
ps -ao pid,cgroup | grep 22734
22734
14:devices,name=named_cgroup:/test.slice,1:name=systemd:/user.slice/user-1000.slice/session-1.scope

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>