### PR TITLE
Adds in support for collecting custom metrics from a Jolokia endpoint.

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/google/cadvisor/version"
 
+	"crypto/tls"
 	"github.com/golang/glog"
 )
 
@@ -118,7 +119,7 @@ func main() {
 		glog.Fatalf("Failed to create a system interface: %s", err)
 	}
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet)
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet, tls.Config{})
 	if err != nil {
 		glog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/collector/config.go
+++ b/collector/config.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"time"
 
+	"encoding/json"
 	"github.com/google/cadvisor/info/v1"
 )
 
@@ -59,4 +60,61 @@ type Prometheus struct {
 
 	//holds names of different metrics that can be collected
 	MetricsConfig []string `json:"metrics_config"`
+}
+
+type Jolokia struct {
+	//the endpoint to hit to scrape metrics. Eg https://${HOST}/jolokia
+	Endpoint JolokiaEndpointConfig `json:"endpoint"`
+
+	//holds names of different metrics that can be collected
+	MetricsConfig []JolokiaMetricConfig `json:"metrics_config"`
+
+	//the frequency at which metrics should be collected
+	PollingFrequency string `json:"polling_frequency"`
+
+	// if insecure connections should be allowed or not
+	TrustInsecure bool `json:"trust_insecure"`
+
+	// optional value to be able to specify the CA certificate to used to verify an certificate
+	CAPath string `json:"ca_cert_path"`
+}
+
+type JolokiaMetricConfig struct {
+	//the name of the metric Eg "HeapMemoryUsage" or "MyMetricFoo"
+	Name string `json:"name"`
+
+	//the name of the mbean. Eg java.lang:type=Memory
+	MBean string `json:"mbean"`
+	// the attribute from the mbean Eg HeapMemoryUsage
+	Attribute string `json:"attribute"`
+	//the path contianing the mbean to be used Eg used
+	Path string `json:"path"`
+
+	//enum type for the metric type
+	MetricType v1.MetricType `json:"metric_type"`
+
+	// metric units to display on UI and in storage (eg: MB, cores)
+	// this is only used for display.
+	Units string `json:"units"`
+
+	//data type of the metric (eg: int, float)
+	DataType v1.DataType `json:"data_type"`
+}
+
+type JolokiaEndpointConfig struct {
+	//The full URL of the endpoint to reach
+	URL string
+	// A configuration in which an actual URL is constructed from, using the container's ip address
+	URLConfig JolokiaURLConfig
+}
+
+type JolokiaURLConfig struct {
+	// the protocol to use for connecting to the endpoint. Eg 'http' or 'https'
+	Protocol string `json:"protocol"`
+
+	// the port to use for connecting to the endpoint. Eg '8778'
+	Port json.Number `json:"port"`
+
+	// the path to use for the endpoint. Eg '/jolokia'
+	Path string `json:"path"`
 }

--- a/collector/config/sample_config_jolokia.json
+++ b/collector/config/sample_config_jolokia.json
@@ -1,0 +1,33 @@
+{
+  "endpoint" : "https://123.456.789.1011:8778/jolokia/",
+  "polling_frequency" : "10s",
+  "metrics_config" : [
+    {
+      "name": "JVMHeap",
+      "mbean": "java.lang:type=Memory",
+      "attribute": "HeapMemoryUsage",
+      "path": "used",
+      "metric_type": "gauge",
+      "units": "bytes",
+      "data_type": "int"
+    },
+    {
+      "name": "GCDuration",
+      "mbean": "java.lang:name=PS MarkSweep,type=GarbageCollector",
+      "attribute": "LastGcInfo",
+      "path": "duration",
+      "metric_type": "gauge",
+      "units": "ms",
+      "data_type": "float"
+    },
+    {
+      "name": "nonExistantMBean",
+      "mbean": "i_don't_exist",
+      "attribute": "nope",
+      "path": "nope",
+      "metric_type": "gauge",
+      "units": "mb",
+      "data_type": "int"
+    }
+  ]
+}

--- a/collector/config/sample_config_jolokia_endpoint_config.json
+++ b/collector/config/sample_config_jolokia_endpoint_config.json
@@ -1,0 +1,18 @@
+{
+  "endpoint" : {
+    "protocol" : "https",
+    "path" : "/jolokia",
+    "port" : 8778
+  },
+  "polling_frequency" : "10s",
+  "metrics_config" : [
+    {"name": "JVMHeap",
+      "mbean": "java.lang:type=Memory",
+      "attribute": "HeapMemoryUsage",
+      "path": "used",
+      "metric_type": "gauge",
+      "units": "bytes",
+      "data_type": "int"
+    }
+  ]
+}

