### PR TITLE
Run the integration tests locally with the race detector enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 	@echo ">> running tests"
 	@$(GO) test -tags test -short -race $(pkgs)
 
-test-integration: build test
+test-integration:
 	@./build/integration.sh
 
 format:
@@ -43,4 +43,4 @@ release:
 docker:
 	@docker build -t cadvisor:$(shell git rev-parse --short HEAD) -f deploy/Dockerfile .
 
-.PHONY: all build docker format release test vet
+.PHONY: all build docker format release test test-integration vet

--- a/build/build.sh
+++ b/build/build.sh
@@ -17,6 +17,7 @@
 set -e
 
 RELEASE=${RELEASE:-false} # Whether to build for an official release.
+GO_FLAGS=${GO_FLAGS:-}    # Extra go flags to use in the build.
 
 repo_path="github.com/google/cadvisor"
 
@@ -61,12 +62,12 @@ ldflags="
   -X ${repo_path}/version.BuildDate${ldseparator}${build_date}
   -X ${repo_path}/version.GoVersion${ldseparator}${go_version}"
 
-echo " >   cadvisor"
+echo ">> building cadvisor"
 
 if [ "$RELEASE" == "true" ]; then
   echo "Building release candidate with -ldflags $ldflags"
 fi
 
-GOBIN=$PWD godep go "$GO_CMD" -ldflags "${ldflags}" "${repo_path}"
+GOBIN=$PWD godep go "$GO_CMD" ${GO_FLAGS} -ldflags "${ldflags}" "${repo_path}"
 
 exit 0

--- a/build/integration.sh
+++ b/build/integration.sh
@@ -18,17 +18,38 @@ if [[ -n "${JENKINS_HOME}" ]]; then
     exec ./build/jenkins_e2e.sh
 fi
 
-sudo -v || exit 1
+set -e
 
-echo ">> starting cAdvisor locally"
-sudo ./cadvisor --docker_env_metadata_whitelist=TEST_VAR &
+# Build the test binary.
+GO_FLAGS="-race" ./build/build.sh
 
-readonly TIMEOUT=120 # Timeout to wait for cAdvisor, in seconds.
+TEST_PID=$$
+function start {
+  set +e  # We want to handle errors if cAdvisor crashes.
+  echo ">> starting cAdvisor locally"
+  GORACE="halt_on_error=1" sudo -E ./cadvisor --docker_env_metadata_whitelist=TEST_VAR
+  if [ $? != 0 ]; then
+    echo "!! cAdvisor exited unexpectedly with Exit $?"
+    kill $TEST_PID # cAdvisor crashed: abort testing.
+  fi
+}
+start &
+RUNNER_PID=$!
+
+function cleanup {
+  if pgrep cadvisor > /dev/null; then
+    echo ">> stopping cAdvisor"
+    sudo pkill -SIGINT cadvisor
+    wait $RUNNER_PID
+  fi
+}
+trap cleanup EXIT
+
+readonly TIMEOUT=30 # Timeout to wait for cAdvisor, in seconds.
 START=$(date +%s)
 while [ "$(curl -Gs http://localhost:8080/healthz)" != "ok" ]; do
   if (( $(date +%s) - $START > $TIMEOUT )); then
     echo "Timed out waiting for cAdvisor to start"
-    sudo pkill -9 cadvisor
     exit 1
   fi
   echo "Waiting for cAdvisor to start ..."
@@ -37,11 +58,3 @@ done
 
 echo ">> running integration tests against local cAdvisor"
 godep go test github.com/google/cadvisor/integration/tests/... --vmodule=*=2
-STATUS=$?
-if [ $STATUS -ne 0 ]; then
-    echo "Integration tests failed"
-fi
-echo ">> stopping cAdvisor"
-sudo pkill -9 cadvisor
-
-exit $STATUS


### PR DESCRIPTION
The integration test script was changed so that it aborts the testing
when the cAdvisor binary exits with a non-zero error code.

Also in this PR:
- clean up makefile to print more informative output
- change make release to build the release binary

I will follow up with another PR to enable the race detector on the jenkins jobs.