### PR TITLE
Don't escape e2e test command output in error messages

### DIFF
--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -75,7 +75,7 @@ func getAttributes(ipAddress, portStr string) (*cadvisorApi.Attributes, error) {
 func RunCommand(cmd string, args ...string) error {
 	output, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("command %q %q failed with error: %v and output: %q", cmd, args, err, output)
+		return fmt.Errorf("command %q %q failed with error: %v and output: %v", cmd, args, err, output)
 	}
 
 	return nil


### PR DESCRIPTION
Will make parsing errors such like the following much easier:

```
F0405 05:38:38.584447   18226 runner.go:290] Error 0: error on host e2e-cadvisor-coreos-beta: command "godep" ["go" "test" "--timeout" "15m0s" "github.com/google/cadvisor/integration/tests/..." "--host" "e2e-cadvisor-coreos-beta" "--port" "8080" "--ssh-options" "-i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no"] failed with error: exit status 1 and output: "godep: WARNING: Go version (go1.6) & $GO15VENDOREXPERIMENT= wants to enable the vendor experiment, but disabling because a Godep workspace (Godeps/_workspace) exists\nE0405 05:37:13.574085   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d kubernetes/pause \"]\nE0405 05:37:14.013122   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f 026fa7bda275ef15f3193be11fc35032c8e0aa2ebb00b361ce86c0deb3228367 \"]\nE0405 05:37:15.043048   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d --name test-docker-container-by-name-26077 kubernetes/pause \"]\nE0405 05:37:16.143109   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f 79153741c1b51d33719bd0b02901d841d53680c0c5e1ef0ef16450cd2056b526 \"]\nE0405 05:37:16.483600   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d kubernetes/pause \"]\nE0405 05:37:16.894927   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d kubernetes/pause \"]\nE0405 05:37:17.325416   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f 18dcc6546de9f1633ee8c069353907292684ad1fe12cb51001e68059932a0b2f \"]\nE0405 05:37:17.614628   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f 32f37209e099283782338bb356f46c23ad53a66d4c73a5439b05d58ab06b1e7b \"]\nE0405 05:37:17.934495   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d --name test-basic-docker-container-26077 kubernetes/pause \"]\nE0405 05:37:18.376858   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f 868b8fa7e69af02cd0685a28390c290f7defb409e948fd25c9598a8fad142852 \"]\nE0405 05:37:18.656948   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker version -f '{{.Server.Version}}' \"]\nE0405 05:37:18.837016   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d --cpu-shares 2048 --cpuset 0 --memory 1073741824 kubernetes/pause \"]\n--- FAIL: TestDockerContainerSpec (1.35s)\n\tframework.go:338: Failed to run \"sudo\" [docker run -d --cpu-shares 2048 --cpuset 0 --memory 1073741824 kubernetes/pause] in \"e2e-cadvisor-coreos-beta\" with error: \"exit status 1\". Stdout: \"e81d65f63ff0a227aa3ab0b6b3d2db7c6b3e2ca073933c544e81babfb73e1011\\n\", Stderr: Warning: Permanently added 'e2e-cadvisor-coreos-beta' (ECDSA) to the list of known hosts.\r\n\t\tWarning: '--cpuset' is deprecated, it will be replaced by '--cpuset-cpus' soon. See usage.\n\t\tError response from daemon: Cannot start container e81d65f63ff0a227aa3ab0b6b3d2db7c6b3e2ca073933c544e81babfb73e1011: [8] System error: open /sys/fs/cgroup/memory/system.slice/docker-e81d65f63ff0a227aa3ab0b6b3d2db7c6b3e2ca073933c544e81babfb73e1011.scope/memory.memsw.limit_in_bytes: no such file or directory\nE0405 05:37:20.011774   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d busybox ping www.google.com \"]\nE0405 05:37:20.529861   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f ff24f34747988a794fd1bd37f641ce793c4362db3a33a977f44417ed5971c843 \"]\nE0405 05:37:20.937645   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d busybox ping www.google.com \"]\nE0405 05:37:21.439011   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f a5a22a253b6e9f20dff25d42f822a1708a2840239af4d857377ae26b0dc42d42 \"]\nE0405 05:37:21.831358   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d busybox watch -n1 wget http://www.google.com/ \"]\nE0405 05:37:32.393778   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f 379a39c453b90f64ec0bca6dbc23400509329e7ff9db9aafce15b5a268973b31 \"]\nE0405 05:37:33.340965   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker info \"]\nE0405 05:37:34.291797   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker run -d busybox /bin/sh -c 'dd if=/dev/zero of=/file count=2 bs=8 & ping google.com' \"]\nE0405 05:37:46.198769   26077 framework.go:335] About to run - [ssh -i /home/jenkins/.ssh/google_compute_engine -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no e2e-cadvisor-coreos-beta -- sh -c \" sudo docker rm -f aeafb020a659583cbe21d7068011d1718e80421131943b5ec25f2e5c72a55432 \"]\nFAIL\nFAIL\tgithub.com/google/cadvisor/integration/tests/api\t32.960s\nok  \tgithub.com/google/cadvisor/integration/tests/healthz\t0.015s\ngodep: go exit status 1\n"
&{KernelVersion:4.4.6-coreos ContainerOsVersion:CoreOS 991.2.0 (Coeur Rouge) DockerVersion:1.9.1 CadvisorVersion: NumCores:1 CpuFrequency:2500000 MemoryCapacity:3884789760 MachineID:da7f3ce17e2cb9bfec4df14b8ba22f3e SystemUUID:DA7F3CE1-7E2C-B9BF-EC4D-F14B8BA22F3E Filesystems:[{Device:/dev/sda9 Capacity:6883643392 Type:vfs Inodes:1759104} {Device:/dev/sda3 Capacity:1031946240 Type:vfs Inodes:260096} {Device:/dev/sda6 Capacity:113229824 Type:vfs Inodes:32768}] DiskMap:map[8:0:{Name:sda Major:8 Minor:0 Size:9663676416 Scheduler:cfq}] NetworkDevices:[{Name:ens4v1 MacAddress:42:01:0a:f0:00:08 Speed:0 Mtu:1460}] Topology:[{Id:0 Memory:3884789760 Cores:[{Id:0 Threads:[0] Caches:[{Size:32768 Type:Data Level:1} {Size:32768 Type:Instruction Level:1} {Size:262144 Type:Unified Level:2}]}] Caches:[{Size:31457280 Type:Unified Level:3}]}] CloudProvider:GCE InstanceType:n1-standard-1}
```