--- a/collector/jolokia_collector.go
+++ b/collector/jolokia_collector.go
@@ -1,0 +1,241 @@
+// Copyright 2015-2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"crypto/tls"
+	"github.com/golang/glog"
+	"github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/info/v1"
+	"strconv"
+)
+
+const minpollingfrequency = 1 * time.Second
+const defaultPollingFrequency = 15 * time.Second
+
+var tlsConfig tls.Config
+
+type JolokiaCollector struct {
+	//name of the collector
+	name string
+
+	//holds information extracted from the config file for a collector
+	configFile Jolokia
+
+	// Limit for the number of scaped metrics. If the count is higher,
+	// no metrics will be returned.
+	metricCountLimit int
+
+	//rate at which metrics are collected
+	pollingFrequency time.Duration
+}
+
+type timeEpoch time.Time
+
+type JolokiaResponse struct {
+	Request   JolokiaRequest `json:"request"`
+	Status    int32          `json:"status"`
+	TimeStamp timeEpoch      `json:"timestamp"`
+	Value     json.Number    `json:"value"`
+}
+
+type JolokiaRequest struct {
+	Attribute string `json:"attribute"`
+	MBean     string `json:"mbean"`
+	path      string `json:"path"`
+}
+
+func (jec *JolokiaEndpointConfig) UnmarshalJSON(b []byte) error {
+	url := ""
+	config := JolokiaURLConfig{}
+
+	if err := json.Unmarshal(b, &url); err == nil {
+		jec.URL = url
+		return nil
+	}
+	err := json.Unmarshal(b, &config)
+	if err == nil {
+		jec.URLConfig = config
+		return nil
+	}
+	return err
+}
+
+func (te *timeEpoch) UnmarshalJSON(b []byte) error {
+	var seconds int64
+	err := json.Unmarshal(b, &seconds)
+	if err == nil {
+		time := time.Unix(seconds, 0)
+		*te = timeEpoch(time)
+		return nil
+	} else {
+		return err
+	}
+}
+
+//Returns a new collector using the information extracted from the configfile
+func NewJolokiaCollector(collectorName string, configFile []byte, metricCountLimit int, containerHandler container.ContainerHandler, tls tls.Config) (*JolokiaCollector, error) {
+	var configInJSON Jolokia
+	err := json.Unmarshal(configFile, &configInJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	if configInJSON.Endpoint.URL == "" {
+		ipAddress := containerHandler.GetContainerIPAddress()
+		configInJSON.Endpoint.URL = configInJSON.Endpoint.URLConfig.Protocol + "://" + ipAddress + ":" + configInJSON.Endpoint.URLConfig.Port.String() + configInJSON.Endpoint.URLConfig.Path
+	}
+
+	// Add the caCertificate used to sign the jolokia servers https certificate
+	tlsConfig = tls
+	if configInJSON.CAPath != "" {
+		caCert, err := containerHandler.ReadFile(configInJSON.CAPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate from contianer %v", caCert, err)
+		}
+		tlsConfig.RootCAs.AppendCertsFromPEM(caCert)
+	}
+
+	// if specified, disable security so that we can connect to a secured endpoint which cannot be verified
+	if configInJSON.TrustInsecure == true {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	pollingFrequency, err := time.ParseDuration(configInJSON.PollingFrequency)
+	if err != nil {
+		glog.Warningf("Failed to properly parse the 'polling_frequency' values as a go time.Duration object. Setting to %vs.", defaultPollingFrequency.Seconds())
+		pollingFrequency = defaultPollingFrequency
+	}
+	if pollingFrequency < minpollingfrequency {
+		glog.Warningf("The polling frequency is lower than the minium, the poll frequency for %s has now been to the minium (%vs).", collectorName, minpollingfrequency.Seconds())
+		pollingFrequency = minpollingfrequency
+	}
+
+	if metricCountLimit < 0 {
+		return nil, fmt.Errorf("Metric count limit must be greater than 0")
+	}
+
+	if len(configInJSON.MetricsConfig) > metricCountLimit {
+		return nil, fmt.Errorf("Too many metrics defined: %d limit %d", len(configInJSON.MetricsConfig), metricCountLimit)
+	}
+
+	if !strings.HasSuffix(configInJSON.Endpoint.URL, "/") {
+		configInJSON.Endpoint.URL = configInJSON.Endpoint.URL + "/"
+	}
+
+	return &JolokiaCollector{
+		name:             collectorName,
+		configFile:       configInJSON,
+		metricCountLimit: metricCountLimit,
+		pollingFrequency: pollingFrequency,
+	}, nil
+}
+
+//Returns name of the collector
+func (collector *JolokiaCollector) Name() string {
+	return collector.name
+}
+
+func (collector *JolokiaCollector) configToSpec(config JolokiaMetricConfig) v1.MetricSpec {
+	return v1.MetricSpec{
+		Name:   config.Name,
+		Type:   config.MetricType,
+		Format: config.DataType,
+		Units:  config.Units,
+	}
+}
+
+func (collector *JolokiaCollector) GetSpec() []v1.MetricSpec {
+	specs := []v1.MetricSpec{}
+
+	for _, metricConfig := range collector.configFile.MetricsConfig {
+		spec := collector.configToSpec(metricConfig)
+		specs = append(specs, spec)
+	}
+	return specs
+}
+
+//Returns collected metrics and the next collection time of the collector
+func (collector *JolokiaCollector) Collect(metrics map[string][]v1.MetricVal) (time.Time, map[string][]v1.MetricVal, error) {
+	currentTime := time.Now()
+	nextCollectionTime := currentTime.Add(time.Duration(collector.pollingFrequency))
+
+	var errorSlice []error
+
+	transport := &http.Transport{TLSClientConfig: &tlsConfig}
+	httpClient := &http.Client{Transport: transport}
+
+	for _, metricConfig := range collector.configFile.MetricsConfig {
+		metricValues, err := collectSingleJolokiaMetric(collector.configFile.Endpoint.URL, metricConfig, httpClient)
+		if err != nil {
+			errorSlice = append(errorSlice, err)
+		}
+		metrics[metricConfig.Name] = metricValues
+	}
+	return nextCollectionTime, metrics, compileErrors(errorSlice)
+}
+
+func collectSingleJolokiaMetric(endpointURL string, metricConfig JolokiaMetricConfig, httpClient *http.Client) ([]v1.MetricVal, error) {
+	metricURL := endpointURL + "read/" + metricConfig.MBean + "/" + metricConfig.Attribute + "/" + metricConfig.Path
+
+	http.Get(metricURL)
+	response, err := httpClient.Get(metricURL)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	jolokiaResponse := &JolokiaResponse{}
+	json.NewDecoder(response.Body).Decode(jolokiaResponse)
+
+	if metricConfig.DataType == v1.FloatType {
+		regVal, err := strconv.ParseFloat(string(jolokiaResponse.Value), 64)
+		if err != nil {
+			return nil, err
+		}
+		metricsVal := []v1.MetricVal{
+			{
+				FloatValue: regVal,
+				Timestamp:  time.Time(jolokiaResponse.TimeStamp),
+			},
+		}
+		return metricsVal, nil
+	} else if metricConfig.DataType == v1.IntType {
+		if jolokiaResponse.Value != "" {
+			regVal, err := strconv.ParseInt(string(jolokiaResponse.Value), 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			metricVal := []v1.MetricVal{
+				{
+					IntValue:  regVal,
+					Timestamp: time.Time(jolokiaResponse.TimeStamp),
+				},
+			}
+			return metricVal, nil
+		} else {
+			return nil, fmt.Errorf("The value was empty %v", jolokiaResponse)
+		}
+
+	} else {
+		return nil, fmt.Errorf("Unexpected value of 'data_type' for metric '%v' in config ", metricConfig.Name)
+	}
+}

--- a/collector/jolokia_collector_test.go
+++ b/collector/jolokia_collector_test.go
@@ -1,0 +1,125 @@
+package collector
+
+import (
+	"crypto/tls"
+	"fmt"
+	"github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/info/v1"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJolokiaConfigEndpointConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	configFile, err := ioutil.ReadFile("config/sample_config_jolokia_endpoint_config.json")
+	assert.NoError(err)
+
+	// the ip address for the mock container is set to "123.456.789.1011"
+	containerHandler := container.NewMockContainerHandler("mockContainer")
+
+	collector, err := NewJolokiaCollector("test-jolokia", configFile, 10, containerHandler, tls.Config{})
+	assert.NoError(err)
+
+	assert.Equal("test-jolokia", collector.Name())
+
+	assert.Equal("https://123.456.789.1011:8778/jolokia/", collector.configFile.Endpoint.URL)
+}
+
+func TestJolokiaMultipleMetricGathering(t *testing.T) {
+	assert := assert.New(t)
+
+	configFile, err := ioutil.ReadFile("config/sample_config_jolokia.json")
+	assert.NoError(err)
+
+	containerHandler := container.NewMockContainerHandler("mockContainer")
+
+	collector, err := NewJolokiaCollector("test-jolokia", configFile, 10, containerHandler, tls.Config{})
+	assert.NoError(err)
+
+	assert.Equal("test-jolokia", collector.Name())
+
+	assert.Equal("https://123.456.789.1011:8778/jolokia/", collector.configFile.Endpoint.URL)
+
+	tempServer := generateTestServer()
+	defer tempServer.Close()
+
+	collector.configFile.Endpoint.URL = tempServer.URL + "/jolokia/"
+
+	metrics := map[string][]v1.MetricVal{}
+	//time, metrics, errors
+	_, metrics, errMetric := collector.Collect(metrics)
+	assert.NotNil(metrics)
+
+	assert.Equal(3, len(metrics))
+
+	heapMetric := metrics["JVMHeap"][0]
+	assert.Equal(time.Unix(1414141414, 0), heapMetric.Timestamp)
+	assert.Equal(290405160, heapMetric.IntValue)
+	assert.Equal(0, heapMetric.FloatValue)
+
+	gcMetric := metrics["GCDuration"][0]
+	assert.Equal(time.Unix(1515151515, 0), gcMetric.Timestamp)
+	assert.Equal(0, gcMetric.IntValue)
+	assert.Equal(191, gcMetric.FloatValue)
+
+	assert.Equal(0, len(metrics["nonExistantMBean"]))
+	// The nonExistantMBean should throw an error since it couldn't gather metrics for it
+	assert.True(strings.HasPrefix(errMetric.Error(), "Error 0: The value was empty"))
+
+}
+
+func generateTestServer() *httptest.Server {
+	tempServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/jolokia/read/java.lang:type=Memory/HeapMemoryUsage/used" {
+			result := `
+			{
+    				"request": {
+     					"attribute": "HeapMemoryUsage",
+     					"mbean": "java.lang:type=Memory",
+        				"path": "used",
+        				"type": "read"
+    				},
+    				"status": 200,
+				"value": 290405160,
+				"timestamp":1414141414
+			}`
+			fmt.Fprint(w, result)
+		} else if r.URL.Path == "/jolokia/read/java.lang:name=PS MarkSweep,type=GarbageCollector/LastGcInfo/duration" {
+			result := `
+			{
+    				"request": {
+        				"attribute": "LastGcInfo",
+				        "mbean": "java.lang:name=PS MarkSweep,type=GarbageCollector",
+        				"path": "duration",
+        				"type": "read"
+    				},
+    				"status": 200,
+    				"timestamp": 1515151515,
+    				"value": 191
+			}`
+			fmt.Fprint(w, result)
+		} else {
+			result := `
+			{
+    				"error": "javax.management.AttributeNotFoundException : No such attribute: ...",
+    				"error_type": "javax.management.AttributeNotFoundException",
+    				"request": {
+        				"attribute": "....",
+        				"mbean": "....",
+        				"type": "read"
+    				},
+    				"stacktrace": "javax.management.AttributeNotFoundException:...",
+    				"status": 404
+			}
+			`
+			fmt.Fprint(w, result)
+		}
+	}))
+	return tempServer
+}

