### PR TITLE
Update collectors to be able to directly use the ip address of containers

### DIFF
--- a/collector/config/sample_config_endpoint_config.json
+++ b/collector/config/sample_config_endpoint_config.json
@@ -1,0 +1,38 @@
+{
+  "endpoint" : {
+    "protocol": "https",
+    "port": 8000,
+    "path": "/nginx_status"
+  },
+  "metrics_config"  : [
+    { "name" : "activeConnections",
+      "metric_type" : "gauge",
+      "units" : "number of active connections",
+      "data_type" : "int",
+      "polling_frequency" : 10,
+      "regex" : "Active connections: ([0-9]+)"
+    },
+    { "name" : "reading",
+      "metric_type" : "gauge",
+      "units" : "number of reading connections",
+      "data_type" : "int",
+      "polling_frequency" : 10,
+      "regex" : "Reading: ([0-9]+) .*"
+    },
+    { "name" : "writing",
+      "metric_type" : "gauge",
+      "data_type" : "int",
+      "units" : "number of writing connections",
+      "polling_frequency" : 10,
+      "regex" : ".*Writing: ([0-9]+).*"
+    },
+    { "name" : "waiting",
+      "metric_type" : "gauge",
+      "units" : "number of waiting connections",
+      "data_type" : "int",
+      "polling_frequency" : 10,
+      "regex" : ".*Waiting: ([0-9]+)"
+    }
+  ]
+
+}

--- a/collector/config/sample_config_prometheus_endpoint_config.json
+++ b/collector/config/sample_config_prometheus_endpoint_config.json
@@ -1,0 +1,10 @@
+{
+  "endpoint" : {
+    "protocol": "http",
+    "port": 8081,
+    "path": "/METRICS"
+  },
+  "polling_frequency" : 10,
+  "metrics_config" : [
+  ]
+}

--- a/collector/generic_collector_test.go
+++ b/collector/generic_collector_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/cadvisor/info/v1"
 
