### PR TITLE
Update prometheus.io URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 - Enabled CPU load tracking (experimental).
 
 ## 0.11.0 (2015-03-27)
-- Export all stats as [Prometheus](http://prometheus.io/) metrics.
+- Export all stats as [Prometheus](https://prometheus.io/) metrics.
 - Initial support for [events](docs/api.md): creation, deletion, and OOM.
 - Adding machine UUID information.
 - Beta release of the cAdvisor [2.0 API](docs/api_v2.md).

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -8,7 +8,7 @@ cAdvisor supports exporting stats to various storage driver plugins. To enable a
 - [ElasticSearch](https://www.elastic.co/). See the [documentation](elasticsearch.md) for usage and examples.
 - [InfluxDB](https://influxdb.com/). See the [documentation](influxdb.md) for usage and examples.
 - [Kafka](http://kafka.apache.org/). See the [documentation](kafka.md) for usage.
-- [Prometheus](http://prometheus.io). See the [documentation](prometheus.md) for usage and examples.
+- [Prometheus](https://prometheus.io). See the [documentation](prometheus.md) for usage and examples.
 - [Redis](http://redis.io/)
 - [StatsD](https://github.com/etsy/statsd)
 - `stdout` - write stats to standard output.

--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -1,8 +1,8 @@
 # Monitoring cAdvisor with Prometheus
 
-cAdvisor exposes container statistics as [Prometheus](http://prometheus.io) metrics out of the box. By default, these metrics are served under the `/metrics` HTTP endpoint. This endpoint may be customized by setting the `-prometheus_endpoint` command-line flag.
+cAdvisor exposes container statistics as [Prometheus](https://prometheus.io) metrics out of the box. By default, these metrics are served under the `/metrics` HTTP endpoint. This endpoint may be customized by setting the `-prometheus_endpoint` command-line flag.
 
-To monitor cAdvisor with Prometheus, simply configure one or more jobs in Prometheus which scrape the relevant cAdvisor processes at that metrics endpoint. For details, see Prometheus's [Configuration](http://prometheus.io/docs/operating/configuration/) documentation, as well as the [Getting started](http://prometheus.io/docs/introduction/getting_started/) guide.
+To monitor cAdvisor with Prometheus, simply configure one or more jobs in Prometheus which scrape the relevant cAdvisor processes at that metrics endpoint. For details, see Prometheus's [Configuration](https://prometheus.io/docs/operating/configuration/) documentation, as well as the [Getting started](https://prometheus.io/docs/introduction/getting_started/) guide.
 
 # Examples
 [CenturyLink Labs](https://labs.ctl.io/) did an excellent write up on [Monitoring Docker services with Prometheus +cAdvisor](https://labs.ctl.io/monitoring-docker-services-with-prometheus/)


### PR DESCRIPTION
prometheus.io is HTTPS only for some time now.