### PR TITLE
Fix for Prometheus metric "container_scrape_errors" getting stuck

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -493,6 +493,7 @@ func (c *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect fetches the stats from all containers and delivers them as
 // Prometheus metrics. It implements prometheus.PrometheusCollector.
 func (c *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
+	c.errors.Set(0)
 	c.collectMachineInfo(ch)
 	c.collectVersionInfo(ch)
 	c.collectContainersInfo(ch)

--- a/metrics/testdata/prometheus_metrics_failure
+++ b/metrics/testdata/prometheus_metrics_failure
@@ -1,0 +1,3 @@
+# HELP container_scrape_error 1 if there was an error while getting container metrics, 0 otherwise
+# TYPE container_scrape_error gauge
+container_scrape_error 1


### PR DESCRIPTION
This fixes an issue where errors during Prometheus metrics collection would stay counted in the gauge `container_scrape_errors`, making that particular metric useless. Instead, it must be reset on
every scrape.