### PR TITLE
Expose all memory stats contained in memory.stat via API and /metrics

### DIFF
--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -378,6 +378,7 @@ func toContainerStats1(s *cgroups.Stats, ret *info.ContainerStats) {
 func toContainerStats2(s *cgroups.Stats, ret *info.ContainerStats) {
 	ret.Memory.Usage = s.MemoryStats.Usage.Usage
 	ret.Memory.Failcnt = s.MemoryStats.Usage.Failcnt
+	ret.Memory.Stats = s.MemoryStats.Stats
 	if v, ok := s.MemoryStats.Stats["pgfault"]; ok {
 		ret.Memory.ContainerData.Pgfault = v
 		ret.Memory.HierarchicalData.Pgfault = v

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -306,6 +306,9 @@ type MemoryStats struct {
 	// Units: Bytes.
 	Usage uint64 `json:"usage"`
 
+	// Stats
+	Stats map[string]uint64 `json:"stats"`
+
 	// The amount of working set memory, this includes recently accessed memory,
 	// dirty memory, and kernel memory. Working set is <= "usage".
 	// Units: Bytes.

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -306,7 +306,9 @@ type MemoryStats struct {
 	// Units: Bytes.
 	Usage uint64 `json:"usage"`
 
-	// Stats
+	// Various statistics reported in memory.stat in cgroupfs. See the section
+	// "5.2 stat file" of https://www.kernel.org/doc/Documentation/cgroups/memory.txt
+	// for details.
 	Stats map[string]uint64 `json:"stats"`
 
 	// The amount of working set memory, this includes recently accessed memory,

--- a/info/v1/test/datagen.go
+++ b/info/v1/test/datagen.go
@@ -44,6 +44,10 @@ func GenerateRandomStats(numStats, numCores int, duration time.Duration) []*info
 		stats.Cpu.Usage.User = stats.Cpu.Usage.Total
 		stats.Cpu.Usage.System = 0
 		stats.Memory.Usage = uint64(rand.Int63n(4096))
+		stats.Memory.Stats = map[string]uint64{
+			"cache": uint64(rand.Int63n(4096)),
+			"rss":   uint64(rand.Int63n(4096)),
+		}
 		ret[i] = stats
 	}
 	return ret

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -127,6 +127,21 @@ func NewPrometheusCollector(infoProvider infoProvider, f ContainerNameToLabelsFu
 					return values
 				},
 			}, {
+				name:        "container_memory_stats",
+				help:        "Container memory stats",
+				valueType:   prometheus.GaugeValue,
+				extraLabels: []string{"type"},
+				getValues: func(s *info.ContainerStats) metricValues {
+					values := make(metricValues, 0, len(s.Memory.Stats))
+					for key, value := range s.Memory.Stats {
+						values = append(values, metricValue{
+							value:  float64(value),
+							labels: []string{key},
+						})
+					}
+					return values
+				},
+			}, {
 				name:      "container_memory_failcnt",
 				help:      "Number of memory usage hits limits",
 				valueType: prometheus.CounterValue,

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -128,9 +128,9 @@ func NewPrometheusCollector(infoProvider infoProvider, f ContainerNameToLabelsFu
 				},
 			}, {
 				name:        "container_memory_stats",
-				help:        "Container memory stats",
+				help:        `Various memory statistics. See the section "5.2 stat file" of https://www.kernel.org/doc/Documentation/cgroups/memory.txt for details`,
 				valueType:   prometheus.GaugeValue,
-				extraLabels: []string{"type"},
+				extraLabels: []string{"stat_name"},
 				getValues: func(s *info.ContainerStats) metricValues {
 					values := make(metricValues, 0, len(s.Memory.Stats))
 					for key, value := range s.Memory.Stats {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -130,7 +130,7 @@ func NewPrometheusCollector(infoProvider infoProvider, f ContainerNameToLabelsFu
 				name:        "container_memory_stats",
 				help:        `Various memory statistics. See the section "5.2 stat file" of https://www.kernel.org/doc/Documentation/cgroups/memory.txt for details`,
 				valueType:   prometheus.GaugeValue,
-				extraLabels: []string{"stat_name"},
+				extraLabels: []string{"name"},
 				getValues: func(s *info.ContainerStats) metricValues {
 					values := make(metricValues, 0, len(s.Memory.Stats))
 					for key, value := range s.Memory.Stats {

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -79,6 +79,10 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 							Pgfault:    12,
 							Pgmajfault: 13,
 						},
+						Stats: map[string]uint64{
+							"cache": 14,
+							"rss":   15,
+						},
 					},
 					Network: info.NetworkStats{
 						InterfaceStats: info.InterfaceStats{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -77,6 +77,10 @@ container_memory_failures_total{id="testcontainer",image="test",name="testcontai
 container_memory_failures_total{id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgmajfault"} 11
 container_memory_failures_total{id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgfault"} 12
 container_memory_failures_total{id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgmajfault"} 13
+# HELP container_memory_stats Various memory statistics. See the section "5.2 stat file" of https://www.kernel.org/doc/Documentation/cgroups/memory.txt for details
+# TYPE container_memory_stats gauge
+container_memory_stats{id="testcontainer",image="test",name="testcontaineralias",name="cache"} 14
+container_memory_stats{id="testcontainer",image="test",name="testcontaineralias",name="rss"} 15
 # HELP container_memory_usage_bytes Current memory usage in bytes.
 # TYPE container_memory_usage_bytes gauge
 container_memory_usage_bytes{id="testcontainer",image="test",name="testcontaineralias"} 8


### PR DESCRIPTION
fixes #975 