### PR TITLE
Cosmetic styling change: break long words in container name title

### DIFF
--- a/pages/assets/styles/containers.css
+++ b/pages/assets/styles/containers.css
@@ -20,7 +20,10 @@
     white-space: pre-wrap;
 }
 .isolation-title {
-	color:#FFFFFF;
+    color:#FFFFFF;
+}
+.page-header h1 {
+    word-wrap: break-word;
 }
 .table-row {
     font-family: "courier", "monospace";


### PR DESCRIPTION
No one likes horizontal scrollbars.

Before:

![screenshot_2016-09-06_14-06-03](https://cloud.githubusercontent.com/assets/3817380/18271545/4ededfd8-743b-11e6-9990-5e07c1ebaf4f.png)

After:

![screenshot_2016-09-06_14-05-54](https://cloud.githubusercontent.com/assets/3817380/18271544/4edc250e-743b-11e6-9aa5-98750090a725.png)
