### PR TITLE
Netlink: aggressively close cgroup fds

### DIFF
--- a/utils/cpuload/netlink/netlink.go
+++ b/utils/cpuload/netlink/netlink.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"syscall"
 
 	info "github.com/google/cadvisor/info/v1"
@@ -219,10 +220,10 @@ func verifyHeader(msg syscall.NetlinkMessage) error {
 
 // Get load stats for a task group.
 // id: family id for taskstats.
-// fd: fd to path to the cgroup directory under cpu hierarchy.
+// cfd: open file to path to the cgroup directory under cpu hierarchy.
 // conn: open netlink connection used to communicate with kernel.
-func getLoadStats(id uint16, fd uintptr, conn *Connection) (info.LoadStats, error) {
-	msg := prepareCmdMessage(id, fd)
+func getLoadStats(id uint16, cfd *os.File, conn *Connection) (info.LoadStats, error) {
+	msg := prepareCmdMessage(id, cfd.Fd())
 	err := conn.WriteMessage(msg.toRawMsg())
 	if err != nil {
 		return info.LoadStats{}, err

--- a/utils/cpuload/netlink/reader.go
+++ b/utils/cpuload/netlink/reader.go
@@ -66,11 +66,12 @@ func (self *NetlinkReader) GetCpuLoad(name string, path string) (info.LoadStats,
 	}
 
 	cfd, err := os.Open(path)
+	defer cfd.Close()
 	if err != nil {
 		return info.LoadStats{}, fmt.Errorf("failed to open cgroup path %s: %q", path, err)
 	}
 
-	stats, err := getLoadStats(self.familyId, cfd.Fd(), self.conn)
+	stats, err := getLoadStats(self.familyId, cfd, self.conn)
 	if err != nil {
 		return info.LoadStats{}, err
 	}


### PR DESCRIPTION
This is a very simple patch, but I've run into the issue described in the commit message when running the load tests described in #1188. This is, however, not a testing-only problem, as I've needed this patch to roll out a shorter collection interval for load probes in production.

The refactoring (of `getLoadStats`) is here to make it clearer that `getLoadStats` is effectively borrowing the open file and not just a number (i.e. it's important  that the file stays open while `getLoadStats` runs, otherwise we'll use an invalid FD, or even FD that refers to another cgroup..!). There isn't a great way to check that the FD is actually valid (that I know of), though. 

I'm happy to provide a much simpler version of that patch (https://github.com/aptible/cadvisor-factory/blob/master/patches/0009-Netlink-aggressively-close-cgroup-fds.patch is what I'm actually using at this time) if you don't think the refactoring is a real gain in clarity. 

---

Commit message follows:

Not closing the FDs manually means we have to rely on garbage collection
to run before cgroup FDs are closed. If the system is running a lot of
load probes at a high-frequency (i.e. dynamic housekeeping isn't backing
off because of load variations), we can end up hitting our FD limit due
to keeping around lots of (useless) FDs.