### PR TITLE
Revert canary Dockerfile change to install thin-provisioning-tools

### DIFF
--- a/deploy/canary/Dockerfile
+++ b/deploy/canary/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:latest
 MAINTAINER vmarmol@google.com
 
-RUN apt-get install -y git thin-provisioning-tools
+RUN apt-get install -y git
 RUN git clone https://github.com/google/cadvisor.git /go/src/github.com/google/cadvisor
 RUN go get github.com/tools/godep
 RUN cd /go/src/github.com/google/cadvisor && godep go build .


### PR DESCRIPTION
Revert canary Dockerfile change to install thin-provisioning-tools.  Close #948