### PR TITLE
fix chan recieve block on oom event

### DIFF
--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -144,17 +144,18 @@ func (self *OomParser) StreamOoms(outStream chan *OomInstance) {
 			oomCurrentInstance := &OomInstance{
 				ContainerName: "/",
 			}
-			finished := false
-			for !finished {
+			for line := range lineChannel {
 				err := getContainerName(line, oomCurrentInstance)
 				if err != nil {
 					glog.Errorf("%v", err)
 				}
-				finished, err = getProcessNamePid(line, oomCurrentInstance)
+				finished, err := getProcessNamePid(line, oomCurrentInstance)
 				if err != nil {
 					glog.Errorf("%v", err)
 				}
-				line = <-lineChannel
+				if finished {
+					break
+				}
 			}
 			outStream <- oomCurrentInstance
 		}


### PR DESCRIPTION
SteamOoms() blocks on a chan receive on the last line of the OOM kernel message block here:
https://github.com/google/cadvisor/blob/master/utils/oomparser/oomparser.go#L124

This results in the oom event not being reported until another kernel log line comes in after the oom block.