### PR TITLE
Fix cAdivsor docker validation

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -439,10 +439,19 @@ func ValidateInfo() (*docker.DockerInfo, error) {
 		return nil, fmt.Errorf("failed to detect Docker info: %v", err)
 	}
 
+	// Fall back to version API if ServerVersion is not set in info.
+	if dockerInfo.ServerVersion == "" {
+		version, err := client.Version()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get docker version: %v", err)
+		}
+		dockerInfo.ServerVersion = version.Get("Version")
+	}
 	version, err := parseDockerVersion(dockerInfo.ServerVersion)
 	if err != nil {
 		return nil, err
 	}
+
 	if version[0] < 1 {
 		return nil, fmt.Errorf("cAdvisor requires docker version %v or above but we have found version %v reported as %q", []int{1, 0, 0}, version, dockerInfo.ServerVersion)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -233,7 +233,6 @@ func (self *manager) Start() error {
 		glog.Errorf("Registration of the raw container factory failed: %v", err)
 	}
 
-	// FIXME - delete?
 	self.DockerInfo()
 	self.DockerImages()
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -185,24 +185,19 @@ func validateCgroups() (string, string) {
 }
 
 func validateDockerInfo() (string, string) {
-	info, err := docker.DockerInfo()
+	info, err := docker.ValidateInfo()
 	if err != nil {
-		return Unknown, "Docker remote API not reachable\n\t"
+		return Unsupported, fmt.Sprintf("Docker setup is invalid: %v", err)
 	}
 
 	desc := fmt.Sprintf("Docker exec driver is %s. Storage driver is %s.\n", info.ExecutionDriver, info.Driver)
-	if strings.Contains(info.ExecutionDriver, "native") {
-		stateFile := docker.DockerStateDir()
-		if !utils.FileExists(stateFile) {
-			desc += fmt.Sprintf("\tDocker container state directory %q is not accessible.\n", stateFile)
-			return Unsupported, desc
-		}
-		desc += fmt.Sprintf("\tDocker container state directory is at %q and is accessible.\n", stateFile)
-		return Recommended, desc
-	} else if strings.Contains(info.ExecutionDriver, "lxc") {
-		return Supported, desc
+	stateFile := docker.DockerStateDir()
+	if !utils.FileExists(stateFile) {
+		desc += fmt.Sprintf("\tDocker container state directory %q is not accessible.\n", stateFile)
+		return Unsupported, desc
 	}
-	return Unknown, desc
+	desc += fmt.Sprintf("\tDocker container state directory is at %q and is accessible.\n", stateFile)
+	return Recommended, desc
 }
 
 func validateCgroupMounts() (string, string) {


### PR DESCRIPTION
- Synchronize `Validate` policy with docker `factory.go` checks
- Don't enforce `ExecutionDriver == "native"` for docker >= v1.11