### PR TITLE
Make Go 1.5 a requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
- - 1.4
  - 1.5
 install:
  - true

--- a/build/build.sh
+++ b/build/build.sh
@@ -29,12 +29,12 @@ if [ "$(go env GOOS)" = "windows" ]; then
 fi
 
 ldflags="
-  -X ${repo_path}/version.Version ${version}
-  -X ${repo_path}/version.Revision ${revision}
-  -X ${repo_path}/version.Branch ${branch}
-  -X ${repo_path}/version.BuildUser ${USER}@${host}
-  -X ${repo_path}/version.BuildDate ${build_date}
-  -X ${repo_path}/version.GoVersion ${go_version}"
+  -X ${repo_path}/version.Version=${version}
+  -X ${repo_path}/version.Revision=${revision}
+  -X ${repo_path}/version.Branch=${branch}
+  -X ${repo_path}/version.BuildUser=${USER}@${host}
+  -X ${repo_path}/version.BuildDate=${build_date}
+  -X ${repo_path}/version.GoVersion=${go_version}"
 
 echo " >   cadvisor"
 godep go build -ldflags "${ldflags}" -o cadvisor${ext} ${repo_path}

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,6 +6,8 @@
 
 cAdvisor is written in the [Go](http://golang.org) programming language. If you haven't set up a Go development environment, please follow [these instructions](http://golang.org/doc/code.html) to install go tool and set up GOPATH. Ensure that your version of Go is at least 1.3. Note that the version of Go in package repositories of some operating systems is outdated, so please [download](https://golang.org/dl/) the latest version.
 
+**Note**: cAdvisor requires Go 1.5 to build.
+
 After setting up Go, you should be able to `go get` cAdvisor as expected (we use `-d` to only download):
 
 ```


### PR DESCRIPTION
As discussed in https://github.com/google/cadvisor/pull/992#issuecomment-165908173 this makes 1.5 a requirement of using the build tooling (`make`) & disables the 1.4 build for travis (`vet` now doesn't support 1.4 any more so this works around this issue too).

/cc @vishh 