### PR TITLE
allow ignoreMetrics in new manager

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -22,9 +22,11 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/google/cadvisor/container"
 	cadvisorhttp "github.com/google/cadvisor/http"
 	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/utils/sysfs"
@@ -52,6 +54,43 @@ var allowDynamicHousekeeping = flag.Bool("allow_dynamic_housekeeping", true, "Wh
 
 var enableProfiling = flag.Bool("profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
 
+var (
+	// Metrics to be ignored.
+	ignoreMetrics metricSetValue = metricSetValue{container.MetricSet{}}
+
+	// List of metrics that can be ignored.
+	ignoreWhitelist = container.MetricSet{
+		container.DiskUsageMetrics:       struct{}{},
+		container.NetworkUsageMetrics:    struct{}{},
+		container.NetworkTcpUsageMetrics: struct{}{},
+	}
+)
+
+type metricSetValue struct {
+	container.MetricSet
+}
+
+func (ml *metricSetValue) String() string {
+	return fmt.Sprint(*ml)
+}
+
+func (ml *metricSetValue) Set(value string) error {
+	for _, metric := range strings.Split(value, ",") {
+		if ignoreWhitelist.Has(container.MetricKind(metric)) {
+			(*ml).Add(container.MetricKind(metric))
+		} else {
+			return fmt.Errorf("unsupported metric %q specified in disable_metrics", metric)
+		}
+	}
+	return nil
+}
+
+func init() {
+	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of metrics to be disabled. Options are `disk`, `network`, `tcp`. Note: tcp is disabled by default due to high CPU usage.")
+	// Tcp metrics are ignored by default.
+	flag.Set("disable_metrics", "tcp")
+}
+
 func main() {
 	defer glog.Flush()
 	flag.Parse()
@@ -73,7 +112,7 @@ func main() {
 		glog.Fatalf("Failed to create a system interface: %s", err)
 	}
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping)
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet)
 	if err != nil {
 		glog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/cadvisor_test.go
+++ b/cadvisor_test.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/google/cadvisor/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTcpMetricsAreDisabledByDefault(t *testing.T) {
+	assert.True(t, ignoreMetrics.Has(container.NetworkTcpUsageMetrics))
+	flag.Parse()
+	assert.True(t, ignoreMetrics.Has(container.NetworkTcpUsageMetrics))
+}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -29,7 +29,6 @@ import (
 	info "github.com/google/cadvisor/info/v1"
 	itest "github.com/google/cadvisor/info/v1/test"
 	"github.com/google/cadvisor/utils/sysfs/fakesysfs"
-	"github.com/stretchr/testify/assert"
 )
 
 // TODO(vmarmol): Refactor these tests.
@@ -206,12 +205,8 @@ func TestDockerContainersInfo(t *testing.T) {
 }
 
 func TestNewNilManager(t *testing.T) {
-	_, err := New(nil, nil, 60*time.Second, true)
+	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{})
 	if err == nil {
 		t.Fatalf("Expected nil manager to return error")
 	}
-}
-
-func TestTcpMetricsAreDisabledByDefault(t *testing.T) {
-	assert.True(t, ignoreMetrics.Has(container.NetworkTcpUsageMetrics))
 }


### PR DESCRIPTION
kubelet would like to be able to set the ignore metrics but currently this is only supported when invoking cadvisor from the command line.

This allows the caller of manger.New() to pass in a set of metrics to ignore, falling back to the defaults if none are provided.

cc @ncdc @derekwaynecarr 