### PR TITLE
Use docker to build cAdvisor. 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.6.2
+MAINTAINER vishnuk@google.com
+
+RUN go get github.com/tools/godep
+WORKDIR /go/src/github.com/google/cadvisor


### PR DESCRIPTION
`make` now works on OS X.

cc @timstclair @jimmidyson 
