### PR TITLE
Downgrade failure to rgeister runtime factory to warning

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -232,12 +232,12 @@ type manager struct {
 func (self *manager) Start() error {
 	err := docker.Register(self, self.fsInfo, self.ignoreMetrics)
 	if err != nil {
-		glog.Errorf("Docker container factory registration failed: %v.", err)
+		glog.Warningf("Docker container factory registration failed: %v.", err)
 	}
 
 	err = rkt.Register(self, self.fsInfo, self.ignoreMetrics)
 	if err != nil {
-		glog.Errorf("Registration of the rkt container factory failed: %v", err)
+		glog.Warningf("Registration of the rkt container factory failed: %v", err)
 	} else {
 		watcher, err := rktwatcher.NewRktContainerWatcher()
 		if err != nil {
@@ -248,7 +248,7 @@ func (self *manager) Start() error {
 
 	err = systemd.Register(self, self.fsInfo, self.ignoreMetrics)
 	if err != nil {
-		glog.Errorf("Registration of the systemd container factory failed: %v", err)
+		glog.Warningf("Registration of the systemd container factory failed: %v", err)
 	}
 
 	err = raw.Register(self, self.fsInfo, self.ignoreMetrics)


### PR DESCRIPTION
It is not an error to fail to register the Docker factory on a system
running only rkt, and vice-versa, so these failures are downgraded from
an Error to a Warning. The raw handler should always be registered.

/cc @sjpotter 