### PR TITLE
make profiling tunable

### DIFF
--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -62,6 +62,7 @@ cAdvisor-native flags that help in debugging:
 ```
 --log_cadvisor_usage=false: Whether to log the usage of the cAdvisor container
 --version=false: print cAdvisor version and exit
+--profiling=false: Enable profiling via web interface host:port/debug/pprof/
 ```
 
 From [glog](https://github.com/golang/glog) here are some flags we find useful:


### PR DESCRIPTION
Make the `/debug/pprof` as developing level endpoints.

When the cAdvisor is used as a product, the users should not get the debug info, such as `profiler`.  So this patch adds a new tunable option `profiling`, by default, it will disable the profiling.