### PR TITLE
Fix case statements dealing with storageDriver

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -234,11 +234,11 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec := libcontainerConfigToContainerSpec(libcontainerConfig, mi)
 	spec.CreationTime = self.creationTime
 
-	spec.HasFilesystem = false
 	switch self.storageDriver {
-	case aufsStorageDriver:
-	case overlayStorageDriver:
+	case aufsStorageDriver, overlayStorageDriver:
 		spec.HasFilesystem = true
+	default:
+		spec.HasFilesystem = false
 	}
 
 	spec.Labels = self.labels
@@ -250,9 +250,7 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 
 func (self *dockerContainerHandler) getFsStats(stats *info.ContainerStats) error {
 	switch self.storageDriver {
-	case aufsStorageDriver:
-	case overlayStorageDriver:
-		break
+	case aufsStorageDriver, overlayStorageDriver:
 	default:
 		return nil
 	}


### PR DESCRIPTION
cf0adcc817e422e86966a24a1dc758369f3c076f introduced two switch
statements to facilitate the addition of the `overlayStorageDriver`;
unfortunately neither of them conform to the Go switch semantic, which
does not fallthrough unless explicitly requested. In one case this was
innocuous (because a `break` was effectively the same as a no-op) but in
the other it would cause the `HasFilesystem` bool to not be set
appropriately in the case of `aufsStorageDriver` being used.

IMHO it's also more idiomatic to perform the default behaviour in the
default case rather than pre-setting and overriding it.