### PR TITLE
Fix out of date client/README.md

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -15,14 +15,14 @@ Obviously, replace the URL with the path to your actual cAdvisor REST endpoint.
 client.MachineInfo()
 ```
 
-This method returns a cadvisor/info.MachineInfo struct with all the fields filled in.  Here is an example return value:
+This method returns a cadvisor/v1.MachineInfo struct with all the fields filled in.  Here is an example return value:
 
 ```
-(*info.MachineInfo)(0xc208022b10)({
+(*v1.MachineInfo)(0xc208022b10)({
  NumCores: (int) 4,
  MemoryCapacity: (int64) 2106028032,
- Filesystems: ([]info.FsInfo) (len=1 cap=4) {
-  (info.FsInfo) {
+ Filesystems: ([]v1.FsInfo) (len=1 cap=4) {
+  (v1.FsInfo) {
    Device: (string) (len=9) "/dev/sda1",
    Capacity: (uint64) 19507089408
   }
@@ -34,21 +34,21 @@ You can see the full specification of the [MachineInfo struct in the source](../
 
 ### ContainerInfo
 
-Given a container name and a ContainerInfoRequest, will return all information about the specified container.  The ContainerInfoRequest struct just has one field, NumStats, which is the number of stat entries that you want returned.
+Given a container name and a [ContainerInfoRequest](../info/v1/container.go#L101), will return all information about the specified container.  See the [ContainerInfoRequest struct in the source](../info/v1/container.go#L101) for the full specification.
 
 ```go
-request := info.ContainerInfoRequest{10}
+request := v1.ContainerInfoRequest{NumStats: 10}
 sInfo, err := client.ContainerInfo("/docker/d9d3eb10179e6f93a...", &request)
 ```
-Returns a [ContainerInfo struct](../info/v1/container.go#L120)
+Returns a [ContainerInfo struct](../info/v1/container.go#L128)
 
 ### SubcontainersInfo
 
-Given a container name and a ContainerInfoRequest, will recursively return all info about the container and all subcontainers contained within the container.  The ContainerInfoRequest struct just has one field, NumStats, which is the number of stat entries that you want returned.
+Given a container name and a [ContainerInfoRequest](../info/v1/container.go#L101), will recursively return all info about the container and all subcontainers contained within the container.  See the [ContainerInfoRequest struct in the source](../info/v1/container.go#L101) for the full specification.
 
 ```go
-request := info.ContainerInfoRequest{10}
+request := v1.ContainerInfoRequest{NumStats: 10}
 sInfo, err := client.SubcontainersInfo("/docker", &request)
 ```
 
-Returns a [ContainerInfo struct](../info/v1/container.go#L120) with the Subcontainers field populated.
+Returns a [ContainerInfo struct](../info/v1/container.go#L128) with the Subcontainers field populated.

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(cAdvisor): Package comment.
+// This is an implementation of a cAdvisor REST API in Go.
+// To use it, create a client (replace the URL with your actual cAdvisor REST endpoint):
+//   client, err := client.NewClient("http://192.168.59.103:8080/")
+// Then, the client interface exposes go methods corresponding to the REST endpoints.
 package client
 
 import (

--- a/client/v2/README.md
+++ b/client/v2/README.md
@@ -15,14 +15,14 @@ Obviously, replace the URL with the path to your actual cAdvisor REST endpoint.
 client.MachineInfo()
 ```
 
-This method returns a cadvisor/info.MachineInfo struct with all the fields filled in.  Here is an example return value:
+There is no v2 MachineInfo API, so the v2 client exposes the [v1 MachineInfo](../../info/v1/machine.go#L131)
 
 ```
-(*info.MachineInfo)(0xc208022b10)({
+(*v1.MachineInfo)(0xc208022b10)({
  NumCores: (int) 4,
  MemoryCapacity: (int64) 2106028032,
- Filesystems: ([]info.FsInfo) (len=1 cap=4) {
-  (info.FsInfo) {
+ Filesystems: ([]v1.FsInfo) (len=1 cap=4) {
+  (v1.FsInfo) {
    Device: (string) (len=9) "/dev/sda1",
    Capacity: (uint64) 19507089408
   }
@@ -30,7 +30,7 @@ This method returns a cadvisor/info.MachineInfo struct with all the fields fille
 })
 ```
 
-You can see the full specification of the [MachineInfo struct in the source](../../info/v1/machine.go)
+You can see the full specification of the [MachineInfo struct in the source](../../info/v1/machine.go#L131)
 
 ### VersionInfo
 
@@ -46,7 +46,7 @@ This method returns the cAdvisor version.
 client.Attributes()
 ```
 
-This method returns a [cadvisor/info/v2/Attributes](../../info/v2/machine.go) struct with all the fields filled in. Attributes includes hardware attributes (as returned by MachineInfo) as well as software attributes (eg. software versions). Here is an example return value:
+This method returns a [cadvisor/info/v2/Attributes](../../info/v2/machine.go#L24) struct with all the fields filled in. Attributes includes hardware attributes (as returned by MachineInfo) as well as software attributes (eg. software versions). Here is an example return value:
 
 ```
 (*v2.Attributes)({
@@ -56,8 +56,8 @@ This method returns a [cadvisor/info/v2/Attributes](../../info/v2/machine.go) st
  CadvisorVersion: (string) (len=6) "0.10.1"
  NumCores: (int) 4,
  MemoryCapacity: (int64) 2106028032,
- Filesystems: ([]info.FsInfo) (len=1 cap=4) {
-  (info.FsInfo) {
+ Filesystems: ([]v2.FsInfo) (len=1 cap=4) {
+  (v2.FsInfo) {
    Device: (string) (len=9) "/dev/sda1",
    Capacity: (uint64) 19507089408
   }
@@ -65,5 +65,5 @@ This method returns a [cadvisor/info/v2/Attributes](../../info/v2/machine.go) st
 })
 ```
 
-You can see the full specification of the [Attributes struct in the source](../../info/v2/machine.go)
+You can see the full specification of the [Attributes struct in the source](../../info/v2/machine.go#L24)
 


### PR DESCRIPTION
Fixes the worst of https://github.com/google/cadvisor/issues/997, but the overall documentation needs more work.

The documentation could use a complete rewrite with some additional examples, but I think it would be better to do that through better method comments, and directing users to the [godoc](https://godoc.org/github.com/google/cadvisor/client) instead.