### PR TITLE
fixed go vet bug

### DIFF
--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -115,7 +115,7 @@ func expectManagerWithContainers(containers []string, query *info.ContainerInfoR
 			h.On("GetSpec").Return(
 				spec,
 				nil,
-			)
+			).Once()
 			handlerMap[h.Name] = h
 		},
 		t,
@@ -216,10 +216,9 @@ func TestGetContainerInfoV2Failure(t *testing.T) {
 
 	// Make GetSpec fail on /c2
 	mockErr := fmt.Errorf("intentional GetSpec failure")
-	failingHandler := containertest.NewMockContainerHandler(failing)
-	failingHandler.On("GetSpec").Return(info.ContainerSpec{}, mockErr)
-	failingHandler.On("Exists").Return(true)
-	*handlerMap[failing] = *failingHandler
+	handlerMap[failing].GetSpec() // Use up default GetSpec call, and replace below
+	handlerMap[failing].On("GetSpec").Return(info.ContainerSpec{}, mockErr)
+	handlerMap[failing].On("Exists").Return(true)
 	m.containers[namespacedContainerName{Name: failing}].lastUpdatedTime = time.Time{} // Force GetSpec.
 
 	infos, err := m.GetContainerInfoV2("/", options)


### PR DESCRIPTION
This was probably due to a change in go vet.  It does not allow Mutex's to be copied.  Testify.Mock contains a Mutex, and cannot be copied.  Because of this, we cannot change a testify.Mock object after it is added to a list for all viewers of the list.  Since we cannot change objects after they are added to the list, I had to pass a boolean to the function that initially creates the list.  When true, the boolean causes GetSpec to return an error, rather than the normal return value, and cases Exists to return true.