### PR TITLE
Registration of custom function to map container name to prometheus labels

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -78,10 +78,12 @@ func main() {
 	mux := http.DefaultServeMux
 
 	// Register all HTTP handlers.
-	err = cadvisorHttp.RegisterHandlers(mux, containerManager, *httpAuthFile, *httpAuthRealm, *httpDigestFile, *httpDigestRealm, *prometheusEndpoint)
+	err = cadvisorHttp.RegisterHandlers(mux, containerManager, *httpAuthFile, *httpAuthRealm, *httpDigestFile, *httpDigestRealm)
 	if err != nil {
 		glog.Fatalf("Failed to register HTTP handlers: %v", err)
 	}
+
+	cadvisorHttp.RegisterPrometheusHandler(mux, containerManager, *prometheusEndpoint, nil)
 
 	// Start the manager.
 	if err := containerManager.Start(); err != nil {

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -31,7 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func RegisterHandlers(mux httpMux.Mux, containerManager manager.Manager, httpAuthFile, httpAuthRealm, httpDigestFile, httpDigestRealm, prometheusEndpoint string) error {
+func RegisterHandlers(mux httpMux.Mux, containerManager manager.Manager, httpAuthFile, httpAuthRealm, httpDigestFile, httpDigestRealm string) error {
 	// Basic health handler.
 	if err := healthz.RegisterHandler(mux); err != nil {
 		return fmt.Errorf("failed to register healthz handler: %s", err)
@@ -85,11 +85,13 @@ func RegisterHandlers(mux httpMux.Mux, containerManager manager.Manager, httpAut
 		}
 	}
 
-	collector := metrics.NewPrometheusCollector(containerManager)
-	prometheus.MustRegister(collector)
-	http.Handle(prometheusEndpoint, prometheus.Handler())
-
 	return nil
+}
+
+func RegisterPrometheusHandler(mux httpMux.Mux, containerManager manager.Manager, prometheusEndpoint string, containerNameToLabelsFunc metrics.ContainerNameToLabelsFunc) {
+	collector := metrics.NewPrometheusCollector(containerManager, containerNameToLabelsFunc)
+	prometheus.MustRegister(collector)
+	mux.Handle(prometheusEndpoint, prometheus.Handler())
 }
 
 func staticHandlerNoAuth(w http.ResponseWriter, r *http.Request) {

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -152,7 +152,7 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 }
 
 func TestPrometheusCollector(t *testing.T) {
-	prometheus.MustRegister(NewPrometheusCollector(testSubcontainersInfoProvider{}))
+	prometheus.MustRegister(NewPrometheusCollector(testSubcontainersInfoProvider{}, nil))
 
 	rw := httptest.NewRecorder()
 	prometheus.Handler().ServeHTTP(rw, &http.Request{})


### PR DESCRIPTION
This helps with the prometheus metrics in Kubernetes where the container name has info on namespace, pod name & container name. Disabled by default, but useful when embedded inside another app, like the kubelet.

/cc @vishh 