### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ See the more detailed instructions in the [build page](docs/build.md). This incl
 
 ## InfluxDB and Cluster Monitoring
 
-cAdvisor supports exporting stats to [InfluxDB](http://influxdb.com). See the [documentation](docs/influxdb.md) for more information and examples.
+cAdvisor supports exporting stats to [InfluxDB](https://influxdb.com/). See the [documentation](docs/influxdb.md) for more information and examples.
 
 cAdvisor also exposes container stats as [Prometheus](http://prometheus.io) metrics. See the [documentation](docs/prometheus.md) for more information.
 
-[Heapster](https://github.com/GoogleCloudPlatform/heapster) enables cluster wide monitoring of containers using cAdvisor.
+[Heapster](https://github.com/kubernetes/heapster) enables cluster wide monitoring of containers using cAdvisor.
 
 ## Web UI
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/GoogleCloudPlatform/heapster | https://github.com/kubernetes/heapster 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://influxdb.com | https://influxdb.com/ 
