### PR TITLE
[docs] Full URL to container_hints.go

### DIFF
--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -40,7 +40,7 @@ Per-container housekeeping is run once on each container cAdvisor tracks. This t
 
 ## Container Hints
 
-Container hints are a way to pass extra information about a container to cAdvisor. In this way cAdvisor can augment the stats it gathers. For more information on the container hints format see its [definition](container/raw/container_hints.go). Note that container hints are only used by the raw container driver today.
+Container hints are a way to pass extra information about a container to cAdvisor. In this way cAdvisor can augment the stats it gathers. For more information on the container hints format see its [definition](https://github.com/google/cadvisor/blob/master/container/common/container_hints.go). Note that container hints are only used by the raw container driver today.
 
 ```
 --container_hints="/etc/cadvisor/container_hints.json": location of the container hints file


### PR DESCRIPTION
Relative path links in github.com didn't work as expected
