### PR TITLE
Initialize env mapping for labels when creating docker container

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -139,6 +139,7 @@ func newDockerContainerHandler(
 		rootFs:             rootFs,
 		rootfsStorageDir:   rootfsStorageDir,
 		fsHandler:          newFsHandler(time.Minute, rootfsStorageDir, otherStorageDir, fsInfo),
+		envs:               make(map[string]string),
 	}
 
 	// We assume that if Inspect fails then the container is not known to docker.


### PR DESCRIPTION
Fix for change in #1023

Somehow i missed this commit when making the change request. Fixes the following error

```
panic: assignment to entry in nil map

goroutine 108 [running]:
github.com/google/cadvisor/container/docker.newDockerContainerHandler(0xc82013c480, 0xc82042cf9a, 0x5b, 0x7fa188edd9f8, 0xc820001c80, 0x7fa188ed8b20, 0xc8201b3
3f0, 0xc8202881e7, 0x7, 0xc820019c48, ...)
        /var/lib/docker/work_repos/gocode/src/github.com/google/cadvisor/container/docker/handler.go:163 +0x11f2
github.com/google/cadvisor/container/docker.(*dockerFactory).NewContainerHandler(0xc820019c20, 0xc82042cf9a, 0x5b, 0xc820345a01, 0x0, 0x0, 0x0, 0x0)
        /var/lib/docker/work_repos/gocode/src/github.com/google/cadvisor/container/docker/factory.go:135 +0x17e
github.com/google/cadvisor/container.NewContainerHandler(0xc82042cf9a, 0x5b, 0xc820563c01, 0x0, 0x0, 0xc820550000, 0x0, 0x0)
        /var/lib/docker/work_repos/gocode/src/github.com/google/cadvisor/container/factory.go:79 +0x6e6
github.com/google/cadvisor/manager.(*manager).createContainer(0xc820001c80, 0xc82042cf9a, 0x5b, 0x0, 0x0)
        /var/lib/docker/work_repos/gocode/src/github.com/google/cadvisor/manager/manager.go:761 +0x170
github.com/google/cadvisor/manager.(*manager).watchForNewContainers.func2(0xc820649260, 0xc8204a3fc0, 0xc820001c80, 0xc820649200, 0xc8200e8880)
        /var/lib/docker/work_repos/gocode/src/github.com/google/cadvisor/manager/manager.go:978 +0x124
created by github.com/google/cadvisor/manager.(*manager).watchForNewContainers
        /var/lib/docker/work_repos/gocode/src/github.com/google/cadvisor/manager/manager.go:995 +0x245
```