### PR TITLE
Track fs usage for docker versions >= 1.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 	@echo ">> running tests"
 	@$(GO) test -short -race $(pkgs)
 
-test-integration: test
+test-integration: build test
 	@./build/integration.sh
 
 format:

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	v1 "github.com/google/cadvisor/info/v1"
@@ -85,6 +87,23 @@ func (self *Client) Attributes() (attr *v2.Attributes, err error) {
 	return
 }
 
+// Stats returns stats for the requested container.
+func (self *Client) Stats(name string, request *v2.RequestOptions) (map[string]v2.ContainerInfo, error) {
+	u := self.statsUrl(name)
+	ret := make(map[string]v2.ContainerInfo)
+	data := url.Values{
+		"type":      []string{request.IdType},
+		"count":     []string{strconv.Itoa(request.Count)},
+		"recursive": []string{strconv.FormatBool(request.Recursive)},
+	}
+
+	u = fmt.Sprintf("%s?%s", u, data.Encode())
+	if err := self.httpGetJsonData(&ret, nil, u, "stats"); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func (self *Client) machineInfoUrl() string {
 	return self.baseUrl + path.Join("machine")
 }
@@ -101,7 +120,11 @@ func (self *Client) attributesUrl() string {
 	return self.baseUrl + path.Join("attributes")
 }
 
-func (self *Client) httpGetResponse(postData interface{}, url, infoName string) ([]byte, error) {
+func (self *Client) statsUrl(name string) string {
+	return path.Join(self.baseUrl, "stats", name)
+}
+
+func (self *Client) httpGetResponse(postData interface{}, urlPath, infoName string) ([]byte, error) {
 	var resp *http.Response
 	var err error
 
@@ -110,24 +133,24 @@ func (self *Client) httpGetResponse(postData interface{}, url, infoName string) 
 		if marshalErr != nil {
 			return nil, fmt.Errorf("unable to marshal data: %v", marshalErr)
 		}
-		resp, err = http.Post(url, "application/json", bytes.NewBuffer(data))
+		resp, err = http.Post(urlPath, "application/json", bytes.NewBuffer(data))
 	} else {
-		resp, err = http.Get(url)
+		resp, err = http.Get(urlPath)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("unable to post %q to %q: %v", infoName, url, err)
+		return nil, fmt.Errorf("unable to post %q to %q: %v", infoName, urlPath, err)
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("received empty response for %q from %q", infoName, url)
+		return nil, fmt.Errorf("received empty response for %q from %q", infoName, urlPath)
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		err = fmt.Errorf("unable to read all %q from %q: %v", infoName, url, err)
+		err = fmt.Errorf("unable to read all %q from %q: %v", infoName, urlPath, err)
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("request %q failed with error: %q", url, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("request %q failed with error: %q", urlPath, strings.TrimSpace(string(body)))
 	}
 	return body, nil
 }

--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -293,7 +293,8 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo) error {
 
 	storageDir, err := getStorageDir(information)
 	if err != nil {
-		return err
+		glog.V(2).Infof("failed to detect storage directory from docker. Defaulting to using the value in --docker_root: %q", err, *dockerRootDir)
+		storageDir = path.Join(*dockerRootDir, sd)
 	}
 	cgroupSubsystems, err := libcontainer.GetCgroupSubsystems()
 	if err != nil {

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -17,6 +17,7 @@ package docker
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math"
 	"path"
 	"strings"
@@ -82,6 +83,24 @@ type dockerContainerHandler struct {
 	fsHandler fsHandler
 }
 
+func getRwLayerID(containerID, storageDriverDir string, dockerVersion []int) (string, error) {
+	const (
+		// Docker version >=1.10.0 have a randomized ID for the root fs of a container.
+		randomizedRWLayerMinorVersion = 10
+		// Directory where the file containinig the randomized ID of the root fs of a container is stored in versions >= 1.10.0
+		rwLayerIDDir  = "../image/aufs/layerdb/mounts/"
+		rwLayerIDFile = "mount-id"
+	)
+	if dockerVersion[1] < randomizedRWLayerMinorVersion {
+		return containerID, nil
+	}
+	bytes, err := ioutil.ReadFile(path.Join(storageDriverDir, rwLayerIDDir, containerID, rwLayerIDFile))
+	if err != nil {
+		return "", fmt.Errorf("failed to identify the read-write layer ID for container %q. - %v", containerID, err)
+	}
+	return string(bytes), err
+}
+
 func newDockerContainerHandler(
 	client *docker.Client,
 	name string,
@@ -92,6 +111,7 @@ func newDockerContainerHandler(
 	cgroupSubsystems *containerlibcontainer.CgroupSubsystems,
 	inHostNamespace bool,
 	metadataEnvs []string,
+	dockerVersion []int,
 ) (container.ContainerHandler, error) {
 	// Create the cgroup paths.
 	cgroupPaths := make(map[string]string, len(cgroupSubsystems.MountPoints))
@@ -116,12 +136,17 @@ func newDockerContainerHandler(
 
 	// Add the Containers dir where the log files are stored.
 	otherStorageDir := path.Join(path.Dir(storageDriverDir), pathToContainersDir, id)
+
+	rwLayerID, err := getRwLayerID(id, storageDriverDir, dockerVersion)
+	if err != nil {
+		return nil, err
+	}
 	var rootfsStorageDir string
 	switch storageDriver {
 	case aufsStorageDriver:
-		rootfsStorageDir = path.Join(storageDriverDir, aufsRWLayer, id)
+		rootfsStorageDir = path.Join(storageDriverDir, aufsRWLayer, rwLayerID)
 	case overlayStorageDriver:
-		rootfsStorageDir = path.Join(storageDriverDir, id)
+		rootfsStorageDir = path.Join(storageDriverDir, rwLayerID)
 	}
 
 	handler := &dockerContainerHandler{

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -91,7 +91,7 @@ func getRwLayerID(containerID, storageDriverDir string, dockerVersion []int) (st
 		rwLayerIDDir  = "../image/aufs/layerdb/mounts/"
 		rwLayerIDFile = "mount-id"
 	)
-	if dockerVersion[1] < randomizedRWLayerMinorVersion {
+	if (dockerVersion[0] <= 1) && (dockerVersion[1] < randomizedRWLayerMinorVersion) {
 		return containerID, nil
 	}
 	bytes, err := ioutil.ReadFile(path.Join(storageDriverDir, rwLayerIDDir, containerID, rwLayerIDFile))

--- a/container/docker/handler_test.go
+++ b/container/docker/handler_test.go
@@ -1,0 +1,50 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Handler for Docker containers.
+package docker
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStorageDirDetectionWithOldVersions(t *testing.T) {
+	as := assert.New(t)
+	rwLayer, err := getRwLayerID("abcd", "/", []int{1, 9, 0})
+	as.Nil(err)
+	as.Equal(rwLayer, "abcd")
+}
+
+func TestStorageDirDetectionWithNewVersions(t *testing.T) {
+	as := assert.New(t)
+	testDir, err := ioutil.TempDir("", "")
+	as.Nil(err)
+	containerID := "abcd"
+	randomizedID := "xyz"
+	randomIDPath := path.Join(testDir, "image/aufs/layerdb/mounts/", containerID)
+	as.Nil(os.MkdirAll(randomIDPath, os.ModePerm))
+	as.Nil(ioutil.WriteFile(path.Join(randomIDPath, "mount-id"), []byte(randomizedID), os.ModePerm))
+	rwLayer, err := getRwLayerID(containerID, path.Join(testDir, "aufs"), []int{1, 10, 0})
+	as.Nil(err)
+	as.Equal(rwLayer, randomizedID)
+	rwLayer, err = getRwLayerID(containerID, path.Join(testDir, "aufs"), []int{1, 10, 0})
+	as.Nil(err)
+	as.Equal(rwLayer, randomizedID)
+
+}

--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -123,7 +123,7 @@ func ContainerStatsFromV1(spec *v1.ContainerSpec, stats []*v1.ContainerStats) []
 				}
 			} else if len(val.Filesystem) > 1 {
 				// Cannot handle multiple devices per container.
-				glog.Errorf("failed to handle multiple devices for container. Skipping Filesystem stats")
+				glog.V(2).Infof("failed to handle multiple devices for container. Skipping Filesystem stats")
 			}
 		}
 		if spec.HasDiskIo {

--- a/integration/framework/framework.go
+++ b/integration/framework/framework.go
@@ -268,10 +268,12 @@ func (self dockerActions) Run(args DockerRunArgs, cmd ...string) string {
 func (self dockerActions) Version() []string {
 	dockerCommand := []string{"docker", "version", "-f", "'{{.Server.Version}}'"}
 	output, _ := self.fm.Shell().Run("sudo", dockerCommand...)
-	if len(output) != 1 {
-		self.fm.T().Fatalf("need 1 arguments in output %v to get the version but have %v", output, len(output))
+	output = strings.TrimSpace(output)
+	ret := strings.Split(output, ".")
+	if len(ret) != 3 {
+		self.fm.T().Fatalf("invalid version %v", output)
 	}
-	return strings.Split(output, ".")
+	return ret
 }
 
 func (self dockerActions) StorageDriver() string {

--- a/integration/framework/framework.go
+++ b/integration/framework/framework.go
@@ -113,6 +113,8 @@ type DockerActions interface {
 	//   -> docker run busybox ping www.google.com
 	Run(args DockerRunArgs, cmd ...string) string
 	RunStress(args DockerRunArgs, cmd ...string) string
+
+	Version() []string
 }
 
 type ShellActions interface {
@@ -253,6 +255,15 @@ func (self dockerActions) Run(args DockerRunArgs, cmd ...string) string {
 		self.fm.Shell().Run("sudo", "docker", "rm", "-f", containerId)
 	})
 	return containerId
+}
+
+func (self dockerActions) Version() []string {
+	dockerCommand := []string{"docker", "version", "-f", "'{{.Server.Version}}'"}
+	output, _ := self.fm.Shell().Run("sudo", dockerCommand...)
+	if len(output) < 1 {
+		self.fm.T().Fatalf("need 1 arguments in output %v to get the version but have %v", output, len(output))
+	}
+	return strings.Split(output, ".")
 }
 
 func (self dockerActions) RunStress(args DockerRunArgs, cmd ...string) string {

--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -181,7 +181,7 @@ func PushAndRunTests(host, testDir string) error {
 		if err != nil {
 			return fmt.Errorf("error reading local log file: %v", err)
 		}
-		glog.Errorf("%v", string(logs))
+		glog.Errorf("----------------------\nLogs from Host: %q\n%v\n", host, string(logs))
 		err = fmt.Errorf("error on host %s: %v\n%+v", host, err, attributes)
 	}
 	return err


### PR DESCRIPTION
Updated the v2.1 `/stats` endpoint to return `map[ContainerName]v2.ContainerInfo` instead of just `map[ContainerName]v2.ContainerStats`. 

Still Pending: Documenting the v2 API.
cc @pwittrock 