### PR TITLE
Cherry pick #1359 to release-v0.23

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -275,7 +275,10 @@ func (h *dockerFsHandler) Usage() (uint64, uint64) {
 	if h.thinPoolWatcher != nil {
 		thinPoolUsage, err := h.thinPoolWatcher.GetUsage(h.deviceID)
 		if err != nil {
-			glog.Errorf("unable to get fs usage from thin pool for device %v: %v", h.deviceID, err)
+			// TODO: ideally we should keep track of how many times we failed to get the usage for this
+			// device vs how many refreshes of the cache there have been, and display an error e.g. if we've
+			// had at least 1 refresh and we still can't find the device.
+			glog.V(5).Infof("unable to get fs usage from thin pool for device %s: %v", h.deviceID, err)
 		} else {
 			baseUsage = thinPoolUsage
 			usage += thinPoolUsage

--- a/devicemapper/thin_pool_watcher.go
+++ b/devicemapper/thin_pool_watcher.go
@@ -74,7 +74,7 @@ func (w *ThinPoolWatcher) Start() {
 
 			// print latency for refresh
 			duration := time.Since(start)
-			glog.V(3).Infof("thin_ls(%d) took %s", start.Unix(), duration)
+			glog.V(5).Infof("thin_ls(%d) took %s", start.Unix(), duration)
 		}
 	}
 }
@@ -115,7 +115,7 @@ func (w *ThinPoolWatcher) Refresh() error {
 	}
 
 	if currentlyReserved {
-		glog.V(4).Infof("metadata for %v is currently reserved; releasing", w.poolName)
+		glog.V(5).Infof("metadata for %v is currently reserved; releasing", w.poolName)
 		_, err = w.dmsetup.Message(w.poolName, 0, releaseMetadataMessage)
 		if err != nil {
 			err = fmt.Errorf("error releasing metadata snapshot for %v: %v", w.poolName, err)
@@ -123,7 +123,7 @@ func (w *ThinPoolWatcher) Refresh() error {
 		}
 	}
 
-	glog.Infof("reserving metadata snapshot for thin-pool %v", w.poolName)
+	glog.V(5).Infof("reserving metadata snapshot for thin-pool %v", w.poolName)
 	// NOTE: "0" in the call below is for the 'sector' argument to 'dmsetup
 	// message'.  It's not needed for thin pools.
 	if output, err := w.dmsetup.Message(w.poolName, 0, reserveMetadataMessage); err != nil {


### PR DESCRIPTION
Cherry pick of #1359 to release-v0.23

Lower ThinPoolWatcher cache miss log level
Make ThinPoolWatcher loglevel consistent
