### PR TITLE
fix compile issue of influxdb test

### DIFF
--- a/storage/influxdb/influxdb_test.go
+++ b/storage/influxdb/influxdb_test.go
@@ -61,30 +61,8 @@ func (self *influxDbTestStorageDriver) StatsEq(a, b *info.ContainerStats) bool {
 		return false
 	}
 	// Check only the stats populated in influxdb.
-	if a.Cpu.Usage.Total != b.Cpu.Usage.Total {
+	if !reflect.DeepEqual(a.Cpu.Usage, b.Cpu.Usage) {
 		return false
-	}
-	if a.Cpu.Usage.System != b.Cpu.Usage.System {
-		return false
-	}
-	if a.Cpu.Usage.User != b.Cpu.Usage.User {
-		return false
-	}
-
-	// TODO simpler way to check if arrays are equal?
-	if a.Cpu.Usage.PerCpu == nil && b.Cpu.Usage.PerCpu != nil {
-		return false
-	}
-	if a.Cpu.Usage.PerCpu != nil && b.Cpu.Usage.PerCpu == nil {
-		return false
-	}
-	if len(a.Cpu.Usage.PerCpu) != len(b.Cpu.Usage.PerCpu) {
-		return false
-	}
-	for i, usage := range a.Cpu.Usage.PerCpu {
-		if usage != b.Cpu.Usage.PerCpu[i] {
-			return false
-		}
 	}
 
 	if a.Memory.Usage != b.Memory.Usage {

--- a/storage/influxdb/influxdb_test.go
+++ b/storage/influxdb/influxdb_test.go
@@ -107,6 +107,7 @@ func (self *influxDbTestStorageDriver) StatsEq(a, b *info.ContainerStats) bool {
 
 func runStorageTest(f func(test.TestStorageDriver, *testing.T), t *testing.T, bufferCount int) {
 	machineName := "machineA"
+	table := "cadvisor_table"
 	database := "cadvisor_test"
 	username := "root"
 	password := "root"
@@ -131,7 +132,8 @@ func runStorageTest(f func(test.TestStorageDriver, *testing.T), t *testing.T, bu
 	// Delete all data by the end of the call.
 	//defer client.Query(influxdb.Query{Command: fmt.Sprintf("drop database \"%v\"", database)})
 
-	driver, err := New(machineName,
+	driver, err := newStorage(machineName,
+		table,
 		database,
 		username,
 		password,
@@ -150,7 +152,8 @@ func runStorageTest(f func(test.TestStorageDriver, *testing.T), t *testing.T, bu
 	test.StorageDriverFillRandomStatsFunc("containerOnSameMachine", 100, testDriver, t)
 
 	// Generate another container's data on another machine.
-	driverForAnotherMachine, err := New("machineB",
+	driverForAnotherMachine, err := newStorage("machineB",
+		table,
 		database,
 		username,
 		password,
@@ -198,12 +201,14 @@ func TestContainerFileSystemStatsToPoints(t *testing.T) {
 	assert := assert.New(t)
 
 	machineName := "testMachine"
+	table := "cadvisor_table"
 	database := "cadvisor_test"
 	username := "root"
 	password := "root"
 	influxdbHost := "localhost:8086"
 
-	storage, err := New(machineName,
+	storage, err := newStorage(machineName,
+		table,
 		database,
 		username,
 		password,
@@ -267,12 +272,14 @@ func assertContainsPointWithValue(t *testing.T, points []*influxdb.Point, name s
 
 func createTestStorage() (*influxdbStorage, error) {
 	machineName := "testMachine"
+	table := "cadvisor_table"
 	database := "cadvisor_test"
 	username := "root"
 	password := "root"
 	influxdbHost := "localhost:8086"
 
-	storage, err := New(machineName,
+	storage, err := newStorage(machineName,
+		table,
 		database,
 		username,
 		password,


### PR DESCRIPTION
### Before
```
$ godep go test -v github.com/google/cadvisor/storage/influxdb -tags influxdb_test
# github.com/google/cadvisor/storage/influxdb
storage/influxdb/influxdb_test.go:112: undefined: New
storage/influxdb/influxdb_test.go:131: undefined: New
storage/influxdb/influxdb_test.go:184: undefined: New
storage/influxdb/influxdb_test.go:253: undefined: New
FAIL	github.com/google/cadvisor/storage/influxdb [build failed]
godep: go exit status 2
```

### After
```
$ godep go test -v github.com/google/cadvisor/storage/influxdb -tags influxdb_test
=== RUN   TestContainerFileSystemStatsToPoints
--- PASS: TestContainerFileSystemStatsToPoints (0.00s)
=== RUN   TestContainerStatsToPoints
--- PASS: TestContainerStatsToPoints (0.00s)
PASS
ok  	github.com/google/cadvisor/storage/influxdb	0.005s
```