### PR TITLE
Add docs about using elasticsearch as a storage driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ cAdvisor supports exporting stats to [InfluxDB](https://influxdb.com/). See the 
 
 cAdvisor also exposes container stats as [Prometheus](http://prometheus.io) metrics. See the [documentation](docs/prometheus.md) for more information.
 
+cAdvisor also supports exporting stats to [ElasticSearch](https://www.elastic.co/). See the [documentation](docs/elasticsearch.md) for more information.
+
 [Heapster](https://github.com/kubernetes/heapster) enables cluster wide monitoring of containers using cAdvisor.
 
 ## Web UI

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -1,0 +1,28 @@
+# Exporting cAdvisor Stats to ElasticSearch
+
+cAdvisor supports exporting stats to [ElasticSearch](https://www.elastic.co/). To use ES, you need to provide the additional flags to cAdvisor:
+
+Set the storage driver as ES:
+
+```
+ -storage_driver=elasticsearch
+```
+
+Specify ES host address:
+
+```
+ -storage_driver_es_host="http://elasticsearch:9200"
+```
+
+There are also optional flags:
+
+```
+ # ElasticSearch type name. By default it's "stats".
+ -storage_driver_es_type="stats"
+ # ElasticSearch can use a sniffing process to find all nodes of your cluster automatically. False by default.
+ -storage_driver_es_enable_sniffer=false
+```
+
+# Examples
+
+For a detailed tutorial, see [docker-elk-cadvisor-dashboards](https://github.com/gregbkr/docker-elk-cadvisor-dashboards)


### PR DESCRIPTION
It's strange that there is not docs about ES storage driver. It would be useful for me. 