### PR TITLE
Remove CanHandleAndAccept from interface and include in NewContainerHandler

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -86,3 +86,65 @@ type ContainerHandler interface {
 	// It is expected that most implementations will be a no-op.
 	Start()
 }
+
+func NewIgnoreHandler(name string) ContainerHandler {
+	return &ignoreHandler{
+		cGroupPath: name,
+	}
+}
+
+type ignoreHandler struct {
+	cGroupPath string
+}
+
+func (handler *ignoreHandler) ContainerReference() (info.ContainerReference, error) {
+	cr := info.ContainerReference{}
+
+	return cr, nil
+}
+
+func (handler *ignoreHandler) GetSpec() (info.ContainerSpec, error) {
+	cs := info.ContainerSpec{}
+
+	return cs, nil
+}
+
+func (handler *ignoreHandler) GetStats() (*info.ContainerStats, error) {
+	return nil, nil
+}
+
+func (handler *ignoreHandler) ListContainers(listType ListType) ([]info.ContainerReference, error) {
+	return nil, nil
+}
+
+func (handler *ignoreHandler) ListThreads(listType ListType) ([]int, error) {
+	return nil, nil
+}
+
+func (handler *ignoreHandler) ListProcesses(listType ListType) ([]int, error) {
+	return nil, nil
+}
+
+func (handler *ignoreHandler) WatchSubcontainers(events chan SubcontainerEvent) error {
+	return nil
+}
+
+func (handler *ignoreHandler) StopWatchingSubcontainers() error {
+	return nil
+}
+
+func (handler *ignoreHandler) GetCgroupPath(resource string) (string, error) {
+	return handler.cGroupPath, nil
+}
+
+func (handler *ignoreHandler) GetContainerLabels() map[string]string {
+	return nil
+}
+
+func (handler *ignoreHandler) Exists() bool {
+	return false
+}
+
+func (handler *ignoreHandler) Cleanup() {}
+
+func (handler *ignoreHandler) Start() {}

--- a/container/factory.go
+++ b/container/factory.go
@@ -101,9 +101,9 @@ func NewContainerHandler(name string, inHostNamespace bool) (ContainerHandler, e
 				return nil, nil
 			}
 			return handler, err
-		} else {
-			glog.V(4).Infof("Factory %q was unable to handle container %q", factory, name)
 		}
+
+		glog.V(4).Infof("Factory %q was unable to handle container %q", factory, name)
 	}
 
 	return nil, fmt.Errorf("no known factory can handle creation of container")

--- a/container/mock.go
+++ b/container/mock.go
@@ -116,12 +116,12 @@ func (self *FactoryForMockContainerHandler) String() string {
 	return self.Name
 }
 
