### PR TITLE
add cgropu swap usage and export as prometheus metric

### DIFF
--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -383,6 +383,7 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	ret.Memory.Failcnt = s.MemoryStats.Usage.Failcnt
 	ret.Memory.Cache = s.MemoryStats.Stats["cache"]
 	ret.Memory.RSS = s.MemoryStats.Stats["rss"]
+	ret.Memory.Swap = s.MemoryStats.Stats["swap"]
 	if v, ok := s.MemoryStats.Stats["pgfault"]; ok {
 		ret.Memory.ContainerData.Pgfault = v
 		ret.Memory.HierarchicalData.Pgfault = v

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -338,6 +338,10 @@ type MemoryStats struct {
 	// Units: Bytes.
 	RSS uint64 `json:"rss"`
 
+	// The amount of swap currently used by the processes in this cgroup
+	// Units: Bytes.
+	Swap uint64 `json:"swap"`
+
 	// The amount of working set memory, this includes recently accessed memory,
 	// dirty memory, and kernel memory. Working set is <= "usage".
 	// Units: Bytes.

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -167,6 +167,13 @@ func NewPrometheusCollector(infoProvider infoProvider, f ContainerNameToLabelsFu
 					return metricValues{{value: float64(s.Memory.RSS)}}
 				},
 			}, {
+				name:      "container_memory_swap",
+				help:      "Container swap usage in bytes.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Swap)}}
+				},
+			}, {
 				name:      "container_memory_failcnt",
 				help:      "Number of memory usage hits limits",
 				valueType: prometheus.CounterValue,

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -99,6 +99,7 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 						},
 						Cache: 14,
 						RSS:   15,
+						Swap:  8192,
 					},
 					Network: info.NetworkStats{
 						InterfaceStats: info.InterfaceStats{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -92,6 +92,9 @@ container_memory_failures_total{container_env_foo_env="prod",container_label_foo
 # HELP container_memory_rss Size of RSS in bytes.
 # TYPE container_memory_rss gauge
 container_memory_rss{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 15
+# HELP container_memory_swap Container swap usage in bytes.
+# TYPE container_memory_swap gauge
+container_memory_swap{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8192
 # HELP container_memory_usage_bytes Current memory usage in bytes.
 # TYPE container_memory_usage_bytes gauge
 container_memory_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8


### PR DESCRIPTION
Hi ,

this adds the swap information from memory.stat and exports this via prometheus metrics.

Question: Atm this is implemented with the memory.stat file, maybe ists better to use memory_usage_in_bytes and memsw_usage_in_bytes ?


regards f0