### PR TITLE
Adds docker labels to tags for influxdb storage

### DIFF
--- a/storage/influxdb/influxdb.go
+++ b/storage/influxdb/influxdb.go
@@ -162,6 +162,7 @@ func (self *influxdbStorage) tagPoints(ref info.ContainerReference, stats *info.
 	for i := 0; i < len(points); i++ {
 		// merge with existing tags if any
 		addTagsToPoint(points[i], commonTags)
+		addTagsToPoint(points[i], ref.Labels)
 		points[i].Time = stats.Timestamp
 	}
 }


### PR DESCRIPTION
This contribution adds the docker labels to the tags for influxdb.  This is handy to filter out or distinguish data points based on custom criteria (is it staging or production?  is it version 0.1 or 0.2? etc).