### PR TITLE
Fix uint64 overflow in info/v2/conversion.go.

### DIFF
--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -206,7 +206,8 @@ func InstCpuStats(last, cur *v1.ContainerStats) (*CpuInstStats, error) {
 			return 0, fmt.Errorf("cumulative stats decrease")
 		}
 		valueDelta := curValue - lastValue
-		return (valueDelta * 1e9) / timeDeltaNs, nil
+		// Use float64 to keep precision
+		return uint64(float64(valueDelta) / float64(timeDeltaNs) * 1e9), nil
 	}
 	total, err := convertToRate(last.Cpu.Usage.Total, cur.Cpu.Usage.Total)
 	if err != nil {
@@ -267,58 +268,4 @@ func ContainerSpecFromV1(specV1 *v1.ContainerSpec, aliases []string, namespace s
 	specV2.Aliases = aliases
 	specV2.Namespace = namespace
 	return specV2
-}
-
-func instCpuStats(last, cur *v1.ContainerStats) (*CpuInstStats, error) {
-	if last == nil {
-		return nil, nil
-	}
-	if !cur.Timestamp.After(last.Timestamp) {
-		return nil, fmt.Errorf("container stats move backwards in time")
-	}
-	if len(last.Cpu.Usage.PerCpu) != len(cur.Cpu.Usage.PerCpu) {
-		return nil, fmt.Errorf("different number of cpus")
-	}
-	timeDelta := cur.Timestamp.Sub(last.Timestamp)
-	if timeDelta <= 100*time.Millisecond {
-		return nil, fmt.Errorf("time delta unexpectedly small")
-	}
-	// Nanoseconds to gain precision and avoid having zero seconds if the
-	// difference between the timestamps is just under a second
-	timeDeltaNs := uint64(timeDelta.Nanoseconds())
-	convertToRate := func(lastValue, curValue uint64) (uint64, error) {
-		if curValue < lastValue {
-			return 0, fmt.Errorf("cumulative stats decrease")
-		}
-		valueDelta := curValue - lastValue
-		return (valueDelta * 1e9) / timeDeltaNs, nil
-	}
-	total, err := convertToRate(last.Cpu.Usage.Total, cur.Cpu.Usage.Total)
-	if err != nil {
-		return nil, err
-	}
-	percpu := make([]uint64, len(last.Cpu.Usage.PerCpu))
-	for i := range percpu {
-		var err error
-		percpu[i], err = convertToRate(last.Cpu.Usage.PerCpu[i], cur.Cpu.Usage.PerCpu[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	user, err := convertToRate(last.Cpu.Usage.User, cur.Cpu.Usage.User)
-	if err != nil {
-		return nil, err
-	}
-	system, err := convertToRate(last.Cpu.Usage.System, cur.Cpu.Usage.System)
-	if err != nil {
-		return nil, err
-	}
-	return &CpuInstStats{
-		Usage: CpuInstUsage{
-			Total:  total,
-			PerCpu: percpu,
-			User:   user,
-			System: system,
-		},
-	}, nil
 }

--- a/info/v2/conversion_test.go
+++ b/info/v2/conversion_test.go
@@ -352,7 +352,7 @@ func TestInstCpuStats(t *testing.T) {
 		},
 	}
 	for _, c := range tests {
-		got, err := instCpuStats(c.last, c.cur)
+		got, err := InstCpuStats(c.last, c.cur)
 		if err != nil {
 			if c.want == nil {
 				continue


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/27194.

The current implementation of `InstCpuStats` will sometimes cause data overflow. (See [detail](https://github.com/kubernetes/kubernetes/issues/27194#issuecomment-226355934))

Without this change, when `valueDelta` is `18949414524`, `timeDeltaNs` is `17978530662`, it will return `27959484`, with this change it will return `1054002403` correctly.

I also removed the dead code `instCpuStats`.

@dchen1107 
/cc @timstclair @vishh 