### PR TITLE
Cache the Docker thin pool name

### DIFF
--- a/container/docker/docker.go
+++ b/container/docker/docker.go
@@ -37,7 +37,10 @@ func Status() (v1.DockerStatus, error) {
 	if err != nil {
 		return v1.DockerStatus{}, err
 	}
+	return StatusFromDockerInfo(dockerInfo), nil
+}
 
+func StatusFromDockerInfo(dockerInfo dockertypes.Info) v1.DockerStatus {
 	out := v1.DockerStatus{}
 	out.Version = VersionString()
 	out.APIVersion = APIVersionString()
@@ -53,7 +56,7 @@ func Status() (v1.DockerStatus, error) {
 	for _, v := range dockerInfo.DriverStatus {
 		out.DriverStatus[v[0]] = v[1]
 	}
-	return out, nil
+	return out
 }
 
 func Images() ([]v1.DockerImage, error) {

--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -107,6 +107,7 @@ type dockerFactory struct {
 
 	ignoreMetrics container.MetricSet
 
+	thinPoolName    string
 	thinPoolWatcher *devicemapper.ThinPoolWatcher
 
 	zfsWatcher *zfs.ZfsWatcher
@@ -136,6 +137,7 @@ func (self *dockerFactory) NewContainerHandler(name string, inHostNamespace bool
 		metadataEnvs,
 		self.dockerVersion,
 		self.ignoreMetrics,
+		self.thinPoolName,
 		self.thinPoolWatcher,
 		self.zfsWatcher,
 	)
@@ -323,12 +325,18 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics c
 		return fmt.Errorf("failed to get cgroup subsystems: %v", err)
 	}
 
-	var thinPoolWatcher *devicemapper.ThinPoolWatcher
+	var (
+		thinPoolWatcher *devicemapper.ThinPoolWatcher
+		thinPoolName    string
+	)
 	if storageDriver(dockerInfo.Driver) == devicemapperStorageDriver {
 		thinPoolWatcher, err = startThinPoolWatcher(dockerInfo)
 		if err != nil {
 			glog.Errorf("devicemapper filesystem stats will not be reported: %v", err)
 		}
+
+		status := StatusFromDockerInfo(*dockerInfo)
+		thinPoolName = status.DriverStatus[dockerutil.DriverStatusPoolName]
 	}
 
 	var zfsWatcher *zfs.ZfsWatcher
@@ -350,6 +358,7 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics c
 		storageDriver:      storageDriver(dockerInfo.Driver),
 		storageDir:         RootDir(),
 		ignoreMetrics:      ignoreMetrics,
+		thinPoolName:       thinPoolName,
 		thinPoolWatcher:    thinPoolWatcher,
 		zfsWatcher:         zfsWatcher,
 	}


### PR DESCRIPTION
Cache the Docker thin pool name in the dockerFactory and pass it to each Docker container handler,
instead of calling `docker info` each time a new container handler is created, as the thin pool name
is extremely unlikely to change.

@derekwaynecarr @pmorie @sjenning @timothysc 
