### PR TITLE
add optional TLS client auth to Kafka storage

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,8 +22,8 @@
 		},
 		{
 			"ImportPath": "github.com/Shopify/sarama",
-			"Comment": "v1.7.0",
-			"Rev": "87ec8d76e89cc002ff5673ee7598ae1db2f32424"
+			"Comment": "v1.8.0",
+			"Rev": "4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9"
 		},
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -7,7 +7,7 @@ cAdvisor supports exporting stats to various storage driver plugins. To enable a
 - [BigQuery](https://cloud.google.com/bigquery/). See the [documentation](../../storage/bigquery/README.md) for usage.
 - [ElasticSearch](https://www.elastic.co/). See the [documentation](elasticsearch.md) for usage and examples.
 - [InfluxDB](https://influxdb.com/). See the [documentation](influxdb.md) for usage and examples.
-- [Kafka](http://kafka.apache.org/)
+- [Kafka](http://kafka.apache.org/). See the [documentation](kafka.md) for usage.
 - [Prometheus](http://prometheus.io). See the [documentation](prometheus.md) for usage and examples.
 - [Redis](http://redis.io/)
 - [StatsD](https://github.com/etsy/statsd)

--- a/docs/storage/kafka.md
+++ b/docs/storage/kafka.md
@@ -1,0 +1,43 @@
+# Exporting cAdvisor Stats to Kafka
+
+cAdvisor supports exporting stats to [Kafka](http://kafka.apache.org/). To use Kafka, you need to provide the additional flags to cAdvisor:
+
+Set the storage driver as Kafka:
+
+```
+ -storage_driver=kafka
+```
+
+If no broker are provided it will default to a broker listening at localhost:9092, with 'stats' as the default topic.
+
+
+Specify a Kafka broker address:
+
+```
+-storage_driver_kafka_broker_list=localhost:9092
+
+```
+
+Specify a Kafka topic:
+
+```
+-storage_driver_kafka_topic=myTopic
+```
+
+As of version 9.0. Kafka supports TLS client auth:
+
+```
+ # To enable TLS client auth support you need to provide the following:
+
+ # Location to Certificate Authority certificate
+  -storage_driver_kafka_ssl_ca=/path/to/ca.pem
+
+ # Location to client certificate certificate
+  -storage_driver_kafka_ssl_cert=/path/to/client_cert.pem
+
+ # Location to client certificate key
+  -storage_driver_kafka_ssl_key=/path/to/client_key.pem
+
+ # Verify SSL certificate chain (default: true)
+  -storage_driver_kafka_ssl_verify=false
+```


### PR DESCRIPTION
This pull requests adds the optional TLS client authentication to the kafka storage driver.