### PR TITLE
on systemd, we should ignore .mount cgroups

### DIFF
--- a/container/systemd/factory.go
+++ b/container/systemd/factory.go
@@ -1,0 +1,57 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systemd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/fs"
+	info "github.com/google/cadvisor/info/v1"
+
+	"github.com/golang/glog"
+)
+
+type systemdFactory struct{}
+
+func (f *systemdFactory) String() string {
+	return "systemd"
+}
+
+func (f *systemdFactory) NewContainerHandler(name string, inHostNamespace bool) (container.ContainerHandler, error) {
+	return nil, fmt.Errorf("Not yet supported")
+}
+
+func (f *systemdFactory) CanHandleAndAccept(name string) (bool, bool, error) {
+	// on systemd using devicemapper each mount into the container has an associated cgroup that we ignore.
+	// for details on .mount units: http://man7.org/linux/man-pages/man5/systemd.mount.5.html
+	if strings.HasSuffix(name, ".mount") {
+		return true, false, nil
+	}
+	return false, false, fmt.Errorf("%s not handled by systemd handler", name)
+}
+
+func (f *systemdFactory) DebugInfo() map[string][]string {
+	return map[string][]string{}
+}
+
+// Register registers the systemd container factory.
+func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics container.MetricSet) error {
+	glog.Infof("Registering systemd factory")
+	factory := &systemdFactory{}
+	container.RegisterContainerHandlerFactory(factory)
+	return nil
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/cadvisor/container/docker"
 	"github.com/google/cadvisor/container/raw"
 	"github.com/google/cadvisor/container/rkt"
+	"github.com/google/cadvisor/container/systemd"
 	"github.com/google/cadvisor/events"
 	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
@@ -226,6 +227,11 @@ func (self *manager) Start() error {
 	err = rkt.Register(self, self.fsInfo, self.ignoreMetrics)
 	if err != nil {
 		glog.Errorf("Registration of the rkt container factory failed: %v", err)
+	}
+
+	err = systemd.Register(self, self.fsInfo, self.ignoreMetrics)
+	if err != nil {
+		glog.Errorf("Registration of the systemd container factory failed: %v", err)
 	}
 
 	err = raw.Register(self, self.fsInfo, self.ignoreMetrics)


### PR DESCRIPTION
Fixes https://github.com/google/cadvisor/issues/1211

/cc @vishh @pmorie - per our conversation today, this is really basic for now.

FYI @ncdc @smarterclayton  - This was the source of random errors when invoking the kubelet summary stats api when tearing down or bringing up new containers on the node.  Putting this on your radar if you see any other reports, but I suspect I was the one primarily exercising this API right now.