### PR TITLE
Fixes a panic when a prometheus endpoint ends with a newline

### DIFF
--- a/collector/prometheus_collector.go
+++ b/collector/prometheus_collector.go
@@ -120,12 +120,18 @@ func (collector *PrometheusCollector) GetSpec() []v1.MetricSpec {
 	}
 
 	lines := strings.Split(string(pageContent), "\n")
+	lineCount := len(lines)
 	for i, line := range lines {
 		if strings.HasPrefix(line, "# HELP") {
-			stopIndex := strings.Index(lines[i+2], "{")
-			if stopIndex == -1 {
-				stopIndex = strings.Index(lines[i+2], " ")
+			if i+2 >= lineCount {
+				break
 			}
+
+			stopIndex := strings.IndexAny(lines[i+2], "{ ")
+			if stopIndex == -1 {
+				continue
+			}
+
 			name := strings.TrimSpace(lines[i+2][0:stopIndex])
 			if _, ok := collector.metricsSet[name]; collector.metricsSet != nil && !ok {
 				continue


### PR DESCRIPTION
We were experimenting with custom metrics earlier today. When we enabled it on one of our kubelets the next time our prometheus server polled the cadvisor endpoint for metrics the kubelet paniced.

The panic that we got in the logs started with this:

```
panic: runtime error: slice bounds out of range
goroutine 602 [running]:
	github.com/google/cadvisor/collector.(*PrometheusCollector).GetSpec(0xc2082f2d20, 0x0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/collector/prometheus_collector.go:129 +0x7bc
	github.com/google/cadvisor/collector.(*GenericCollectorManager).GetSpec(0xc20888a660, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/collector/collector_manager.go:67 +0x118
	github.com/google/cadvisor/manager.(*containerData).updateSpec(0xc208c925a0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/manager/container.go:465 +0x17e
	github.com/google/cadvisor/manager.(*containerData).GetInfo(0xc208c925a0, 0x0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/manager/container.go:118 +0x83
	github.com/google/cadvisor/manager.(*manager).containerDataToContainerInfo(0xc208578000, 0xc208c925a0, 0xc208b92840, 0xc208f037c0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/manager/manager.go:440 +0x4e
	github.com/google/cadvisor/manager.(*manager).containerDataSliceToContainerInfoSlice(0xc208578000, 0xc208bb4500, 0x92, 0x92, 0xc208b92840, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/manager/manager.go:560 +0x189
	github.com/google/cadvisor/manager.(*manager).SubcontainersInfo(0xc208578000, 0x1e54060, 0x1, 0xc208b92840, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/manager/manager.go:493 +0x263
	k8s.io/kubernetes/pkg/kubelet/cadvisor.(*cadvisorClient).SubcontainersInfo(0xc20851a700, 0x1e54060, 0x1, 0xc208b92840, 0x0, 0x0, 0x0, 0x0, 0x0)
	<autogenerated>:19 +0xb7
	github.com/google/cadvisor/metrics.(*PrometheusCollector).collectContainersInfo(0xc2083a2600, 0xc20911bf20)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/metrics/prometheus.go:503 +0xaf
	github.com/google/cadvisor/metrics.(*PrometheusCollector).Collect(0xc2083a2600, 0xc20911bf20)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/google/cadvisor/metrics/prometheus.go:498 +0x62
	github.com/prometheus/client_golang/prometheus.func·014(0x7feacef8b138, 0xc2083a2600)
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus/registry.go:413 +0x62
	created by github.com/prometheus/client_golang/prometheus.(*registry).writePB
	/go/src/k8s.io/kubernetes/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus/registry.go:414 +0x355```
```

Which lead us to this chunk of code:


[/collector/prometheus_collector.go#L109-143](https://github.com/google/cadvisor/blob/49f3d7ed3d786202ce0ae8d7ff7aa962fea53b93/collector/prometheus_collector.go#L109-143)
```go
func (collector *PrometheusCollector) GetSpec() []v1.MetricSpec {
	specs := []v1.MetricSpec{}
	response, err := http.Get(collector.configFile.Endpoint)
	if err != nil {
		return specs
	}
	defer response.Body.Close()

	pageContent, err := ioutil.ReadAll(response.Body)
	if err != nil {
		return specs
	}

	lines := strings.Split(string(pageContent), "\n")
	for i, line := range lines {
		if strings.HasPrefix(line, "# HELP") {
			stopIndex := strings.Index(lines[i+2], "{")
			if stopIndex == -1 {
				stopIndex = strings.Index(lines[i+2], " ")
			}
			name := strings.TrimSpace(lines[i+2][0:stopIndex])
			if _, ok := collector.metricsSet[name]; collector.metricsSet != nil && !ok {
				continue
			}
			spec := v1.MetricSpec{
				Name:   name,
				Type:   v1.MetricType(getMetricData(lines[i+1])),
				Format: "float",
				Units:  getMetricData(lines[i]),
			}
			specs = append(specs, spec)
		}
	}
	return specs
}
```

We noticed that with our custom metrics the prometheus endpoint was creating output that ended in the following:

```
# HELP custom_metric_counter Number of things
# TYPE custom_metric_counter counter

```

When calculating the `stopIndex` if the line (`lines[i+2]`) doesn't contain a "`{`" or "` `" `stopIndex` will be set to -1 which causes the panic on [/collector/prometheus_collector.go#L129](https://github.com/google/cadvisor/blob/49f3d7ed3d786202ce0ae8d7ff7aa962fea53b93/collector/prometheus_collector.go#L129)

This PR fixes this issue and adds tests to make sure it doesn't happen again :D