### PR TITLE
Cadvisor Configure Root Path

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/fs"
 	cadvisorhttp "github.com/google/cadvisor/http"
 	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/utils/sysfs"
@@ -124,7 +125,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet, &collectorHttpClient)
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet, &collectorHttpClient, fs.DefaultRootPath)
 	if err != nil {
 		glog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -88,7 +88,7 @@ func TestFileNotExist(t *testing.T) {
 
 func TestDirDiskUsage(t *testing.T) {
 	as := assert.New(t)
-	fsInfo, err := NewFsInfo(Context{})
+	fsInfo, err := NewFsInfo(Context{RootPath: DefaultRootPath})
 	as.NoError(err)
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	as.NoError(err)
@@ -108,7 +108,7 @@ func TestDirDiskUsage(t *testing.T) {
 
 func TestDirInodeUsage(t *testing.T) {
 	as := assert.New(t)
-	fsInfo, err := NewFsInfo(Context{})
+	fsInfo, err := NewFsInfo(Context{RootPath: DefaultRootPath})
 	as.NoError(err)
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	as.NoError(err)
@@ -199,7 +199,7 @@ func TestAddSystemRootLabel(t *testing.T) {
 			labels:     map[string]string{},
 			partitions: map[string]partition{},
 		}
-		fsInfo.addSystemRootLabel(tt.mounts)
+		fsInfo.addSystemRootLabel(DefaultRootPath, tt.mounts)
 
 		if source, ok := fsInfo.labels[LabelSystemRoot]; !ok || source != tt.expected {
 			t.Errorf("case %d: expected mount source '%s', got '%s'", i, tt.expected, source)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -127,7 +127,7 @@ type Manager interface {
 }
 
 // New takes a memory storage and returns a new manager.
-func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, ignoreMetricsSet container.MetricSet, collectorHttpClient *http.Client) (Manager, error) {
+func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, ignoreMetricsSet container.MetricSet, collectorHttpClient *http.Client, rootPath string) (Manager, error) {
 	if memoryCache == nil {
 		return nil, fmt.Errorf("manager requires memory storage")
 	}
@@ -154,7 +154,8 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 			Driver:       dockerStatus.Driver,
 			DriverStatus: dockerStatus.DriverStatus,
 		},
-		RktPath: rktPath,
+		RktPath:  rktPath,
+		RootPath: rootPath,
 	}
 	fsInfo, err := fs.NewFsInfo(context)
 	if err != nil {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/docker"
 	containertest "github.com/google/cadvisor/container/testing"
+	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
 	itest "github.com/google/cadvisor/info/v1/test"
 	"github.com/google/cadvisor/info/v2"
@@ -300,7 +301,7 @@ func TestDockerContainersInfo(t *testing.T) {
 }
 
 func TestNewNilManager(t *testing.T) {
-	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient)
+	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient, fs.DefaultRootPath)
 	if err == nil {
 		t.Fatalf("Expected nil manager to return error")
 	}


### PR DESCRIPTION
Cadvisor allows the RootPath to be configured.  The RootPath is used to determine which filesystem is the RootFs.