### PR TITLE
Add support to the handler to support fetching the ip address and files

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -59,6 +59,9 @@ type ContainerHandler interface {
 	// Returns container labels, if available.
 	GetContainerLabels() map[string]string
 
+	// Returns the container's ip address, if available
+	GetContainerIPAddress() string
+
 	// Returns whether the container still exists.
 	Exists() bool
 

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -94,6 +94,9 @@ type dockerContainerHandler struct {
 	// Filesystem handler.
 	fsHandler common.FsHandler
 
+	// The IP address of the container
+	ipAddress string
+
 	ignoreMetrics container.MetricSet
 
 	// thin pool watcher
@@ -221,6 +224,22 @@ func newDockerContainerHandler(
 	handler.image = ctnr.Config.Image
 	handler.networkMode = ctnr.HostConfig.NetworkMode
 	handler.deviceID = ctnr.GraphDriver.Data["DeviceId"]
+
+	// Obtain the IP address for the contianer.
+	// If the NetworkMode starts with 'container:' then we need to use the IP address of the container specified.
+	// This happens in cases such as kubernetes where the containers doesn't have an IP address itself and we need to use the pod's address
+	ipAddress := ctnr.NetworkSettings.IPAddress
+	networkMode := string(ctnr.HostConfig.NetworkMode)
+	if ipAddress == "" && strings.HasPrefix(networkMode, "container:") {
+		containerId := strings.TrimPrefix(networkMode, "container:")
+		c, err := client.ContainerInspect(context.Background(), containerId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect container %q: %v", id, err)
+		}
+		ipAddress = c.NetworkSettings.IPAddress
+	}
+
+	handler.ipAddress = ipAddress
 
 	if !ignoreMetrics.Has(container.DiskUsageMetrics) {
 		handler.fsHandler = &dockerFsHandler{
@@ -410,6 +429,10 @@ func (self *dockerContainerHandler) GetCgroupPath(resource string) (string, erro
 
 func (self *dockerContainerHandler) GetContainerLabels() map[string]string {
 	return self.labels
+}
+
+func (self *dockerContainerHandler) GetContainerIPAddress() string {
+	return self.ipAddress
 }
 
 func (self *dockerContainerHandler) ListProcesses(listType container.ListType) ([]int, error) {

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -256,6 +256,11 @@ func (self *rawContainerHandler) GetContainerLabels() map[string]string {
 	return map[string]string{}
 }
 
+func (self *rawContainerHandler) GetContainerIPAddress() string {
+	// the IP address for the raw container corresponds to the system ip address.
+	return "127.0.0.1"
+}
+
 func (self *rawContainerHandler) ListContainers(listType container.ListType) ([]info.ContainerReference, error) {
 	return common.ListContainers(self.name, self.cgroupPaths, listType)
 }

--- a/container/rkt/handler.go
+++ b/container/rkt/handler.go
@@ -250,6 +250,21 @@ func (handler *rktContainerHandler) GetStats() (*info.ContainerStats, error) {
 	return stats, nil
 }
 
+func (self *rktContainerHandler) GetContainerIPAddress() string {
+	// attempt to return the ip address of the pod
+	// if a specific ip address of the pod could not be determined, return the system ip address
+	if self.isPod && len(self.apiPod.Networks) > 0 {
+		address := self.apiPod.Networks[0].Ipv4
+		if address != "" {
+			return address
+		} else {
+			return self.apiPod.Networks[0].Ipv6
+		}
+	} else {
+		return "127.0.0.1"
+	}
+}
+
 func (handler *rktContainerHandler) GetCgroupPath(resource string) (string, error) {
 	path, ok := handler.cgroupPaths[resource]
 	if !ok {

--- a/container/testing/mock_handler.go
+++ b/container/testing/mock_handler.go
@@ -96,6 +96,11 @@ func (self *MockContainerHandler) Type() container.ContainerType {
 	return args.Get(0).(container.ContainerType)
 }
 
+func (self *MockContainerHandler) GetContainerIPAddress() string {
+	args := self.Called()
+	return args.Get(0).(string)
+}
+
 type FactoryForMockContainerHandler struct {
 	Name                        string
 	PrepareContainerHandlerFunc func(name string, handler *MockContainerHandler)


### PR DESCRIPTION
Adds support to the handler to be able to fetch the ip address of a container and the files from within a container.

Support added for docker containers, but if someone knows more about the raw or rkt containers, they should also be updated to add in this support.

Being able to fetch the ip address of container is essential for supporting custom metrics. Without this we need to be able to know the ip address before starting the container. This is especially cumbersome with kuberentes as it requires setting up hostports and manually managing each container that wants to expose metrics. The support added here will work with both plain docker images and kubernetes pods.

Note: this is in piece of the PR sent for https://github.com/google/cadvisor/pull/1328 as it has been deemed more appropriate to split that request into smaller separate ones.