### PR TITLE
Fix cgroupPathRegExp to match path after the first colon after devices

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -43,7 +43,7 @@ import (
 // Housekeeping interval.
 var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
 
-var cgroupPathRegExp = regexp.MustCompile(`.*devices.*:(.*?)[,;$].*`)
+var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
 
 type containerInfo struct {
 	info.ContainerReference


### PR DESCRIPTION
If in getCgroupPath in cgroups we have some other hierarchies after
"devices" using ".*" will cause matching wrong string as a container path
so we need to prefer fewer matches here with ".*?".

e.g.
If cgroups is 14:devices,name=named_cgroup:/test.slice,1:name=systemd:/user.slice/user-1000.slice/session-1.scope
match[1] will be /user.slice/user-1000.slice/session-1.scope
but not /test.slice as intended.

These fixes the commit:
4cbd91c761 Make getCgroupPath work in case of named or multi- hierarchies