### PR TITLE
Fix docker GetSpec to include image, labels, and env vars

### DIFF
--- a/build/integration.sh
+++ b/build/integration.sh
@@ -21,7 +21,7 @@ fi
 sudo -v || exit 1
 
 echo ">> starting cAdvisor locally"
-sudo ./cadvisor &
+sudo ./cadvisor --docker_env_metadata_whitelist=TEST_VAR &
 
 readonly TIMEOUT=120 # Timeout to wait for cAdvisor, in seconds.
 START=$(date +%s)

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -229,7 +229,13 @@ func (self *dockerContainerHandler) needNet() bool {
 
 func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	hasFilesystem := !self.ignoreMetrics.Has(container.DiskUsageMetrics)
-	return common.GetSpec(self.cgroupPaths, self.machineInfoFactory, self.needNet(), hasFilesystem)
+	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, self.needNet(), hasFilesystem)
+
+	spec.Labels = self.labels
+	spec.Envs = self.envs
+	spec.Image = self.image
+
+	return spec, err
 }
 
 func (self *dockerContainerHandler) getFsStats(stats *info.ContainerStats) error {

--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -113,7 +113,7 @@ func PushAndRunTests(host, testDir string) error {
 	portStr := strconv.Itoa(*port)
 	errChan := make(chan error)
 	go func() {
-		err = RunSshCommand("ssh", host, "--", fmt.Sprintf("sudo %s --port %s --logtostderr  &> %s/log.txt", path.Join(testDir, cadvisorBinary), portStr, testDir))
+		err = RunSshCommand("ssh", host, "--", fmt.Sprintf("sudo %s --port %s --logtostderr --docker_env_metadata_whitelist=TEST_VAR  &> %s/log.txt", path.Join(testDir, cadvisorBinary), portStr, testDir))
 		if err != nil {
 			errChan <- fmt.Errorf("error running cAdvisor: %v", err)
 		}


### PR DESCRIPTION
Regressed in https://github.com/google/cadvisor/pull/1213

Added an integration test to catch this in the future.

Thanks @sjpotter for spotting this!