### PR TITLE
Support Loading Metrics Configs from Labels

### DIFF
--- a/collector/collector_manager.go
+++ b/collector/collector_manager.go
@@ -22,7 +22,10 @@ import (
 	"github.com/google/cadvisor/info/v1"
 )
 
-const metricLabelPrefix = "io.cadvisor.metric."
+const (
+	metricLabelPrefix   = "io.cadvisor.metric."
+	metricInLabelPrefix = "io.cadvisor.metric-config."
+)
 
 type GenericCollectorManager struct {
 	Collectors         []*collectorData
@@ -42,15 +45,23 @@ func NewCollectorManager() (CollectorManager, error) {
 	}, nil
 }
 
-func GetCollectorConfigs(labels map[string]string) map[string]string {
+func getConfigLabelsWithPrefix(prefix string, labels map[string]string) map[string]string {
 	configs := map[string]string{}
 	for k, v := range labels {
-		if strings.HasPrefix(k, metricLabelPrefix) {
-			name := strings.TrimPrefix(k, metricLabelPrefix)
+		if strings.HasPrefix(k, prefix) {
+			name := strings.TrimPrefix(k, prefix)
 			configs[name] = v
 		}
 	}
 	return configs
+}
+
+func GetCollectorConfigs(labels map[string]string) map[string]string {
+	return getConfigLabelsWithPrefix(metricLabelPrefix, labels)
+}
+
+func GetInLabelCollectorConfigs(labels map[string]string) map[string]string {
+	return getConfigLabelsWithPrefix(metricInLabelPrefix, labels)
 }
 
 func (cm *GenericCollectorManager) RegisterCollector(collector Collector) error {

--- a/docs/application_metrics.md
+++ b/docs/application_metrics.md
@@ -70,7 +70,7 @@ Another sample config that collects only selected metrics:
 
 ## Passing the configuration to cAdvisor
 
-cAdvisor can discover any configurations for a container using Docker container labels. Any label starting with ```io.cadvisor.metric``` is parsed as a cadvisor application-metric label.
+cAdvisor can discover any configurations for a container using Docker container labels. Any label starting with ```io.cadvisor.metric.``` is parsed as a cadvisor application-metric label.
 cAdvisor uses the value as an indicator of where the configuration can be found.  Labels of the form ```io.cadvisor.metric.prometheus-xyz``` indicate that the configuration points to a
 Prometheus metrics endpoint.
 
@@ -84,6 +84,8 @@ Dockerfile (or runtime):
  ADD ADD redis_config.json /var/cadvisor/redis_config.json
  LABEL io.cadvisor.metric.redis="/var/cadvisor/redis_config.json"
 ```
+
+It is also possible to store the configuration JSON itself directly in the label.  To do so, simply use a label with the prefix ```io.cadvisor.metric-config.```.
 
 cAdvisor will then reach into the container image at runtime, process the config, and start collecting and exposing application metrics.
 


### PR DESCRIPTION
Previously, the custom metrics configuration was loaded
from a file in the container, by specifiying a file path
as the value for a label of the form "io.cadvisor.metrics.xyz".

Now, you can also just specify the configuration JSON directly
in label, by using a label with the name
"io.cadvisor.metric-config.xyz".

Part of #1016