### PR TITLE
Only retry whitelisted test failure…

### DIFF
--- a/integration/runner/retrywhitelist.txt
+++ b/integration/runner/retrywhitelist.txt
@@ -1,0 +1,2 @@
+Network tx and rx bytes should not be equal
+Network tx and rx packets should not be equal

--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -121,7 +121,6 @@ func PushAndRunTests(host, testDir string) error {
 
 	// Run the tests in a retry loop.
 	glog.Infof("Running integration tests targeting %q...", host)
-
 	for i := 0; i <= *testRetryCount; i++ {
 		// Check if this is a retry
 		if i > 0 {
@@ -141,7 +140,6 @@ func PushAndRunTests(host, testDir string) error {
 			break
 		}
 	}
-
 	if err != nil {
 		err = fmt.Errorf("error on host %s: %v", host, err)
 	}

--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -205,8 +205,8 @@ func Run() error {
 	return nil
 }
 
-// initWhiltelist initializes the whitelist of test failures that can be retried.
-func initWhitelist() {
+// initRetryWhitelist initializes the whitelist of test failures that can be retried.
+func initRetryWhitelist() {
 	if *testRetryWhitelist == "" {
 		return
 	}
@@ -238,7 +238,7 @@ func main() {
 	if len(flag.Args()) == 0 {
 		glog.Fatalf("USAGE: runner <hosts to test>")
 	}
-	initWhitelist()
+	initRetryWhitelist()
 
 	// Run the tests.
 	err := Run()

--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -120,7 +120,10 @@ func PushAndRunTests(host, testDir string) error {
 	glog.Infof("Running integration tests targeting %q...", host)
 
 	// Only retry on test failures caused by these known flaky failure conditions
-	retryRegex := regexp.MustCompile("Network tx and rx bytes should not be equal")
+	retryStrings := []string{
+		"Network tx and rx bytes should not be equal",
+		"Network tx and rx packets should not be equal"}
+	retryRegex := regexp.MustCompile(strings.Join(retryStrings, "|"))
 	for i := 0; i <= *testRetryCount; i++ {
 		// Check if this is a retry
 		if i > 0 {
@@ -135,9 +138,11 @@ func PushAndRunTests(host, testDir string) error {
 		}
 		if !retryRegex.Match([]byte(err.Error())) {
 			// If error not in whitelist, break out of loop
+			glog.Warningf("Skipping retry for tests on host %s because error is not whitelisted: %s", *testRetryCount, host, err.Error())
 			break
 		}
 	}
+
 	if err != nil {
 		err = fmt.Errorf("error on host %s: %v", host, err)
 	}


### PR DESCRIPTION
… flakes instead of retrying on any failure.

We should explicitly be retrying on certain conditions and not blindly doing so.