+	containertest "github.com/google/cadvisor/container/testing"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,7 +45,8 @@ func TestEmptyConfig(t *testing.T) {
 	configFile, err := ioutil.ReadFile("temp.json")
 	assert.NoError(err)
 
-	_, err = NewCollector("tempCollector", configFile, 100)
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	_, err = NewCollector("tempCollector", configFile, 100, containerHandler)
 	assert.Error(err)
 
 	assert.NoError(os.Remove("temp.json"))
@@ -74,7 +76,8 @@ func TestConfigWithErrors(t *testing.T) {
 	configFile, err := ioutil.ReadFile("temp.json")
 	assert.NoError(err)
 
-	_, err = NewCollector("tempCollector", configFile, 100)
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	_, err = NewCollector("tempCollector", configFile, 100, containerHandler)
 	assert.Error(err)
 
 	assert.NoError(os.Remove("temp.json"))
@@ -112,7 +115,8 @@ func TestConfigWithRegexErrors(t *testing.T) {
 	configFile, err := ioutil.ReadFile("temp.json")
 	assert.NoError(err)
 
-	_, err = NewCollector("tempCollector", configFile, 100)
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	_, err = NewCollector("tempCollector", configFile, 100, containerHandler)
 	assert.Error(err)
 
 	assert.NoError(os.Remove("temp.json"))
@@ -125,10 +129,28 @@ func TestConfig(t *testing.T) {
 	configFile, err := ioutil.ReadFile("config/sample_config.json")
 	assert.NoError(err)
 
-	collector, err := NewCollector("nginx", configFile, 100)
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	collector, err := NewCollector("nginx", configFile, 100, containerHandler)
 	assert.NoError(err)
 	assert.Equal(collector.name, "nginx")
-	assert.Equal(collector.configFile.Endpoint, "http://localhost:8000/nginx_status")
+	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8000/nginx_status")
+	assert.Equal(collector.configFile.MetricsConfig[0].Name, "activeConnections")
+}
+
+func TestEndpointConfig(t *testing.T) {
+	assert := assert.New(t)
+	configFile, err := ioutil.ReadFile("config/sample_config_endpoint_config.json")
+	assert.NoError(err)
+
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
+
+	collector, err := NewCollector("nginx", configFile, 100, containerHandler)
+	assert.NoError(err)
+	assert.Equal(collector.name, "nginx")
+	assert.Equal(collector.configFile.Endpoint.URL, "https://111.111.111.111:8000/nginx_status")
 	assert.Equal(collector.configFile.MetricsConfig[0].Name, "activeConnections")
 }
 
@@ -139,7 +161,8 @@ func TestMetricCollection(t *testing.T) {
 	configFile, err := ioutil.ReadFile("config/sample_config.json")
 	assert.NoError(err)
 
-	fakeCollector, err := NewCollector("nginx", configFile, 100)
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	fakeCollector, err := NewCollector("nginx", configFile, 100, containerHandler)
 	assert.NoError(err)
 
 	tempServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -147,7 +170,7 @@ func TestMetricCollection(t *testing.T) {
 		fmt.Fprintln(w, "5 5 32\nReading: 0 Writing: 1 Waiting: 2")
 	}))
 	defer tempServer.Close()
-	fakeCollector.configFile.Endpoint = tempServer.URL
+	fakeCollector.configFile.Endpoint.URL = tempServer.URL
 
 	metrics := map[string][]v1.MetricVal{}
 	_, metrics, errMetric := fakeCollector.Collect(metrics)
@@ -174,6 +197,7 @@ func TestMetricCollectionLimit(t *testing.T) {
 	configFile, err := ioutil.ReadFile("config/sample_config.json")
 	assert.NoError(err)
 
-	_, err = NewCollector("nginx", configFile, 1)
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	_, err = NewCollector("nginx", configFile, 1, containerHandler)
 	assert.Error(err)
 }

--- a/collector/prometheus_collector.go
+++ b/collector/prometheus_collector.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/info/v1"
 )
 
@@ -46,12 +47,14 @@ type PrometheusCollector struct {
 }
 
 //Returns a new collector using the information extracted from the configfile
-func NewPrometheusCollector(collectorName string, configFile []byte, metricCountLimit int) (*PrometheusCollector, error) {
+func NewPrometheusCollector(collectorName string, configFile []byte, metricCountLimit int, containerHandler container.ContainerHandler) (*PrometheusCollector, error) {
 	var configInJSON Prometheus
 	err := json.Unmarshal(configFile, &configInJSON)
 	if err != nil {
 		return nil, err
 	}
+
+	configInJSON.Endpoint.configure(containerHandler)
 
 	minPollingFrequency := configInJSON.PollingFrequency
 
@@ -108,7 +111,7 @@ func getMetricData(line string) string {
 
 func (collector *PrometheusCollector) GetSpec() []v1.MetricSpec {
 	specs := []v1.MetricSpec{}
-	response, err := http.Get(collector.configFile.Endpoint)
+	response, err := http.Get(collector.configFile.Endpoint.URL)
 	if err != nil {
 		return specs
 	}
@@ -153,7 +156,7 @@ func (collector *PrometheusCollector) Collect(metrics map[string][]v1.MetricVal)
 	currentTime := time.Now()
 	nextCollectionTime := currentTime.Add(time.Duration(collector.pollingFrequency))
 
-	uri := collector.configFile.Endpoint
+	uri := collector.configFile.Endpoint.URL
 	response, err := http.Get(uri)
 	if err != nil {
 		return nextCollectionTime, nil, err

--- a/collector/util.go
+++ b/collector/util.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import "github.com/google/cadvisor/container"
+
+func (endpointConfig *EndpointConfig) configure(containerHandler container.ContainerHandler) {
+	//If the exact URL was not specified, generate it based on the ip address of the container.
+	endpoint := endpointConfig
+	if endpoint.URL == "" {
+		ipAddress := containerHandler.GetContainerIPAddress()
+		endpointConfig.URL = endpoint.URLConfig.Protocol + "://" + ipAddress + ":" + endpoint.URLConfig.Port.String() + endpoint.URLConfig.Path
+	}
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -752,7 +752,7 @@ func (m *manager) registerCollectors(collectorConfigs map[string]string, cont *c
 		glog.V(3).Infof("Got config from %q: %q", v, configFile)
 
 		if strings.HasPrefix(k, "prometheus") || strings.HasPrefix(k, "Prometheus") {
-			newCollector, err := collector.NewPrometheusCollector(k, configFile, *applicationMetricsCountLimit)
+			newCollector, err := collector.NewPrometheusCollector(k, configFile, *applicationMetricsCountLimit, cont.handler)
 			if err != nil {
 				glog.Infof("failed to create collector for container %q, config %q: %v", cont.info.Name, k, err)
 				return err
@@ -763,7 +763,7 @@ func (m *manager) registerCollectors(collectorConfigs map[string]string, cont *c
 				return err
 			}
 		} else {
-			newCollector, err := collector.NewCollector(k, configFile, *applicationMetricsCountLimit)
+			newCollector, err := collector.NewCollector(k, configFile, *applicationMetricsCountLimit, cont.handler)
 			if err != nil {
 				glog.Infof("failed to create collector for container %q, config %q: %v", cont.info.Name, k, err)
 				return err


### PR DESCRIPTION
Allows collectors to directly use the ip address of containers.

This means that custom metrics no longer have to know the ip address of the container before they are deployed.

In Kubernetes environments, it greatly makes handling custom metrics much easier. We no longer have to deal with special permissions for hostports and we can now deploy multiple pods of the same type without having to manually manage the ports in use.