-func (self *FactoryForMockContainerHandler) NewContainerHandler(name string, inHostNamespace bool) (ContainerHandler, bool, error) {
+func (self *FactoryForMockContainerHandler) NewContainerHandler(name string, inHostNamespace bool) (ContainerHandler, error) {
 	handler := &MockContainerHandler{}
 	if self.PrepareContainerHandlerFunc != nil {
 		self.PrepareContainerHandlerFunc(name, handler)
 	}
-	return handler, false, nil
+	return handler, nil
 }
 
 func (self *FactoryForMockContainerHandler) CanHandle(name string) bool {

--- a/container/mock.go
+++ b/container/mock.go
@@ -116,12 +116,12 @@ func (self *FactoryForMockContainerHandler) String() string {
 	return self.Name
 }
 
-func (self *FactoryForMockContainerHandler) NewContainerHandler(name string, inHostNamespace bool) (ContainerHandler, error) {
+func (self *FactoryForMockContainerHandler) NewContainerHandler(name string, inHostNamespace bool) (ContainerHandler, bool, error) {
 	handler := &MockContainerHandler{}
 	if self.PrepareContainerHandlerFunc != nil {
 		self.PrepareContainerHandlerFunc(name, handler)
 	}
-	return handler, nil
+	return handler, false, nil
 }
 
 func (self *FactoryForMockContainerHandler) CanHandle(name string) bool {

--- a/container/raw/factory.go
+++ b/container/raw/factory.go
@@ -50,11 +50,17 @@ func (self *rawFactory) String() string {
 	return "raw"
 }
 
-func (self *rawFactory) NewContainerHandler(name string, inHostNamespace bool) (container.ContainerHandler, bool, error) {
+func (self *rawFactory) NewContainerHandler(name string, inHostNamespace bool) (container.ContainerHandler, error) {
 	handle, accept, err := self.canHandleAndAccept(name)
-
-	if handle == false || accept == false || err != nil {
-		return nil, !accept, err
+	if handle != true {
+		return nil, nil
+	}
+	if accept != true {
+		ignore := container.NewIgnoreHandler(name)
+		return ignore, nil
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	rootFs := "/"
@@ -64,7 +70,7 @@ func (self *rawFactory) NewContainerHandler(name string, inHostNamespace bool) (
 
 	handler, err := newRawContainerHandler(name, self.cgroupSubsystems, self.machineInfoFactory, self.fsInfo, self.watcher, rootFs, self.ignoreMetrics)
 
-	return handler, !accept, err
+	return handler, err
 }
 
 // The raw factory can handle any container. If --docker_only is set to false, non-docker containers are ignored.

--- a/container/rkt/factory.go
+++ b/container/rkt/factory.go
@@ -44,16 +44,22 @@ func (self *rktFactory) String() string {
 	return "rkt"
 }
 
-func (self *rktFactory) NewContainerHandler(name string, inHostNamespace bool) (container.ContainerHandler, bool, error) {
+func (self *rktFactory) NewContainerHandler(name string, inHostNamespace bool) (container.ContainerHandler, error) {
 	handle, accept, err := self.canHandleAndAccept(name)
-
-	if handle == false || accept == false || err != nil {
-		return nil, !accept, err
+	if handle != true {
+		return nil, nil
+	}
+	if accept != true {
+		ignore := container.NewIgnoreHandler(name)
+		return ignore, nil
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	client, err := Client()
 	if err != nil {
-		return nil, !accept, err
+		return nil, err
 	}
 
 	rootFs := "/"
@@ -63,7 +69,7 @@ func (self *rktFactory) NewContainerHandler(name string, inHostNamespace bool) (
 
 	handler, err := newRktContainerHandler(name, client, self.rktPath, self.cgroupSubsystems, self.machineInfoFactory, self.fsInfo, rootFs, self.ignoreMetrics)
 
-	return handler, !accept, err
+	return handler, err
 }
 
 func (self *rktFactory) canHandleAndAccept(name string) (bool, bool, error) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -771,11 +771,11 @@ func (m *manager) createContainer(containerName string) error {
 		return nil
 	}
 
-	handler, accept, err := container.NewContainerHandler(containerName, m.inHostNamespace)
+	handler, err := container.NewContainerHandler(containerName, m.inHostNamespace)
 	if err != nil {
 		return err
 	}
-	if !accept {
+	if handler == nil {
 		// ignoring this container.
 		glog.V(4).Infof("ignoring container %q", containerName)
 		return nil


### PR DESCRIPTION
This is about simplifying the inteface

change the ContainerHandlerFactory

removes
   CanHandleAndAccept(name string) (handle bool, accept bool, err error)

changes
   NewContainerHandler(name string, inHostNamespace bool) (c ContainerHandler, err error)
to
   NewContainerHandler(name string, inHostNamespace bool) (c ContainerHandler, ignore bool, err error)

NewContainerHandler will make the decision if its handling/accepting the container or if its explicitly ignoring it.  ignoring is if it could handle but decides not to accept.

if a container is ignored, its not handled by any other container.

so before we had a few cases

|old CanHandleAndAccept ||new NewContainerHandler||
| --- | --- | --- | --- |
|**handle**|**accept**|**handler**|**ignore**|
| true | false | nil | true |
| false | true | shouldn't happen | |
| false | false | nil | false |
| true | true | !nil | false |

this patch changes the interface and moves every container handler CanHandleAndAccept() into their own NewContainerHandler() and returns appropriately

also changed the tests to reflect these changes

The reason being is that deciding on acceptance and actually creating the handler often require the same information. 
