### PR TITLE
RFC: Client/server storage driver over RPC

### DIFF
--- a/storage/plugin/client/client.go
+++ b/storage/plugin/client/client.go
@@ -1,0 +1,86 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"flag"
+	"fmt"
+	"net/rpc"
+
+	"github.com/golang/glog"
+	info "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/storage"
+)
+
+func init() {
+	storage.RegisterStorageDriver("plugin", NewClient)
+}
+
+var socket = flag.String("storage_driver_socket", "/var/run/cadvisor-storage.sock", "Unix domain socket to connect to for storage driver plugin.")
+
+type pluginClient struct {
+	client  *rpc.Client
+	version string
+}
+
+func NewClient() (storage.StorageDriver, error) {
+	// Connect to server.
+	client, err := rpc.Dial("unix", *socket)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to server: %v", err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			client.Close()
+		}
+	}()
+
+	// Check the plugin version.
+	var version string
+	if err := client.Call("StoragePlugin.Version", false, &version); err != nil {
+		return nil, fmt.Errorf("failed to get plugin version: %v", err)
+	}
+	// Currently only version 1.0.0 is supported.
+	if version != "1.0.0" {
+		return nil, fmt.Errorf("incompatible plugin version: %s", version)
+	}
+
+	cleanup = false
+	return &pluginClient{client, version}, nil
+}
+
+func (c *pluginClient) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+	if stats == nil {
+		return nil
+	}
+
+	req := info.ContainerInfo{
+		ContainerReference: ref,
+		Stats:              []*info.ContainerStats{stats},
+	}
+
+	err := c.client.Call("StoragePlugin.AddStats", req, nil)
+	if err == rpc.ErrShutdown {
+		// TODO: Figure out a better way of handling this permanent error.
+		glog.Exitf("Storage plugin connection terminated.")
+	}
+
+	return err
+}
+
+func (c *pluginClient) Close() error {
+	return c.client.Close()
+}

--- a/storage/plugin/plugin_test.go
+++ b/storage/plugin/plugin_test.go
@@ -1,0 +1,87 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/storage/plugin/client"
+	"github.com/google/cadvisor/storage/plugin/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientServer(t *testing.T) {
+	statsChan := make(chan v1.ContainerInfo, 2)
+	driver := &testDriver{statsChan}
+
+	const socket = "cadvisor-test.sock"
+	flag.Set("storage_driver_socket", socket)
+
+	s, err := server.Start(socket, driver)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+
+	client, err := client.NewClient()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, client.Close())
+	}()
+
+	ref := v1.ContainerReference{
+		Id:      "12345",
+		Name:    "test",
+		Aliases: []string{"test-alias"},
+	}
+	stats := v1.ContainerStats{
+		Timestamp: time.Now(),
+		Cpu: v1.CpuStats{
+			LoadAverage: 12,
+		},
+	}
+
+	// Send the stats.
+	assert.NoError(t, client.AddStats(ref, &stats))
+
+	const timeout = 30 * time.Second
+	select {
+	case v := <-statsChan:
+		assert.Equal(t, ref, v.ContainerReference, "Received ContainerReference")
+		assert.Len(t, v.Stats, 1)
+		assert.Equal(t, stats, *v.Stats[0], "Received ContainerStats")
+	case <-time.After(timeout):
+		assert.Fail(t, "Timed out after %s", timeout.String())
+	}
+}
+
+type testDriver struct {
+	statsChan chan v1.ContainerInfo
+}
+
+func (d *testDriver) AddStats(ref v1.ContainerReference, stats *v1.ContainerStats) error {
+	d.statsChan <- v1.ContainerInfo{
+		ContainerReference: ref,
+		Stats:              []*v1.ContainerStats{stats},
+	}
+	return nil
+}
+
+func (d *testDriver) Close() error {
+	return nil
+}

