### PR TITLE
Add udp and udp6 network statistics

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/cadvisor/version"
 
 	"crypto/tls"
+
 	"github.com/golang/glog"
 )
 
@@ -60,13 +61,17 @@ var collectorKey = flag.String("collector_key", "", "Key for the collector's cer
 var (
 	// Metrics to be ignored.
 	// Tcp metrics are ignored by default.
-	ignoreMetrics metricSetValue = metricSetValue{container.MetricSet{container.NetworkTcpUsageMetrics: struct{}{}}}
+	ignoreMetrics metricSetValue = metricSetValue{container.MetricSet{
+		container.NetworkTcpUsageMetrics: struct{}{},
+		container.NetworkUdpUsageMetrics: struct{}{},
+	}}
 
 	// List of metrics that can be ignored.
 	ignoreWhitelist = container.MetricSet{
 		container.DiskUsageMetrics:       struct{}{},
 		container.NetworkUsageMetrics:    struct{}{},
 		container.NetworkTcpUsageMetrics: struct{}{},
+		container.NetworkUdpUsageMetrics: struct{}{},
 	}
 )
 
@@ -98,7 +103,7 @@ func (ml *metricSetValue) Set(value string) error {
 }
 
 func init() {
-	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'disk', 'network', 'tcp'. Note: tcp is disabled by default due to high CPU usage.")
+	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'disk', 'network', 'tcp', 'udp'. Note: tcp and udp are disabled by default due to high CPU usage.")
 }
 
 func main() {

--- a/cadvisor_test.go
+++ b/cadvisor_test.go
@@ -28,6 +28,12 @@ func TestTcpMetricsAreDisabledByDefault(t *testing.T) {
 	assert.True(t, ignoreMetrics.Has(container.NetworkTcpUsageMetrics))
 }
 
+func TestUdpMetricsAreDisabledByDefault(t *testing.T) {
+	assert.True(t, ignoreMetrics.Has(container.NetworkUdpUsageMetrics))
+	flag.Parse()
+	assert.True(t, ignoreMetrics.Has(container.NetworkUdpUsageMetrics))
+}
+
 func TestIgnoreMetrics(t *testing.T) {
 	tests := []struct {
 		value    string

--- a/container/factory.go
+++ b/container/factory.go
@@ -48,6 +48,7 @@ const (
 	DiskUsageMetrics       MetricKind = "disk"
 	NetworkUsageMetrics    MetricKind = "network"
 	NetworkTcpUsageMetrics MetricKind = "tcp"
+	NetworkUdpUsageMetrics MetricKind = "udp"
 	AppMetrics             MetricKind = "app"
 )
 

--- a/container/libcontainer/helpers_test.go
+++ b/container/libcontainer/helpers_test.go
@@ -15,6 +15,7 @@
 package libcontainer
 
 import (
+	"os"
 	"testing"
 
 	info "github.com/google/cadvisor/info/v1"
@@ -59,5 +60,29 @@ func TestScanInterfaceStats(t *testing.T) {
 		if v != stats[i] {
 			t.Errorf("Expected %#v, got %#v", v, stats[i])
 		}
+	}
+}
+
+func TestScanUDPStats(t *testing.T) {
+	udpStatsFile := "testdata/procnetudp"
+	r, err := os.Open(udpStatsFile)
+	if err != nil {
+		t.Errorf("failure opening %s: %v", udpStatsFile, err)
+	}
+
+	stats, err := scanUdpStats(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var udpstats = info.UdpStat{
+		Listen:   2,
+		Dropped:  4,
+		RxQueued: 10,
+		TxQueued: 11,
+	}
+
+	if stats != udpstats {
+		t.Errorf("Expected %#v, got %#v", udpstats, stats)
 	}
 }

--- a/container/libcontainer/testdata/procnetudp
+++ b/container/libcontainer/testdata/procnetudp
@@ -1,0 +1,3 @@
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops             
+  1: 00000000:07D3 00000000:0000 07 00000000:00000000 00:00000000 00000000     0        0 16583 2 ffff8800b4549400 0         
+  21: 00000000:A841 00000000:0000 07 0000000A:0000000B 00:00000000 00000000  1000        0 114299623 2 ffff880338477800 4     

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -386,6 +386,10 @@ type NetworkStats struct {
 	Tcp TcpStat `json:"tcp"`
 	// TCP6 connection stats (Established, Listen...)
 	Tcp6 TcpStat `json:"tcp6"`
+	// UDP connection stats
+	Udp UdpStat `json:"udp"`
+	// UDP6 connection stats
+	Udp6 UdpStat `json:"udp6"`
 }
 
 type TcpStat struct {
@@ -411,6 +415,20 @@ type TcpStat struct {
 	Listen uint64
 	// Count of TCP connections in state "Closing"
 	Closing uint64
+}
+
+type UdpStat struct {
+	// Count of UDP sockets in state "Listen"
+	Listen uint64
+
+	// Count of UDP packets dropped by the IP stack
+	Dropped uint64
+
+	// Count of packets Queued for Receieve
+	RxQueued uint64
+
+	// Count of packets Queued for Transmit
+	TxQueued uint64
 }
 
 type FsStats struct {

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -269,6 +269,10 @@ type NetworkStats struct {
 	Tcp TcpStat `json:"tcp"`
 	// TCP6 connection stats (Established, Listen...)
 	Tcp6 TcpStat `json:"tcp6"`
+	// UDP connection stats
+	Udp v1.UdpStat `json:"udp"`
+	// UDP6 connection stats
+	Udp6 v1.UdpStat `json:"udp6"`
 }
 
 // Instantaneous CPU stats


### PR DESCRIPTION
This is a first crack at adding UDP stats collection support.
One possible issue here is that the dropped packets is a coutner.
if many sockets come and go withint he container, the sum of the
dropped packet counters will not be monotonically increasing.
