### PR TITLE
Systemd docker container improvements, including customized cgroup parent

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -44,7 +44,7 @@ var dockerRunDir = flag.String("docker_run", "/var/run/docker", "Absolute path t
 
 // Regexp that identifies docker cgroups, containers started with
 // --cgroup-parent have another prefix than 'docker'
-var dockerCgroupRegexp = regexp.MustCompile(`[A-z]+-([a-z0-9]+)\.scope`)
+var dockerCgroupRegexp = regexp.MustCompile(`(.+)-([a-z0-9]{64})\.scope$`)
 
 // TODO(vmarmol): Export run dir too for newer Dockers.
 // Directory holding Docker container state information.
@@ -118,24 +118,24 @@ func (self *dockerFactory) NewContainerHandler(name string, inHostNamespace bool
 }
 
 // Returns the Docker ID from the full container name.
-func ContainerNameToDockerId(name string) string {
+func ContainerNameToDockerId(name string) (string, string) {
 	id := path.Base(name)
 
 	// Turn systemd cgroup name into Docker ID.
 	if UseSystemd() {
 		if matches := dockerCgroupRegexp.FindStringSubmatch(id); matches != nil {
-			id = matches[1]
+			return matches[2], matches[1]
 		}
 	}
 
-	return id
+	return id, ""
 }
 
 // Returns a full container name for the specified Docker ID.
-func FullContainerName(dockerId string) string {
+func FullContainerName(dockerId string, cgroupParent string) string {
 	// Add the full container name.
 	if UseSystemd() {
-		return path.Join("/system.slice", fmt.Sprintf("docker-%s.scope", dockerId))
+		return path.Join("/system.slice", fmt.Sprintf("%s-%s.scope", cgroupParent, dockerId))
 	} else {
 		return path.Join("/docker", dockerId)
 	}
@@ -147,12 +147,12 @@ func (self *dockerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	canAccept := true
 
 	// When using Systemd all docker containers have a .scope suffix
-	if UseSystemd() && !strings.HasSuffix(path.Base(name), ".scope") {
+	if UseSystemd() && !dockerCgroupRegexp.MatchString(path.Base(name)) {
 		return false, canAccept, nil
 	}
 
 	// Check if the container is known to docker and it is active.
-	id := ContainerNameToDockerId(name)
+	id, _ := ContainerNameToDockerId(name)
 
 	// We assume that if Inspect fails then the container is not known to docker.
 	ctnr, err := self.client.InspectContainer(id)

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -42,6 +42,7 @@ type dockerContainerHandler struct {
 	client             *docker.Client
 	name               string
 	id                 string
+	cgroupParent       string
 	aliases            []string
 	machineInfoFactory info.MachineInfoFactory
 
@@ -113,11 +114,12 @@ func newDockerContainerHandler(
 		rootFs = "/rootfs"
 	}
 
-	id := ContainerNameToDockerId(name)
+	id, cgroupParent := ContainerNameToDockerId(name)
 	handler := &dockerContainerHandler{
 		id:                 id,
 		client:             client,
 		name:               name,
+		cgroupParent:       cgroupParent,
 		machineInfoFactory: machineInfoFactory,
 		cgroupPaths:        cgroupPaths,
 		cgroupManager:      cgroupManager,
@@ -312,7 +314,7 @@ func (self *dockerContainerHandler) ListContainers(listType container.ListType) 
 		}
 
 		ref := info.ContainerReference{
-			Name:      FullContainerName(c.ID),
+			Name:      FullContainerName(c.ID, self.cgroupParent),
 			Aliases:   append(c.Names, c.ID),
 			Namespace: DockerNamespace,
 		}

--- a/pages/docker.go
+++ b/pages/docker.go
@@ -68,9 +68,10 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) error
 		}
 		subcontainers := make([]link, 0, len(conts))
 		for _, cont := range conts {
+			id, _ := docker.ContainerNameToDockerId(cont.ContainerReference.Name)
 			subcontainers = append(subcontainers, link{
 				Text: getContainerDisplayName(cont.ContainerReference),
-				Link: path.Join(rootDir, DockerPage, docker.ContainerNameToDockerId(cont.ContainerReference.Name)),
+				Link: path.Join(rootDir, DockerPage, id),
 			})
 		}
 
@@ -118,9 +119,10 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) error
 			Text: "Docker Containers",
 			Link: path.Join(rootDir, DockerPage),
 		})
+		id, _ := docker.ContainerNameToDockerId(cont.ContainerReference.Name)
 		parentContainers = append(parentContainers, link{
 			Text: displayName,
-			Link: path.Join(rootDir, DockerPage, docker.ContainerNameToDockerId(cont.Name)),
+			Link: path.Join(rootDir, DockerPage, id),
 		})
 
 		// Get the MachineInfo


### PR DESCRIPTION
Includes commit from #821 & extends to include cgroup parent in full container name. #821 can be closed in preference to this.

/cc @basvdlei @whosthatknocking