### PR TITLE
Modify working set memory stats calculation

### DIFF
--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -387,23 +387,16 @@ func toContainerStats2(s *cgroups.Stats, ret *info.ContainerStats) {
 		ret.Memory.ContainerData.Pgmajfault = v
 		ret.Memory.HierarchicalData.Pgmajfault = v
 	}
-	if v, ok := s.MemoryStats.Stats["total_inactive_anon"]; ok {
-		workingSet := ret.Memory.Usage
+
+	workingSet := ret.Memory.Usage
+	if v, ok := s.MemoryStats.Stats["total_inactive_file"]; ok {
 		if workingSet < v {
 			workingSet = 0
 		} else {
 			workingSet -= v
 		}
-
-		if v, ok := s.MemoryStats.Stats["total_inactive_file"]; ok {
-			if workingSet < v {
-				workingSet = 0
-			} else {
-				workingSet -= v
-			}
-		}
-		ret.Memory.WorkingSet = workingSet
 	}
+	ret.Memory.WorkingSet = workingSet
 }
 
 func toContainerStats3(libcontainerStats *libcontainer.Stats, ret *info.ContainerStats) {


### PR DESCRIPTION
Change working set calculation to usage - total_inactive_file, rather than usage - total_inactive_anon - total_inactive_file. Since writes to tmpfs get tracked as total_inactive_anon when swap is disabled, the old calculation would under-report memory pressure.

See these for context:
https://github.com/kubernetes/kubernetes/issues/28619
https://github.com/kubernetes/kubernetes/pull/28693

cc @vishh @timstclair 
