### PR TITLE
Provide option to control Prometheus labels

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -89,8 +89,11 @@ func RegisterHandlers(mux httpmux.Mux, containerManager manager.Manager, httpAut
 	return nil
 }
 
-func RegisterPrometheusHandler(mux httpmux.Mux, containerManager manager.Manager, prometheusEndpoint string, containerNameToLabelsFunc metrics.ContainerNameToLabelsFunc) {
-	collector := metrics.NewPrometheusCollector(containerManager, containerNameToLabelsFunc)
+// RegisterPrometheusHandler creates a new PrometheusCollector, registers it
+// on the global registry and configures the provided HTTP mux to handle the
+// given Prometheus endpoint.
+func RegisterPrometheusHandler(mux httpmux.Mux, containerManager manager.Manager, prometheusEndpoint string, f metrics.ContainerLabelsFunc) {
+	collector := metrics.NewPrometheusCollector(containerManager, f)
 	prometheus.MustRegister(collector)
 	mux.Handle(prometheusEndpoint, prometheus.Handler())
 }

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -180,10 +180,10 @@ var (
 )
 
 func TestPrometheusCollector(t *testing.T) {
-	c := NewPrometheusCollector(testSubcontainersInfoProvider{}, func(name string) map[string]string {
-		return map[string]string{
-			"zone.name": "hello",
-		}
+	c := NewPrometheusCollector(testSubcontainersInfoProvider{}, func(container *info.ContainerInfo) map[string]string {
+		s := DefaultContainerLabels(container)
+		s["zone.name"] = "hello"
+		return s
 	})
 	prometheus.MustRegister(c)
 	defer prometheus.Unregister(c)
@@ -212,7 +212,7 @@ func testPrometheusCollector(t *testing.T, c *PrometheusCollector, metricsFile s
 			continue
 		}
 		if want != gotLines[i] {
-			t.Fatalf("want %s, got %s", want, gotLines[i])
+			t.Fatalf("unexpected metric line\nwant: %s\nhave: %s", want, gotLines[i])
 		}
 	}
 }
@@ -250,10 +250,10 @@ func TestPrometheusCollector_scrapeFailure(t *testing.T) {
 		shouldFail:         true,
 	}
 
-	c := NewPrometheusCollector(provider, func(name string) map[string]string {
-		return map[string]string{
-			"zone.name": "hello",
-		}
+	c := NewPrometheusCollector(provider, func(container *info.ContainerInfo) map[string]string {
+		s := DefaultContainerLabels(container)
+		s["zone.name"] = "hello"
+		return s
 	})
 	prometheus.MustRegister(c)
 	defer prometheus.Unregister(c)


### PR DESCRIPTION
This change generalizes the existing ContainerNameToLabelsFunc to allow the user to fully control all labels attached to exported Prometheus metrics. The existing behavior is available as DefaultContainerLabels and is used if no custom function is provided.

This will allow Kubernetes to filter out its internal Docker labels.

Fixes #1312. Once Kubernetes provides a custom function to filter its internal labels implemented in kubernetes/kubernetes#31064.

PTAL @jimmidyson @fabxc @vishh @timstclair 

@vishh Tim and I discussed that the current label settings classify as bug and that this should be included in Kubernetes v1.4.