### PR TITLE
Add jitter to housekeeping interval

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"math/rand"
 	"os/exec"
 	"path"
 	"regexp"
@@ -76,6 +77,17 @@ type containerData struct {
 
 	// Runs custom metric collectors.
 	collectorManager collector.CollectorManager
+}
+
+// jitter returns a time.Duration between duration and duration + maxFactor * duration,
+// to allow clients to avoid converging on periodic behavior.  If maxFactor is 0.0, a
+// suggested default value will be chosen.
+func jitter(duration time.Duration, maxFactor float64) time.Duration {
+	if maxFactor <= 0.0 {
+		maxFactor = 1.0
+	}
+	wait := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
+	return wait
 }
 
 func (c *containerData) Start() error {
@@ -356,7 +368,7 @@ func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Tim
 		}
 	}
 
-	return lastHousekeeping.Add(self.housekeepingInterval)
+	return lastHousekeeping.Add(jitter(self.housekeepingInterval, 1.0))
 }
 
 // TODO(vmarmol): Implement stats collecting as a custom collector.


### PR DESCRIPTION
per https://github.com/google/cadvisor/issues/1053 adding jitter to housekeeping intervals similar to what is done internally in kubernetes.  

@jimmidyson @vishh 