### PR TITLE
fix dd string being treated as a single command

### DIFF
--- a/integration/tests/api/docker_test.go
+++ b/integration/tests/api/docker_test.go
@@ -300,7 +300,7 @@ func TestDockerFilesystemStats(t *testing.T) {
 		sleepDuration = 10 * time.Second
 	)
 	// Wait for the container to show up.
-	containerId := fm.Docker().RunBusybox("/bin/sh", "-c", fmt.Sprintf("'dd if=/dev/zero of=/file count=2 bs=%d & sleep 10000'", ddUsage))
+	containerId := fm.Docker().RunBusybox("/bin/sh", "-c", fmt.Sprintf("dd if=/dev/zero of=/file count=2 bs=%d & sleep 10000", ddUsage))
 	waitForContainer(containerId, fm)
 	request := &v2.RequestOptions{
 		IdType: v2.TypeDocker,


### PR DESCRIPTION
After running integration tests (and hacking the code to not remove the containers)

```
02b69f1b7f1d        busybox             "/bin/sh -c ''dd if=/" ...
# docker logs 02b69f1b7f1d
/bin/sh: dd if=/dev/zero of=/file count=2 bs=8 & sleep 10000: not found
```

This PR keeps the dd string from being treated as a single huge command, which of course isn't found.

Fixes #1130 (#1135 remains)