### PR TITLE
Validate systemd cgroup name as docker id

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -136,10 +136,25 @@ func FullContainerName(dockerId string) string {
 	}
 }
 
+// Returns true if container name matches pattern
+func isContainerName(name string) bool {
+	id := path.Base(name)
+	if UseSystemd() {
+		return strings.HasPrefix(id, "docker-") && strings.HasSuffix(id, ".scope")
+	} else {
+		return true
+	}
+}
+
 // Docker handles all containers under /docker
 func (self *dockerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	// docker factory accepts all containers it can handle.
 	canAccept := true
+	// Validate systemd cgroup name as Docker ID
+	if !isContainerName(name) {
+		return false, canAccept, fmt.Errorf("failed to match container name")
+	}
+
 	// Check if the container is known to docker and it is active.
 	id := ContainerNameToDockerId(name)
 


### PR DESCRIPTION
cAdvisor (0.16.0.2) when started with default runtime options on system with systemd service manager calls Docker API for systemd service files.

```
Sep 18 20:06:12 docker: time="2015-09-18T20:06:12.299962820-07:00" level=info msg="GET /containers/rsyslog.service/json"
Sep 18 20:06:12 docker: time="2015-09-18T20:06:12.300056485-07:00" level=error msg="Handler for GET /containers/{name:.*}/json returned error: no such id: rsyslog.service"
Sep 18 20:06:12 docker: time="2015-09-18T20:06:12.300074752-07:00" level=error msg="HTTP Error" err="no such id: rsyslog.service" statusCode=404
```

The purpose of this PR is to remove unnecessary docker API calls by validating container names against currently defined container name patterns, `docker-` prefix and `.scope` suffix. 