### PR TITLE
Fixes for --disable_metrics flag

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -72,11 +72,15 @@ type metricSetValue struct {
 }
 
 func (ml *metricSetValue) String() string {
-	return fmt.Sprint(*ml)
+	var values []string
+	for metric, _ := range ml.MetricSet {
+		values = append(values, string(metric))
+	}
+	return strings.Join(values, ",")
 }
 
 func (ml *metricSetValue) Set(value string) error {
-	ignoreMetrics = metricSetValue{}
+	ml.MetricSet = container.MetricSet{}
 	if value == "" {
 		return nil
 	}
@@ -91,7 +95,7 @@ func (ml *metricSetValue) Set(value string) error {
 }
 
 func init() {
-	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of metrics to be disabled. Options are `disk`, `network`, `tcp`. Note: tcp is disabled by default due to high CPU usage.")
+	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'disk', 'network', 'tcp'. Note: tcp is disabled by default due to high CPU usage.")
 }
 
 func main() {

--- a/cadvisor_test.go
+++ b/cadvisor_test.go
@@ -28,8 +28,22 @@ func TestTcpMetricsAreDisabledByDefault(t *testing.T) {
 	assert.True(t, ignoreMetrics.Has(container.NetworkTcpUsageMetrics))
 }
 
-func TestTcpMetricsAreEnabledOnDemand(t *testing.T) {
-	assert.True(t, ignoreMetrics.Has(container.NetworkTcpUsageMetrics))
-	ignoreMetrics.Set("")
-	assert.False(t, ignoreMetrics.Has(container.NetworkTcpUsageMetrics))
+func TestIgnoreMetrics(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected []container.MetricKind
+	}{
+		{"", []container.MetricKind{}},
+		{"disk", []container.MetricKind{container.DiskUsageMetrics}},
+		{"disk,tcp,network", []container.MetricKind{container.DiskUsageMetrics, container.NetworkTcpUsageMetrics, container.NetworkUsageMetrics}},
+	}
+
+	for _, test := range tests {
+		assert.NoError(t, ignoreMetrics.Set(test.value))
+
+		assert.Equal(t, len(test.expected), len(ignoreMetrics.MetricSet))
+		for _, expected := range test.expected {
+			assert.True(t, ignoreMetrics.Has(expected), "Missing %s", expected)
+		}
+	}
 }


### PR DESCRIPTION
1. Fix for writing to nil map when value is non-empty.
2. Fix the usage string: go flag package uses backticks for the flag
name.
3. Render the flag default value in the same format as the flag accepts.