--- a/container/container.go
+++ b/container/container.go
@@ -59,6 +59,12 @@ type ContainerHandler interface {
 	// Returns container labels, if available.
 	GetContainerLabels() map[string]string
 
+	// Returns the container's ip address, if available
+	GetContainerIPAddress() string
+
+	// Reads a file from within the container
+	ReadFile(path string) ([]byte, error)
+
 	// Returns whether the container still exists.
 	Exists() bool
 

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -93,6 +94,9 @@ type dockerContainerHandler struct {
 
 	// Filesystem handler.
 	fsHandler common.FsHandler
+
+	// The IP address of the container
+	ipAddress string
 
 	ignoreMetrics container.MetricSet
 
@@ -410,6 +414,21 @@ func (self *dockerContainerHandler) GetCgroupPath(resource string) (string, erro
 
 func (self *dockerContainerHandler) GetContainerLabels() map[string]string {
 	return self.labels
+}
+
+func (self *dockerContainerHandler) GetContainerIPAddress() string {
+	return self.ipAddress
+}
+
+func (self *dockerContainerHandler) ReadFile(filepath string) ([]byte, error) {
+	pid := self.pid
+	filePath := path.Join(self.rootFs, "/proc", strconv.Itoa(pid), "/root", filepath)
+	glog.V(3).Infof("Trying path %q", filePath)
+	data, err := ioutil.ReadFile(filePath)
+	if err == nil {
+		return data, err
+	}
+	return nil, fmt.Errorf("file %q does not exist.", filepath)
 }
 
 func (self *dockerContainerHandler) ListProcesses(listType container.ListType) ([]int, error) {

--- a/container/mock.go
+++ b/container/mock.go
@@ -97,6 +97,14 @@ func (self *MockContainerHandler) Type() ContainerType {
 	return args.Get(0).(ContainerType)
 }
 
+func (self *MockContainerHandler) GetContainerIPAddress() string {
+	return "123.456.789.1011"
+}
+
+func (self *MockContainerHandler) ReadFile(path string) ([]byte, error) {
+	return nil, nil
+}
+
 type FactoryForMockContainerHandler struct {
 	Name                        string
 	PrepareContainerHandlerFunc func(name string, handler *MockContainerHandler)

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -17,6 +17,7 @@ package raw
 
 import (
 	"fmt"
+	"io/ioutil"
 
 	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/common"
@@ -254,6 +255,15 @@ func (self *rawContainerHandler) GetCgroupPath(resource string) (string, error) 
 
 func (self *rawContainerHandler) GetContainerLabels() map[string]string {
 	return map[string]string{}
+}
+
+func (self *rawContainerHandler) GetContainerIPAddress() string {
+	return ""
+}
+
+func (self *rawContainerHandler) ReadFile(filepath string) ([]byte, error) {
+	data, err := ioutil.ReadFile(filepath)
+	return data, err
 }
 
 func (self *rawContainerHandler) ListContainers(listType container.ListType) ([]info.ContainerReference, error) {

--- a/container/rkt/handler.go
+++ b/container/rkt/handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	cgroupfs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"io/ioutil"
 )
 
 type rktContainerHandler struct {
@@ -248,6 +249,15 @@ func (handler *rktContainerHandler) GetStats() (*info.ContainerStats, error) {
 	}
 
 	return stats, nil
+}
+
+func (self *rktContainerHandler) GetContainerIPAddress() string {
+	return ""
+}
+
+func (self *rktContainerHandler) ReadFile(filepath string) ([]byte, error) {
+	data, err := ioutil.ReadFile(filepath)
+	return data, err
 }
 
 func (handler *rktContainerHandler) GetCgroupPath(resource string) (string, error) {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"crypto/tls"
 	"github.com/google/cadvisor/cache/memory"
 	"github.com/google/cadvisor/collector"
 	"github.com/google/cadvisor/container"
@@ -297,7 +298,7 @@ func TestDockerContainersInfo(t *testing.T) {
 }
 
 func TestNewNilManager(t *testing.T) {
-	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{})
+	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, tls.Config{})
 	if err == nil {
 		t.Fatalf("Expected nil manager to return error")
 	}


### PR DESCRIPTION
This adds support for collecting metrics from a Jolokia endpoint (used for monitoring Java application).

As part of this support it adds in a few new methods to the ContainerHandler:

- GetContainerIPAddress allows us to get the containers ip address (either from the docker image directly if it has it, or from the pod if using Kubernetes). This allows us to not rely on using hostports when running in a Kubernetes environment

- ReadFile allows us to read files from within the docker image. This is useful for accessing secured endpoint as we can fetch the ca cert when dealing with self signed certificates

I also added a tls.config to the manager. We need some way to pass certificates to the http client used to fetch metrics so that we can do things such as certificate based authentication. This allows Kubernetes/OpenShift to pass their own certs which can be used by the system.