### PR TITLE
Fix build for go 1.6

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -40,6 +40,6 @@ ldflags="
   -X ${repo_path}/version.GoVersion${ldseparator}${go_version}"
 
 echo " >   cadvisor"
-GOBIN=. godep go install -ldflags "${ldflags}" ${repo_path}
+GOBIN=$PWD godep go install -ldflags "${ldflags}" ${repo_path}
 
 exit 0


### PR DESCRIPTION
Fix error: `cannot install, GOBIN must be an absolute path`