### PR TITLE
Add 'release mode' to build script

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -16,14 +16,27 @@
 
 set -e
 
+RELEASE=${RELEASE:-false} # Whether to build for an official release.
+
 repo_path="github.com/google/cadvisor"
 
 version=$( cat version/VERSION )
 revision=$( git rev-parse --short HEAD 2> /dev/null || echo 'unknown' )
 branch=$( git rev-parse --abbrev-ref HEAD 2> /dev/null || echo 'unknown' )
-host=$( hostname -f )
+build_user="${USER}@${HOSTNAME}"
 build_date=$( date +%Y%m%d-%H:%M:%S )
 go_version=$( go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/' )
+
+GO_CMD="install"
+
+if [ "$RELEASE" == "true" ]; then
+  # Don't include hostname with release builds
+  build_user="$(git config --get user.email)"
+  build_date=$( date +%Y%m%d ) # Release date is only to day-granularity
+
+  # Don't use cached build objects for releases.
+  GO_CMD="build"
+fi
 
 # go 1.4 requires ldflags format to be "-X key value", not "-X key=value"
 ldseparator="="
@@ -35,11 +48,16 @@ ldflags="
   -X ${repo_path}/version.Version${ldseparator}${version}
   -X ${repo_path}/version.Revision${ldseparator}${revision}
   -X ${repo_path}/version.Branch${ldseparator}${branch}
-  -X ${repo_path}/version.BuildUser${ldseparator}${USER}@${host}
+  -X ${repo_path}/version.BuildUser${ldseparator}${build_user}
   -X ${repo_path}/version.BuildDate${ldseparator}${build_date}
   -X ${repo_path}/version.GoVersion${ldseparator}${go_version}"
 
 echo " >   cadvisor"
-GOBIN=$PWD godep go install -ldflags "${ldflags}" ${repo_path}
+
+if [ "$RELEASE" == "true" ]; then
+  echo "Building release candidate with -ldflags $ldflags"
+fi
+
+GOBIN=$PWD godep go "$GO_CMD" -ldflags "${ldflags}" "${repo_path}"
 
 exit 0


### PR DESCRIPTION
Build releases with:
```
RELEASE=true build/build.sh
```

Differences in release mode are:
- Don't use cached build artifacts (`go build` instead of `go install`)
- Don't include hostname in the binary, use git email instead
- Day (instead of second) granularity for the BuildDate