### PR TITLE
Make release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 0.17.0 (2015-09-23)
+### 0.18.0 (2015-09-23)
 - Large bunch of bug-fixes
 - Fixed networking stats for newer docker versions using libnetwork.
 - Added application-specific metrics

--- a/version/version.go
+++ b/version/version.go
@@ -15,4 +15,4 @@
 package version
 
 // Version of cAdvisor.
-const VERSION = "0.17.0"
+const VERSION = "0.18.0"


### PR DESCRIPTION
Didn't notice that we already had a tag for 0.17.0 from last week.
Let's skip that and move to 0.18.