### PR TITLE
Dont block on grpc if nothing is listeing on rkt api service port

### DIFF
--- a/container/rkt/client.go
+++ b/container/rkt/client.go
@@ -38,17 +38,19 @@ var (
 
 func Client() (rktapi.PublicAPIClient, error) {
 	once.Do(func() {
-		_, err := net.Dial("tcp", "localhost:15441")
+		conn, err := net.DialTimeout("tcp", defaultRktAPIServiceAddr, 2*time.Second)
 		if err != nil {
 			rktClient = nil
-			rktClientErr = fmt.Errorf("rkt: cannot connect to rkt api service: %v", err)
+			rktClientErr = fmt.Errorf("rkt: cannot tcp Dial rkt api service: %v", err)
 			return
 		}
+
+		conn.Close()
 
 		apisvcConn, err := grpc.Dial(defaultRktAPIServiceAddr, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
 		if err != nil {
 			rktClient = nil
-			rktClientErr = fmt.Errorf("rkt: cannot connect to rkt api service: %v", err)
+			rktClientErr = fmt.Errorf("rkt: cannot grpc Dial rkt api service: %v", err)
 			return
 		}
 

--- a/container/rkt/client.go
+++ b/container/rkt/client.go
@@ -16,6 +16,7 @@ package rkt
 
 import (
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -37,6 +38,13 @@ var (
 
 func Client() (rktapi.PublicAPIClient, error) {
 	once.Do(func() {
+		_, err := net.Dial("tcp", "localhost:15441")
+		if err != nil {
+			rktClient = nil
+			rktClientErr = fmt.Errorf("rkt: cannot connect to rkt api service: %v", err)
+			return
+		}
+
 		apisvcConn, err := grpc.Dial(defaultRktAPIServiceAddr, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
 		if err != nil {
 			rktClient = nil

--- a/container/rkt/client.go
+++ b/container/rkt/client.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	defaultRktAPIServiceAddr = "localhost:15441"
+	timeout = 2*time.Second
 )
 
 var (
@@ -38,7 +39,7 @@ var (
 
 func Client() (rktapi.PublicAPIClient, error) {
 	once.Do(func() {
-		conn, err := net.DialTimeout("tcp", defaultRktAPIServiceAddr, 2*time.Second)
+		conn, err := net.DialTimeout("tcp", defaultRktAPIServiceAddr, timeout)
 		if err != nil {
 			rktClient = nil
 			rktClientErr = fmt.Errorf("rkt: cannot tcp Dial rkt api service: %v", err)
@@ -47,7 +48,7 @@ func Client() (rktapi.PublicAPIClient, error) {
 
 		conn.Close()
 
-		apisvcConn, err := grpc.Dial(defaultRktAPIServiceAddr, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+		apisvcConn, err := grpc.Dial(defaultRktAPIServiceAddr, grpc.WithInsecure(), grpc.WithTimeout(timeout))
 		if err != nil {
 			rktClient = nil
 			rktClientErr = fmt.Errorf("rkt: cannot grpc Dial rkt api service: %v", err)

--- a/container/rkt/client.go
+++ b/container/rkt/client.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	defaultRktAPIServiceAddr = "localhost:15441"
-	timeout = 2*time.Second
+	timeout                  = 2 * time.Second
 )
 
 var (


### PR DESCRIPTION
Attempts an initial connection to the rkt api service via the golang net api.  Only try grpc if that succeeds.