### PR TITLE
Filter internal kubernetes labels from Prometheus metrics

### DIFF
--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -65,7 +65,15 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 				},
 				CreationTime: time.Unix(1257894000, 0),
 				Labels: map[string]string{
-					"foo.label": "bar",
+					"foo.label":                                      "bar",
+					"io.kubernetes.container.hash":                   "e2b4295e",
+					"io.kubernetes.container.name":                   "POD",
+					"io.kubernetes.container.restartCount":           "0",
+					"io.kubernetes.container.terminationMessagePath": "",
+					"io.kubernetes.pod.name":                         "foo-bar-1985164696-y8y0d",
+					"io.kubernetes.pod.namespace":                    "qux",
+					"io.kubernetes.pod.terminationGracePeriod":       "30",
+					"io.kubernetes.pod.uid":                          "6a291e48-47c4-11e6-84a4-c81f66bdf8bd",
 				},
 				Envs: map[string]string{
 					"foo+env": "prod",

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -3,150 +3,150 @@
 cadvisor_version_info{cadvisorRevision="abcdef",cadvisorVersion="0.16.0",dockerVersion="1.8.1",kernelVersion="4.1.6-200.fc22.x86_64",osVersion="Fedora 22 (Twenty Two)"} 1
 # HELP container_cpu_cfs_periods_total Number of elapsed enforcement period intervals.
 # TYPE container_cpu_cfs_periods_total counter
-container_cpu_cfs_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 723
+container_cpu_cfs_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 723
 # HELP container_cpu_cfs_throttled_periods_total Number of throttled period intervals.
 # TYPE container_cpu_cfs_throttled_periods_total counter
-container_cpu_cfs_throttled_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 18
+container_cpu_cfs_throttled_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 18
 # HELP container_cpu_cfs_throttled_seconds_total Total time duration the container has been throttled.
 # TYPE container_cpu_cfs_throttled_seconds_total counter
-container_cpu_cfs_throttled_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.724314
+container_cpu_cfs_throttled_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.724314
 # HELP container_cpu_system_seconds_total Cumulative system cpu time consumed in seconds.
 # TYPE container_cpu_system_seconds_total counter
-container_cpu_system_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 7e-09
+container_cpu_system_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 7e-09
 # HELP container_cpu_usage_seconds_total Cumulative cpu time consumed per cpu in seconds.
 # TYPE container_cpu_usage_seconds_total counter
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu00",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2e-09
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu01",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3e-09
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu02",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4e-09
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu03",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",cpu="cpu00",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",cpu="cpu01",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",cpu="cpu02",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",cpu="cpu03",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5e-09
 # HELP container_cpu_user_seconds_total Cumulative user cpu time consumed in seconds.
 # TYPE container_cpu_user_seconds_total counter
-container_cpu_user_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 6e-09
+container_cpu_user_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 6e-09
 # HELP container_fs_io_current Number of I/Os currently in progress
 # TYPE container_fs_io_current gauge
-container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 42
-container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 47
+container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 42
+container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 47
 # HELP container_fs_io_time_seconds_total Cumulative count of seconds spent doing I/Os
 # TYPE container_fs_io_time_seconds_total counter
-container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.3e-08
-container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.8e-08
+container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.3e-08
+container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.8e-08
 # HELP container_fs_io_time_weighted_seconds_total Cumulative weighted I/O time in seconds
 # TYPE container_fs_io_time_weighted_seconds_total counter
-container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.4e-08
-container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.9e-08
+container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.4e-08
+container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.9e-08
 # HELP container_fs_limit_bytes Number of bytes that can be consumed by the container on this filesystem.
 # TYPE container_fs_limit_bytes gauge
-container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 22
-container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 37
+container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 22
+container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 37
 # HELP container_fs_read_seconds_total Cumulative count of seconds spent reading
 # TYPE container_fs_read_seconds_total counter
-container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2.7e-08
-container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.2e-08
+container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2.7e-08
+container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.2e-08
 # HELP container_fs_reads_merged_total Cumulative count of reads merged
 # TYPE container_fs_reads_merged_total counter
-container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 25
-container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 40
+container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 25
+container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 40
 # HELP container_fs_reads_total Cumulative count of reads completed
 # TYPE container_fs_reads_total counter
-container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 24
-container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 39
+container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 24
+container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 39
 # HELP container_fs_sector_reads_total Cumulative count of sector reads completed
 # TYPE container_fs_sector_reads_total counter
-container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 26
-container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 41
+container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 26
+container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 41
 # HELP container_fs_sector_writes_total Cumulative count of sector writes completed
 # TYPE container_fs_sector_writes_total counter
-container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 40
-container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 45
+container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 40
+container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 45
 # HELP container_fs_usage_bytes Number of bytes that are consumed by the container on this filesystem.
 # TYPE container_fs_usage_bytes gauge
-container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 23
-container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 38
+container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 23
+container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 38
 # HELP container_fs_write_seconds_total Cumulative count of seconds spent writing
 # TYPE container_fs_write_seconds_total counter
-container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.1e-08
-container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.6e-08
+container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.1e-08
+container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.6e-08
 # HELP container_fs_writes_merged_total Cumulative count of writes merged
 # TYPE container_fs_writes_merged_total counter
-container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 39
-container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 44
+container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 39
+container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 44
 # HELP container_fs_writes_total Cumulative count of writes completed
 # TYPE container_fs_writes_total counter
-container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 28
-container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 43
+container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 28
+container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 43
 # HELP container_last_seen Last time a container was seen by the exporter
 # TYPE container_last_seen gauge
-container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.426203694e+09
+container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.426203694e+09
 # HELP container_memory_cache Number of bytes of page cache memory.
 # TYPE container_memory_cache gauge
-container_memory_cache{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 14
+container_memory_cache{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 14
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
-container_memory_failcnt{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0
+container_memory_failcnt{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0
 # HELP container_memory_failures_total Cumulative count of memory allocation failures.
 # TYPE container_memory_failures_total counter
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgfault",zone_name="hello"} 10
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgmajfault",zone_name="hello"} 11
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgfault",zone_name="hello"} 12
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgmajfault",zone_name="hello"} 13
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgfault",zone_name="hello"} 10
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgmajfault",zone_name="hello"} 11
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgfault",zone_name="hello"} 12
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgmajfault",zone_name="hello"} 13
 # HELP container_memory_rss Size of RSS in bytes.
 # TYPE container_memory_rss gauge
-container_memory_rss{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 15
+container_memory_rss{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 15
 # HELP container_memory_swap Container swap usage in bytes.
 # TYPE container_memory_swap gauge
-container_memory_swap{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8192
+container_memory_swap{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8192
 # HELP container_memory_usage_bytes Current memory usage in bytes.
 # TYPE container_memory_usage_bytes gauge
-container_memory_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8
+container_memory_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8
 # HELP container_memory_working_set_bytes Current working set in bytes.
 # TYPE container_memory_working_set_bytes gauge
-container_memory_working_set_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 9
+container_memory_working_set_bytes{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 9
 # HELP container_network_receive_bytes_total Cumulative count of bytes received
 # TYPE container_network_receive_bytes_total counter
-container_network_receive_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 14
+container_network_receive_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 14
 # HELP container_network_receive_errors_total Cumulative count of errors encountered while receiving
 # TYPE container_network_receive_errors_total counter
-container_network_receive_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 16
+container_network_receive_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 16
 # HELP container_network_receive_packets_dropped_total Cumulative count of packets dropped while receiving
 # TYPE container_network_receive_packets_dropped_total counter
-container_network_receive_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 17
+container_network_receive_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 17
 # HELP container_network_receive_packets_total Cumulative count of packets received
 # TYPE container_network_receive_packets_total counter
-container_network_receive_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 15
+container_network_receive_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 15
 # HELP container_network_transmit_bytes_total Cumulative count of bytes transmitted
 # TYPE container_network_transmit_bytes_total counter
-container_network_transmit_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 18
+container_network_transmit_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 18
 # HELP container_network_transmit_errors_total Cumulative count of errors encountered while transmitting
 # TYPE container_network_transmit_errors_total counter
-container_network_transmit_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 20
+container_network_transmit_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 20
 # HELP container_network_transmit_packets_dropped_total Cumulative count of packets dropped while transmitting
 # TYPE container_network_transmit_packets_dropped_total counter
-container_network_transmit_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 21
+container_network_transmit_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 21
 # HELP container_network_transmit_packets_total Cumulative count of packets transmitted
 # TYPE container_network_transmit_packets_total counter
-container_network_transmit_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 19
+container_network_transmit_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 19
 # HELP container_scrape_error 1 if there was an error while getting container metrics, 0 otherwise
 # TYPE container_scrape_error gauge
 container_scrape_error 0
 # HELP container_spec_cpu_period CPU period of the container.
 # TYPE container_spec_cpu_period gauge
-container_spec_cpu_period{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 100000
+container_spec_cpu_period{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 100000
 # HELP container_spec_cpu_quota CPU quota of the container.
 # TYPE container_spec_cpu_quota gauge
-container_spec_cpu_quota{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 10000
+container_spec_cpu_quota{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 10000
 # HELP container_spec_cpu_shares CPU share of the container.
 # TYPE container_spec_cpu_shares gauge
-container_spec_cpu_shares{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1000
+container_spec_cpu_shares{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1000
 # HELP container_start_time_seconds Start time of the container since unix epoch in seconds.
 # TYPE container_start_time_seconds gauge
-container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
+container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
 # HELP container_tasks_state Number of tasks in given state
 # TYPE container_tasks_state gauge
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="iowaiting",zone_name="hello"} 54
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="running",zone_name="hello"} 51
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="sleeping",zone_name="hello"} 50
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="stopped",zone_name="hello"} 52
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="uninterruptible",zone_name="hello"} 53
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",state="iowaiting",zone_name="hello"} 54
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",state="running",zone_name="hello"} 51
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",state="sleeping",zone_name="hello"} 50
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",state="stopped",zone_name="hello"} 52
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",container_label_io_kubernetes_container_name="POD",container_label_io_kubernetes_pod_name="foo-bar-1985164696-y8y0d",container_label_io_kubernetes_pod_namespace="qux",id="testcontainer",image="test",name="testcontaineralias",state="uninterruptible",zone_name="hello"} 53
 # HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
 # TYPE http_request_duration_microseconds summary
 http_request_duration_microseconds{handler="prometheus",quantile="0.5"} 0


### PR DESCRIPTION
Kubernetes sets a bunch of internal labels on each docker container in
order to recover information in case of loss of the pod information
after a crash. These labels are not meaningful for Prometheus monitoring
and will create new timeseries in case they change (like restartCount).

With @jimmidyson's recent change to prefix labels with `container_label_`, users would have seen `container_label_io_kubernetes_container_hash`. 

@fabxc @timstclair @vishh 