### PR TITLE
filesystem usage stats are wrong in v2 api

### DIFF
--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -24,7 +24,8 @@ import (
 
 func machineFsStatsFromV1(fsStats []v1.FsStats) []MachineFsStats {
 	var result []MachineFsStats
-	for _, stat := range fsStats {
+	for i := range fsStats {
+		stat := fsStats[i]
 		readDuration := time.Millisecond * time.Duration(stat.ReadTime)
 		writeDuration := time.Millisecond * time.Duration(stat.WriteTime)
 		ioDuration := time.Millisecond * time.Duration(stat.IoTime)


### PR DESCRIPTION
Go reuses memory, so the result was that things that took the pointer value of `stat` would get a random result from a different `filesystem` for available, capacity, etc.  It caused the output of `/v2.1/machinestats` to just be really wrong and confusing ;-)

/cc @ronnielai @vishh @timstclair @ncdc @pmorie 