### PR TITLE
Add Envs to specV2 from specV1

### DIFF
--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -256,6 +256,7 @@ func ContainerSpecFromV1(specV1 *v1.ContainerSpec, aliases []string, namespace s
 		HasCustomMetrics: specV1.HasCustomMetrics,
 		Image:            specV1.Image,
 		Labels:           specV1.Labels,
+		Envs:             specV1.Envs,
 	}
 	if specV1.HasCpu {
 		specV2.Cpu.Limit = specV1.Cpu.Limit


### PR DESCRIPTION
Add `Envs` to `specV2` from `specV1`, so the cAdvisor remote `REST API 2.x` can get the env specs.
