### PR TITLE
Fix machine ID file path when running in container

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -155,7 +155,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 		allowDynamicHousekeeping: allowDynamicHousekeeping,
 	}
 
-	machineInfo, err := getMachineInfo(sysfs, fsInfo)
+	machineInfo, err := getMachineInfo(sysfs, fsInfo, inHostNamespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #955 

This is a quick fix, we need to do a full clean-up sometime of filepaths when running in a container rather than passing `inHostNamespace` everywhere, but this is good enough for now IMO.