### PR TITLE
there shows empty data for network metrics in k8s cluster, the root cause is that ,the network type blocks the metrics data

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"strings"
 	"time"
-
+	"regexp"
 	"github.com/docker/libcontainer/cgroups"
 	cgroup_fs "github.com/docker/libcontainer/cgroups/fs"
 	libcontainerConfigs "github.com/docker/libcontainer/configs"
@@ -213,6 +213,10 @@ var (
 )
 
 func hasNet(networkMode string) bool {
+	matched, _ := regexp.MatchString("container:*", networkMode)
+	if matched == true {
+		return true
+	}	
 	return hasNetworkModes[networkMode]
 }
 


### PR DESCRIPTION
if the network mode is --net=container:name, cadvisor will consider it  not having network, then in the case of k8s, network metrics from pod containers will be lost.