### PR TITLE
Including the number of free inodes in FsInfo

### DIFF
--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -216,6 +216,9 @@ type FsInfo struct {
 
 	// Labels associated with this filesystem.
 	Labels []string `json:"labels"`
+
+	// Number of available Inodes.
+	InodesFree uint64 `json:"inodes_free"`
 }
 
 type RequestOptions struct {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -687,6 +687,7 @@ func (self *manager) GetFsInfo(label string) ([]v2.FsInfo, error) {
 			Usage:      fs.Usage,
 			Available:  fs.Available,
 			Labels:     labels,
+			InodesFree: fs.InodesFree,
 		}
 		fsInfo = append(fsInfo, fi)
 	}


### PR DESCRIPTION
This info helps Kubelet decide on declaring OutOfDisk 