### PR TITLE
comment fix for function ContainerInfoRequest

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -87,7 +87,7 @@ func (self ContainerReferenceSlice) Len() int           { return len(self) }
 func (self ContainerReferenceSlice) Swap(i, j int)      { self[i], self[j] = self[j], self[i] }
 func (self ContainerReferenceSlice) Less(i, j int) bool { return self[i].Name < self[j].Name }
 
-// ContainerInfoQuery is used when users check a container info from the REST api.
+// ContainerInfoRequest is used when users check a container info from the REST API.
 // It specifies how much data users want to get about a container
 type ContainerInfoRequest struct {
 	// Max number of stats to return. Specify -1 for all stats currently available.


### PR DESCRIPTION
In commit https://github.com/google/cadvisor/commit/6818ac9b9f873fd037f7bcc75c6eada7d03c8406, the comment for function ContainerInfoRequest didn't change.