### PR TITLE
Revert "Merge pull request #1503 from dashpole/configure_root_path"

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/google/cadvisor/container"
-	"github.com/google/cadvisor/fs"
 	cadvisorhttp "github.com/google/cadvisor/http"
 	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/utils/sysfs"
@@ -125,7 +124,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet, &collectorHttpClient, fs.DefaultRootPath)
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet, &collectorHttpClient)
 	if err != nil {
 		glog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -43,7 +43,6 @@ const (
 	LabelSystemRoot   = "root"
 	LabelDockerImages = "docker-images"
 	LabelRktImages    = "rkt-images"
-	DefaultRootPath   = "/"
 )
 
 // The maximum number of `du` and `find` tasks that can be running at once.
@@ -88,8 +87,6 @@ type Context struct {
 	// docker root directory.
 	Docker  DockerContext
 	RktPath string
-	// The "rootFs" filesystem is the filesystem that contains the RootPath
-	RootPath string
 }
 
 type DockerContext struct {
@@ -118,15 +115,7 @@ func NewFsInfo(context Context) (FsInfo, error) {
 	fsInfo.addDockerImagesLabel(context, mounts)
 
 	glog.Infof("Filesystem partitions: %+v", fsInfo.partitions)
-	rootDevice, err := fsInfo.GetDirFsDevice(context.RootPath)
-	if err != nil {
-		return nil, fmt.Errorf("error trying to get filesystem Device for rootPath %v: err: %v", context.RootPath, err)
-	}
-	rootMountpoint, err := fsInfo.GetMountpointForDevice(rootDevice.Device)
-	if err != nil {
-		return nil, fmt.Errorf("error trying to get MountPoint for Root Device: %v, err: %v", rootDevice, err)
-	}
-	fsInfo.addSystemRootLabel(rootMountpoint, mounts)
+	fsInfo.addSystemRootLabel(mounts)
 	return fsInfo, nil
 }
 
@@ -198,10 +187,10 @@ func (self *RealFsInfo) getDockerDeviceMapperInfo(context DockerContext) (string
 	}, nil
 }
 
-// addSystemRootLabel attempts to determine which device contains the mount for rootMountpoint.
-func (self *RealFsInfo) addSystemRootLabel(rootMountpoint string, mounts []*mount.Info) {
+// addSystemRootLabel attempts to determine which device contains the mount for /.
+func (self *RealFsInfo) addSystemRootLabel(mounts []*mount.Info) {
 	for _, m := range mounts {
-		if m.Mountpoint == rootMountpoint {
+		if m.Mountpoint == "/" {
 			self.partitions[m.Source] = partition{
 				fsType:     m.Fstype,
 				mountpoint: m.Mountpoint,

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -88,7 +88,7 @@ func TestFileNotExist(t *testing.T) {
 
 func TestDirDiskUsage(t *testing.T) {
 	as := assert.New(t)
-	fsInfo, err := NewFsInfo(Context{RootPath: DefaultRootPath})
+	fsInfo, err := NewFsInfo(Context{})
 	as.NoError(err)
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	as.NoError(err)
@@ -108,7 +108,7 @@ func TestDirDiskUsage(t *testing.T) {
 
 func TestDirInodeUsage(t *testing.T) {
 	as := assert.New(t)
-	fsInfo, err := NewFsInfo(Context{RootPath: DefaultRootPath})
+	fsInfo, err := NewFsInfo(Context{})
 	as.NoError(err)
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	as.NoError(err)
@@ -199,7 +199,7 @@ func TestAddSystemRootLabel(t *testing.T) {
 			labels:     map[string]string{},
 			partitions: map[string]partition{},
 		}
-		fsInfo.addSystemRootLabel(DefaultRootPath, tt.mounts)
+		fsInfo.addSystemRootLabel(tt.mounts)
 
 		if source, ok := fsInfo.labels[LabelSystemRoot]; !ok || source != tt.expected {
 			t.Errorf("case %d: expected mount source '%s', got '%s'", i, tt.expected, source)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -127,7 +127,7 @@ type Manager interface {
 }
 
 // New takes a memory storage and returns a new manager.
-func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, ignoreMetricsSet container.MetricSet, collectorHttpClient *http.Client, rootPath string) (Manager, error) {
+func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, ignoreMetricsSet container.MetricSet, collectorHttpClient *http.Client) (Manager, error) {
 	if memoryCache == nil {
 		return nil, fmt.Errorf("manager requires memory storage")
 	}
@@ -154,8 +154,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 			Driver:       dockerStatus.Driver,
 			DriverStatus: dockerStatus.DriverStatus,
 		},
-		RktPath:  rktPath,
-		RootPath: rootPath,
+		RktPath: rktPath,
 	}
 	fsInfo, err := fs.NewFsInfo(context)
 	if err != nil {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/docker"
 	containertest "github.com/google/cadvisor/container/testing"
-	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
 	itest "github.com/google/cadvisor/info/v1/test"
 	"github.com/google/cadvisor/info/v2"
@@ -301,7 +300,7 @@ func TestDockerContainersInfo(t *testing.T) {
 }
 
 func TestNewNilManager(t *testing.T) {
-	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient, fs.DefaultRootPath)
+	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient)
 	if err == nil {
 		t.Fatalf("Expected nil manager to return error")
 	}


### PR DESCRIPTION
Undo this commit
This reverts commit 719df516db2581e41a753f739148c46aebb4cd4a, reversing
changes made to cae5bfaee63f62fdf374519f04bf24e02a742f87.

We decided that we could get filesystem information from the filesystem that contains a specific path in a better way.