### PR TITLE
cloudinfo: bugfix openstack identified as aws

### DIFF
--- a/utils/cloudinfo/aws.go
+++ b/utils/cloudinfo/aws.go
@@ -15,24 +15,26 @@
 package cloudinfo
 
 import (
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"io/ioutil"
+	"strings"
 
 	info "github.com/google/cadvisor/info/v1"
 )
 
+const (
+	ProductVerFileName = "/sys/class/dmi/id/product_version"
+	Amazon             = "amazon"
+)
+
 func onAWS() bool {
-	// the default client behavior retried the operation multiple times with a 5s timeout per attempt.
-	// if you were not on aws, you would block for 20s when invoking this operation.
-	// we reduce retries to 0 and set the timeout to 2s to reduce the time this blocks when not on aws.
-	client := ec2metadata.New(session.New(&aws.Config{MaxRetries: aws.Int(0)}))
-	if client.Config.HTTPClient != nil {
-		client.Config.HTTPClient.Timeout = time.Duration(2 * time.Second)
+	data, err := ioutil.ReadFile(ProductVerFileName)
+	if err != nil {
+		return false
 	}
-	return client.Available()
+	return strings.Contains(string(data), Amazon)
 }
 
 func getAwsMetadata(name string) string {


### PR DESCRIPTION
Because openstack and aws uses the exact same api,
the previous method to check for if running on aws
would have returned true on openstack as well.