--- a/storage/plugin/server/server.go
+++ b/storage/plugin/server/server.go
@@ -1,0 +1,139 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/rpc"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/storage"
+)
+
+type StoragePlugin struct {
+	driver storage.StorageDriver
+}
+
+type server struct {
+	*StoragePlugin
+
+	conn io.Closer
+}
+
+var (
+	// The default socket to listen on.
+	DefaultSocket = "/var/run/cadvisor-storage.sock"
+
+	// Signals to listen on to shut down the server.
+	TerminationSignals = []os.Signal{syscall.SIGINT, syscall.SIGKILL, syscall.SIGHUP}
+
+	// Whether to silence log messages.
+	DisableLogging = false
+)
+
+// Add flags used by the plugin.
+func AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&DefaultSocket, "socket", DefaultSocket, "The unix domain socket to listen on.")
+}
+
+// Run starts the server using the given driver and default socket. It waits for a termination
+// signal and then cleans up the connection. A simple plugin implementation only needs to call this
+// method.
+func Run(driver storage.StorageDriver) {
+	s, err := Start(DefaultSocket, driver)
+	if err != nil {
+		logf("Error: failed to start server: %v", err)
+		return
+	}
+	defer s.Close()
+
+	logf("Started server listening on %s", DefaultSocket)
+
+	WaitForTermination()
+}
+
+// Start exposes finer controls over running the plugin server. It starts the server with the given
+// driver and socket. It is the caller's responsibility to run as long as needed
+// (e.g. WaitForTermination) and close the server when done.
+func Start(socket string, driver storage.StorageDriver) (io.Closer, error) {
+	plugin := &StoragePlugin{driver}
+	rpc.Register(plugin)
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		return nil, fmt.Errorf("could not listen on %s: %v", socket, err)
+	}
+	go rpc.Accept(listener)
+
+	return &server{plugin, listener}, nil
+}
+
+// WaitForTermination blocks until a termination signal is received.
+func WaitForTermination() {
+	stop := make(chan os.Signal)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGKILL, syscall.SIGHUP)
+	<-stop
+}
+
+// AddStats implements the main RPC call that receives stats pushes from cAdvisor.
+func (s *StoragePlugin) AddStats(info *v1.ContainerInfo, _ *bool) error {
+	if info == nil {
+		return errors.New("nil request received")
+	}
+	if len(info.Stats) == 0 {
+		return fmt.Errorf("no stats in request %+v", *info)
+	}
+
+	for _, stats := range info.Stats {
+		err := s.driver.AddStats(info.ContainerReference, stats)
+		if err != nil {
+			return fmt.Errorf("error adding stats: %v", err)
+		}
+	}
+	return nil
+}
+
+// Version reports the version of the plugin API implemented by this server.
+func (s *StoragePlugin) Version(_ bool, version *string) error {
+	*version = "1.0.0"
+	return nil
+}
+
+// Close the server and cleanup its resources.
+func (s *server) Close() error {
+	err := s.driver.Close()
+	cerr := s.conn.Close()
+	if cerr != nil {
+		if err != nil {
+			err = fmt.Errorf("%v; %v", cerr, err)
+		} else {
+			err = cerr
+		}
+	}
+	return err
+}
+
+func logf(format string, v ...interface{}) {
+	if !DisableLogging {
+		log.Printf(format, v...)
+	}
+}

--- a/storage/plugin/server/server.go
+++ b/storage/plugin/server/server.go
@@ -45,7 +45,7 @@ var (
 	DefaultSocket = "/var/run/cadvisor-storage.sock"
 
 	// Signals to listen on to shut down the server.
-	TerminationSignals = []os.Signal{syscall.SIGINT, syscall.SIGKILL, syscall.SIGHUP}
+	TerminationSignals = []os.Signal{syscall.SIGINT, syscall.SIGHUP}
 
 	// Whether to silence log messages.
 	DisableLogging = false
@@ -90,7 +90,7 @@ func Start(socket string, driver storage.StorageDriver) (io.Closer, error) {
 // WaitForTermination blocks until a termination signal is received.
 func WaitForTermination() {
 	stop := make(chan os.Signal)
-	signal.Notify(stop, syscall.SIGINT, syscall.SIGKILL, syscall.SIGHUP)
+	signal.Notify(stop, TerminationSignals...)
 	<-stop
 }
 

--- a/storagedriver.go
+++ b/storagedriver.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/google/cadvisor/storage/elasticsearch"
 	_ "github.com/google/cadvisor/storage/influxdb"
 	_ "github.com/google/cadvisor/storage/kafka"
+	_ "github.com/google/cadvisor/storage/plugin/client"
 	_ "github.com/google/cadvisor/storage/redis"
 	_ "github.com/google/cadvisor/storage/statsd"
 	_ "github.com/google/cadvisor/storage/stdout"


### PR DESCRIPTION
Proof-of-concept storage driver over RPC. A server implementation is as simple as:

``` go
package main

import "github.com/google/cadvisor/storage/plugin/server"

func main() {
  driver := newStorageDriver() // Implements the StorageDriver interface
  server.Run(driver)
}
```

Then, start cAdvisor with the `--storage_driver=plugin` option to connect.

Eventually I'd like to move all storage drivers to this model. It could either be the users responsibility to run them, or the binary could be passed to cAdvisor (through a flag), and cAdvisor would handle starting (and restarting, if needed) the server.

For https://github.com/google/cadvisor/issues/1458

/cc @vishh @ncdc 
