### PR TITLE
Update collectors to use a customized httpClient.

### DIFF
--- a/collector/generic_collector_test.go
+++ b/collector/generic_collector_test.go
@@ -46,7 +46,7 @@ func TestEmptyConfig(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	_, err = NewCollector("tempCollector", configFile, 100, containerHandler)
+	_, err = NewCollector("tempCollector", configFile, 100, containerHandler, http.DefaultClient)
 	assert.Error(err)
 
 	assert.NoError(os.Remove("temp.json"))
@@ -77,7 +77,7 @@ func TestConfigWithErrors(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	_, err = NewCollector("tempCollector", configFile, 100, containerHandler)
+	_, err = NewCollector("tempCollector", configFile, 100, containerHandler, http.DefaultClient)
 	assert.Error(err)
 
 	assert.NoError(os.Remove("temp.json"))
@@ -116,7 +116,7 @@ func TestConfigWithRegexErrors(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	_, err = NewCollector("tempCollector", configFile, 100, containerHandler)
+	_, err = NewCollector("tempCollector", configFile, 100, containerHandler, http.DefaultClient)
 	assert.Error(err)
 
 	assert.NoError(os.Remove("temp.json"))
@@ -130,7 +130,7 @@ func TestConfig(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	collector, err := NewCollector("nginx", configFile, 100, containerHandler)
+	collector, err := NewCollector("nginx", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "nginx")
 	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8000/nginx_status")
@@ -147,7 +147,7 @@ func TestEndpointConfig(t *testing.T) {
 		"111.111.111.111",
 	)
 
-	collector, err := NewCollector("nginx", configFile, 100, containerHandler)
+	collector, err := NewCollector("nginx", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "nginx")
 	assert.Equal(collector.configFile.Endpoint.URL, "https://111.111.111.111:8000/nginx_status")
@@ -162,7 +162,7 @@ func TestMetricCollection(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	fakeCollector, err := NewCollector("nginx", configFile, 100, containerHandler)
+	fakeCollector, err := NewCollector("nginx", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 
 	tempServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -198,6 +198,6 @@ func TestMetricCollectionLimit(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	_, err = NewCollector("nginx", configFile, 1, containerHandler)
+	_, err = NewCollector("nginx", configFile, 1, containerHandler, http.DefaultClient)
 	assert.Error(err)
 }

--- a/collector/prometheus_collector_test.go
+++ b/collector/prometheus_collector_test.go
@@ -34,7 +34,7 @@ func TestPrometheus(t *testing.T) {
 	//Create a prometheus collector using the config file 'sample_config_prometheus.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus.json")
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler)
+	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
 	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8080/metrics")
@@ -87,7 +87,7 @@ func TestPrometheusEndpointConfig(t *testing.T) {
 		"222.222.222.222",
 	)
 
-	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler)
+	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
 	assert.Equal(collector.configFile.Endpoint.URL, "http://222.222.222.222:8081/METRICS")
@@ -99,7 +99,7 @@ func TestPrometheusShortResponse(t *testing.T) {
 	//Create a prometheus collector using the config file 'sample_config_prometheus.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus.json")
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler)
+	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
 	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8080/metrics")
@@ -122,7 +122,7 @@ func TestPrometheusMetricCountLimit(t *testing.T) {
 	//Create a prometheus collector using the config file 'sample_config_prometheus.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus.json")
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	collector, err := NewPrometheusCollector("Prometheus", configFile, 10, containerHandler)
+	collector, err := NewPrometheusCollector("Prometheus", configFile, 10, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
 	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8080/metrics")
@@ -151,7 +151,7 @@ func TestPrometheusFiltersMetrics(t *testing.T) {
 	//Create a prometheus collector using the config file 'sample_config_prometheus_filtered.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus_filtered.json")
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler)
+	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
 	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8080/metrics")
@@ -187,6 +187,6 @@ func TestPrometheusFiltersMetricsCountLimit(t *testing.T) {
 	//Create a prometheus collector using the config file 'sample_config_prometheus_filtered.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus_filtered.json")
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
-	_, err = NewPrometheusCollector("Prometheus", configFile, 1, containerHandler)
+	_, err = NewPrometheusCollector("Prometheus", configFile, 1, containerHandler, http.DefaultClient)
 	assert.Error(err)
 }

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/utils/sysfs/fakesysfs"
 	"github.com/stretchr/testify/assert"
+	"net/http"
 )
 
 // TODO(vmarmol): Refactor these tests.
@@ -298,7 +299,7 @@ func TestDockerContainersInfo(t *testing.T) {
 }
 
 func TestNewNilManager(t *testing.T) {
-	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{})
+	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient)
 	if err == nil {
 		t.Fatalf("Expected nil manager to return error")
 	}


### PR DESCRIPTION
Updates collectors to use a customized httpClient.

This client has been configured to be able to read from https endpoints which in which cAdvisor cannot entirely trust. For instance, in the case of endpoints where its secured with self signed certificates or do not have the right ip address as part of the certificate. We do not need to verify that endpoints have properly certificates, this is just to make reading endpoints regardless if they are http or https based.

Expose as a configuration option the ability to specify a certificate to be used by the collectors when accessing endpoints. This means that endpoints can be configured to be use client certificate based authentication, allowing endpoints to only allow access to custom metrics if they trust the cAdvisor certificates.