### PR TITLE
Control cpu usage when getting disk usage.

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -15,7 +15,11 @@
 package fs
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDiskStatsMap(t *testing.T) {
@@ -75,4 +79,24 @@ func TestFileNotExist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getDiskStatsMap must not error for absent file: %s", err)
 	}
+}
+
+func TestDirUsage(t *testing.T) {
+	as := assert.New(t)
+	fsInfo, err := NewFsInfo()
+	as.NoError(err)
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	as.NoError(err)
+	defer os.RemoveAll(dir)
+	dataSize := 1024 * 100 //100 KB
+	b := make([]byte, dataSize)
+	f, err := ioutil.TempFile(dir, "")
+	as.NoError(err)
+	as.NoError(ioutil.WriteFile(f.Name(), b, 0700))
+	fi, err := f.Stat()
+	as.NoError(err)
+	expectedSize := uint64(fi.Size())
+	size, err := fsInfo.GetDirUsage(dir)
+	as.NoError(err)
+	as.True(expectedSize <= size)
 }

--- a/fs/types.go
+++ b/fs/types.go
@@ -63,4 +63,7 @@ type FsInfo interface {
 
 	// Returns the mountpoint associated with a particular device.
 	GetMountpointForDevice(device string) (string, error)
+
+	// Computes and adds labels for devices.
+	AddLabels(context Context)
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -126,8 +126,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 	}
 	glog.Infof("cAdvisor running in container: %q", selfContainer)
 
-	context := fs.Context{DockerRoot: docker.RootDir()}
-	fsInfo, err := fs.NewFsInfo(context)
+	fsInfo, err := fs.NewFsInfo()
 	if err != nil {
 		return nil, err
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -19,7 +19,6 @@ package validate
 
 import (
 	"fmt"
-	"github.com/google/cadvisor/manager"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -29,6 +28,8 @@ import (
 	"github.com/docker/libcontainer/cgroups"
 	dclient "github.com/fsouza/go-dockerclient"
 	"github.com/google/cadvisor/container/docker"
+	"github.com/google/cadvisor/container/libcontainer"
+	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/utils"
 )
 
@@ -198,7 +199,8 @@ func validateDockerInfo() (string, string) {
 				desc += "\tCgroups are being created through cgroup filesystem.\n"
 			}
 			if strings.Contains(execDriver, "native") {
-				stateFile := docker.DockerStateDir()
+				rootDir := info.Get("DockerRootDir")
+				stateFile := libcontainer.DockerStateDir(rootDir)
 				if !utils.FileExists(stateFile) {
 					desc += fmt.Sprintf("\tDocker container state directory %q is not accessible.\n", stateFile)
 					return Unsupported, desc


### PR DESCRIPTION
1. Run `du` less often
2. Set `ulimit -t` just in case.

While I was at it, I also refactor docker storage path handling a bit. A lot of cleanup is still pending :(

I intend to add support for `overlay` and `device mapper` storage drivers in a subsequent PR.

Fixes #898 (I guess)

cc @yujuhong 