### PR TITLE
Supporting IO statistics for persistent volumes for docker containers.

### DIFF
--- a/container/common/helpers.go
+++ b/container/common/helpers.go
@@ -45,7 +45,7 @@ func DebugInfo(watches map[string][]string) map[string][]string {
 	return out
 }
 
-func GetSpec(cgroupPaths map[string]string, machineInfoFactory info.MachineInfoFactory, hasNetwork, hasFilesystem bool) (info.ContainerSpec, error) {
+func GetSpec(cgroupPaths map[string]string, machineInfoFactory info.MachineInfoFactory, hasNetwork, hasFilesystem bool, hasVolumeIo bool) (info.ContainerSpec, error) {
 	var spec info.ContainerSpec
 
 	// Assume unified hierarchy containers.
@@ -116,6 +116,7 @@ func GetSpec(cgroupPaths map[string]string, machineInfoFactory info.MachineInfoF
 
 	spec.HasNetwork = hasNetwork
 	spec.HasFilesystem = hasFilesystem
+	spec.HasVolumeIo = hasVolumeIo
 
 	if blkioRoot, ok := cgroupPaths["blkio"]; ok && utils.FileExists(blkioRoot) {
 		spec.HasDiskIo = true

--- a/container/docker/drivers/vmdk_stats.go
+++ b/container/docker/drivers/vmdk_stats.go
@@ -13,35 +13,33 @@
 // limitations under the License.
 
 // Handler for VMDK Docker volume driver.
-package docker
+package drivers
 
 import (
-	"path"
-	"strings"
 	info "github.com/google/cadvisor/info/v1"
 	docker "github.com/docker/engine-api/client"
 	"golang.org/x/net/context"
 )
 
-IO_STATS = 'iostats'
+const io_stats="iostats"
 
 type VmdkDriver struct {
 }
 
-func newVmdkDriver() *VmdkDriver {
-	return &VmdkDrier{}
+func NewVmdkDriver() *VmdkDriver {
+	return &VmdkDriver{}
 }
 
-func (driver *VmdkDriver) GetStats(client docker.Client, name string) (VolumeIoStats, error) {
+func (driver *VmdkDriver) GetStats(client *docker.Client, name string) (info.VolumeIoStats, error) {
 	volume, err := client.VolumeInspect(context.Background(), name)	
 
-	if !err && volume.Status[IO_STATS] {
-		return ConvertToVolumeIoStats(volume.Status), Nil
+	if err == nil && volume.Status[io_stats] != nil {
+		return ConvertToVolumeIoStats(volume.Status), nil
 	} else {
-		return Nil, err
+		return info.VolumeIoStats{}, err
 	}
 }
 
-func ConvertToVolumeIoStats(status map[string]interface{}) VolumeIoStats {
-
+func ConvertToVolumeIoStats(status map[string]interface{}) info.VolumeIoStats {
+	return info.VolumeIoStats{}
 }

--- a/container/docker/drivers/vmdk_stats.go
+++ b/container/docker/drivers/vmdk_stats.go
@@ -1,0 +1,47 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Handler for VMDK Docker volume driver.
+package docker
+
+import (
+	"path"
+	"strings"
+	info "github.com/google/cadvisor/info/v1"
+	docker "github.com/docker/engine-api/client"
+	"golang.org/x/net/context"
+)
+
+IO_STATS = 'iostats'
+
+type VmdkDriver struct {
+}
+
+func newVmdkDriver() *VmdkDriver {
+	return &VmdkDrier{}
+}
+
+func (driver *VmdkDriver) GetStats(client docker.Client, name string) (VolumeIoStats, error) {
+	volume, err := client.VolumeInspect(context.Background(), name)	
+
+	if !err && volume.Status[IO_STATS] {
+		return ConvertToVolumeIoStats(volume.Status), Nil
+	} else {
+		return Nil, err
+	}
+}
+
+func ConvertToVolumeIoStats(status map[string]interface{}) VolumeIoStats {
+
+}

--- a/container/docker/drivers/vmdk_stats.go
+++ b/container/docker/drivers/vmdk_stats.go
@@ -23,6 +23,7 @@ import (
 
 const io_stats="iostats"
 
+// Empty for now.
 type VmdkVolumeStats struct {
 }
 
@@ -35,13 +36,7 @@ func (stats *VmdkVolumeStats) GetStats(client *docker.Client, name string) (info
 	volume, err := client.VolumeInspect(context.Background(), name)
 
 	if err == nil && volume.Status[io_stats] != nil {
-                io := info.VolumeIoStats{}
-		for k, v := range volume.Status[io_stats].(map[string]interface{}) {
-			io.IoStats[k] = v
-		}
-		io.Name = name
-
-		return io, nil
+		return info.VolumeIoStats{Volume: name, Stats:volume.Status[io_stats].(map[string]interface{})}, nil
 	} else {
 		return info.VolumeIoStats{}, err
 	}

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -130,7 +130,7 @@ func (self *rawContainerHandler) Cleanup() {}
 func (self *rawContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	const hasNetwork = false
 	hasFilesystem := isRootCgroup(self.name) || len(self.externalMounts) > 0
-	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, hasNetwork, hasFilesystem)
+	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, hasNetwork, hasFilesystem, false)
 	if err != nil {
 		return spec, err
 	}

--- a/container/rkt/handler.go
+++ b/container/rkt/handler.go
@@ -194,7 +194,7 @@ func (handler *rktContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	hasNetwork := handler.hasNetwork && !handler.ignoreMetrics.Has(container.NetworkUsageMetrics)
 	hasFilesystem := !handler.ignoreMetrics.Has(container.DiskUsageMetrics)
 
-	spec, err := common.GetSpec(handler.cgroupPaths, handler.machineInfoFactory, hasNetwork, hasFilesystem)
+	spec, err := common.GetSpec(handler.cgroupPaths, handler.machineInfoFactory, hasNetwork, hasFilesystem, false)
 
 	spec.Labels = handler.labels
 

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -512,7 +512,7 @@ type ContainerStats struct {
 	TaskStats LoadStats `json:"task_stats,omitempty"`
 
 	// Volume stats
-	VolumeIo  []VolumeIOStats `json:"volumeio,omitempty"`
+	VolumeIo  []VolumeIoStats `json:"volumeio,omitempty"`
 
 	//Custom metrics from all collectors
 	CustomMetrics map[string][]MetricVal `json:"custom_metrics,omitempty"`

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -511,6 +511,9 @@ type ContainerStats struct {
 	// Task load stats
 	TaskStats LoadStats `json:"task_stats,omitempty"`
 
+	// Volume stats
+	VolumeIo  []VolumeIOStats `json:"volumeio,omitempty"`
+
 	//Custom metrics from all collectors
 	CustomMetrics map[string][]MetricVal `json:"custom_metrics,omitempty"`
 }
@@ -604,4 +607,20 @@ type OomKillEventData struct {
 
 	// The name of the killed process
 	ProcessName string `json:"process_name"`
+}
+
+type VolumeIoStats struct {
+	VolName      string `json:"name,omitempty"`
+	AvgRdsPerSec uint64 `json:"avg_rds_per_sec,omitempty"`
+	AvgWrsPerSec uint64 `json:"avg_wrs_per_sec,omitempty"`
+	AvgInProgRds uint64 `json:"avg_inprog_rds,omitempty"`
+	AvgInProgWrs uint64 `json:"avg_inprog_wrs,omitempty"`
+	AvgRdLat     uint64 `json:"avg_rd_latency,omitempty"`
+	AvgWrLat     uint64 `json:"avg_wr_latency,omitempty"`
+	AvgRdReqSz   uint64 `json:"avg_rd_req_sz,omitempty"`
+	AvgWrReqSz   uint64 `json:"avg_Wr_req_sz,omitempty"`
+	RdLatency    uint64 `json:"rd_latency,omitempty"`
+	WrLatency    uint64 `json:"wr_latency,omitempty"`
+	RdRate       uint64 `json:"rd_rate,omitempty"`
+	WrRate       uint64 `json:"wr_rate,omitempty"`
 }

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -609,18 +609,20 @@ type OomKillEventData struct {
 	ProcessName string `json:"process_name"`
 }
 
+// Volume IO stats
 type VolumeIoStats struct {
-	VolName      string `json:"name,omitempty"`
-	AvgRdsPerSec uint64 `json:"avg_rds_per_sec,omitempty"`
-	AvgWrsPerSec uint64 `json:"avg_wrs_per_sec,omitempty"`
-	AvgInProgRds uint64 `json:"avg_inprog_rds,omitempty"`
-	AvgInProgWrs uint64 `json:"avg_inprog_wrs,omitempty"`
-	AvgRdLat     uint64 `json:"avg_rd_latency,omitempty"`
-	AvgWrLat     uint64 `json:"avg_wr_latency,omitempty"`
-	AvgRdReqSz   uint64 `json:"avg_rd_req_sz,omitempty"`
-	AvgWrReqSz   uint64 `json:"avg_Wr_req_sz,omitempty"`
-	RdLatency    uint64 `json:"rd_latency,omitempty"`
-	WrLatency    uint64 `json:"wr_latency,omitempty"`
-	RdRate       uint64 `json:"rd_rate,omitempty"`
-	WrRate       uint64 `json:"wr_rate,omitempty"`
+	Name         string `json:"name,omitempty"`
+	IoStats      map[string]interface{}
 }
+//AvgRdsPerSec uint64 `json:"avg_rds_per_sec,omitempty"`
+//AvgWrsPerSec uint64 `json:"avg_wrs_per_sec,omitempty"`
+//AvgInProgRds uint64 `json:"avg_inprog_rds,omitempty"`
+//AvgInProgWrs uint64 `json:"avg_inprog_wrs,omitempty"`
+//AvgRdLat     uint64 `json:"avg_rd_latency,omitempty"`
+//AvgWrLat     uint64 `json:"avg_wr_latency,omitempty"`
+//AvgRdReqSz   uint64 `json:"avg_rd_req_sz,omitempty"`
+//AvgWrReqSz   uint64 `json:"avg_Wr_req_sz,omitempty"`
+//RdLatency    uint64 `json:"rd_latency,omitempty"`
+//WrLatency    uint64 `json:"wr_latency,omitempty"`
+//RdRate       uint64 `json:"rd_rate,omitempty"`
+//WrRate       uint64 `json:"wr_rate,omitempty"`

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -62,6 +62,7 @@ type ContainerSpec struct {
 
 	// HasDiskIo when true, indicates that DiskIo stats will be available.
 	HasDiskIo bool `json:"has_diskio"`
+	HasVolumeIo bool `json:"has_volumeio"`
 
 	HasCustomMetrics bool         `json:"has_custom_metrics"`
 	CustomMetrics    []MetricSpec `json:"custom_metrics,omitempty"`
@@ -611,18 +612,6 @@ type OomKillEventData struct {
 
 // Volume IO stats
 type VolumeIoStats struct {
-	Name         string `json:"name,omitempty"`
-	IoStats      map[string]interface{}
+	Volume         string `json:"volume,omitempty"`
+	Stats          map[string]interface{} `json:"stats,omitempty"`
 }
-//AvgRdsPerSec uint64 `json:"avg_rds_per_sec,omitempty"`
-//AvgWrsPerSec uint64 `json:"avg_wrs_per_sec,omitempty"`
-//AvgInProgRds uint64 `json:"avg_inprog_rds,omitempty"`
-//AvgInProgWrs uint64 `json:"avg_inprog_wrs,omitempty"`
-//AvgRdLat     uint64 `json:"avg_rd_latency,omitempty"`
-//AvgWrLat     uint64 `json:"avg_wr_latency,omitempty"`
-//AvgRdReqSz   uint64 `json:"avg_rd_req_sz,omitempty"`
-//AvgWrReqSz   uint64 `json:"avg_Wr_req_sz,omitempty"`
-//RdLatency    uint64 `json:"rd_latency,omitempty"`
-//WrLatency    uint64 `json:"wr_latency,omitempty"`
-//RdRate       uint64 `json:"rd_rate,omitempty"`
-//WrRate       uint64 `json:"wr_rate,omitempty"`

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -125,7 +125,7 @@ type DeprecatedContainerStats struct {
 	Load    v1.LoadStats `json:"load_stats,omitempty"`
 	// Volume stats
 	HasVolumeIo bool     `json:"has_custom_metrics"`
-	VolumeIo  []v1.VolumeIOStats `json:"volumeio,omitempty"`
+	VolumeIo  []v1.VolumeIoStats `json:"volumeio,omitempty"`
 	// Custom Metrics
 	HasCustomMetrics bool                      `json:"has_custom_metrics"`
 	CustomMetrics    map[string][]v1.MetricVal `json:"custom_metrics,omitempty"`
@@ -150,7 +150,7 @@ type ContainerStats struct {
 	// Task load statistics
 	Load *v1.LoadStats `json:"load_stats,omitempty"`
 	// Volume stats
-	VolumeIo  []v1.VolumeIOStats `json:"volumeio,omitempty"`
+	VolumeIo  []v1.VolumeIoStats `json:"volumeio,omitempty"`
 	// Custom Metrics
 	CustomMetrics map[string][]v1.MetricVal `json:"custom_metrics,omitempty"`
 }

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -94,6 +94,7 @@ type ContainerSpec struct {
 	HasNetwork    bool `json:"has_network"`
 	HasFilesystem bool `json:"has_filesystem"`
 	HasDiskIo     bool `json:"has_diskio"`
+	HasVolumeIo   bool `json:"has_volumeio"`
 
 	// Image name used for this container.
 	Image string `json:"image,omitempty"`
@@ -124,7 +125,7 @@ type DeprecatedContainerStats struct {
 	HasLoad bool         `json:"has_load"`
 	Load    v1.LoadStats `json:"load_stats,omitempty"`
 	// Volume stats
-	HasVolumeIo bool     `json:"has_custom_metrics"`
+	HasVolumeIo bool     `json:"has_volumeio"`
 	VolumeIo  []v1.VolumeIoStats `json:"volumeio,omitempty"`
 	// Custom Metrics
 	HasCustomMetrics bool                      `json:"has_custom_metrics"`

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -123,6 +123,9 @@ type DeprecatedContainerStats struct {
 	// Task load statistics
 	HasLoad bool         `json:"has_load"`
 	Load    v1.LoadStats `json:"load_stats,omitempty"`
+	// Volume stats
+	HasVolumeIo bool     `json:"has_custom_metrics"`
+	VolumeIo  []v1.VolumeIOStats `json:"volumeio,omitempty"`
 	// Custom Metrics
 	HasCustomMetrics bool                      `json:"has_custom_metrics"`
 	CustomMetrics    map[string][]v1.MetricVal `json:"custom_metrics,omitempty"`
@@ -146,6 +149,8 @@ type ContainerStats struct {
 	Filesystem *FilesystemStats `json:"filesystem,omitempty"`
 	// Task load statistics
 	Load *v1.LoadStats `json:"load_stats,omitempty"`
+	// Volume stats
+	VolumeIo  []v1.VolumeIOStats `json:"volumeio,omitempty"`
 	// Custom Metrics
 	CustomMetrics map[string][]v1.MetricVal `json:"custom_metrics,omitempty"`
 }

--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -137,6 +137,9 @@ func ContainerStatsFromV1(spec *v1.ContainerSpec, stats []*v1.ContainerStats) []
 		if spec.HasDiskIo {
 			stat.DiskIo = &val.DiskIo
 		}
+		if spec.HasVolumeIo {
+			stat.VolumeIo = val.VolumeIo
+		}
 		if spec.HasCustomMetrics {
 			stat.CustomMetrics = val.CustomMetrics
 		}
@@ -157,6 +160,7 @@ func DeprecatedStatsFromV1(cont *v1.ContainerInfo) []DeprecatedContainerStats {
 			HasNetwork:       cont.Spec.HasNetwork,
 			HasFilesystem:    cont.Spec.HasFilesystem,
 			HasDiskIo:        cont.Spec.HasDiskIo,
+			HasVolumeIo:      cont.Spec.HasVolumeIo,
 			HasCustomMetrics: cont.Spec.HasCustomMetrics,
 		}
 		if stat.HasCpu {
@@ -180,6 +184,9 @@ func DeprecatedStatsFromV1(cont *v1.ContainerInfo) []DeprecatedContainerStats {
 		}
 		if stat.HasDiskIo {
 			stat.DiskIo = val.DiskIo
+		}
+		if stat.HasVolumeIo {
+			stat.VolumeIo = val.VolumeIo
 		}
 		if stat.HasCustomMetrics {
 			stat.CustomMetrics = val.CustomMetrics
@@ -254,6 +261,7 @@ func ContainerSpecFromV1(specV1 *v1.ContainerSpec, aliases []string, namespace s
 		HasFilesystem:    specV1.HasFilesystem,
 		HasNetwork:       specV1.HasNetwork,
 		HasDiskIo:        specV1.HasDiskIo,
+		HasVolumeIo:      specV1.HasVolumeIo,
 		HasCustomMetrics: specV1.HasCustomMetrics,
 		Image:            specV1.Image,
 		Labels:           specV1.Labels,


### PR DESCRIPTION
Changes to support collecting IO stats from third party volume drivers for persistent volumes (that provide Docker's volume driver API).

The changes are in cadvisor code to allow passing volume IO stats, which by far are more accurate than whats collected inside of a guest OS and provide more stats than what can be got from inside the guest. That's the primary reason why volume IO stats from the volume provider is needed, to get a precise and accurate picture of the workload.

The change also includes code to collect IO stats from the docker vsphere volume driver (modified version to provide IO stats per volume via GET API). More volume drivers can be supported by adding a new file in containers/docker/drivers folder.

The format of the number and type of IO stats isn't specified by cAdvisor as its assumed that each volume driver should be allowed to specify what ever stats it can provide without being restrictive on the number and type of stats. The stats provided by the driver is only expected to be a map string-key and value pair provided by each driver.

Sample output for a docker container with a single persistent volume attached:

---

{"/docker/b7c7be300d75fc3dd3fbe8caa2dba851e5f2511b3ef0c12b72adfe1910b5ac07":[{"timestamp":"2016-10-25T21:44:00.841287216-07:00","has_cpu":true,"cpu":{"usage":{"total":9629700,"per_cpu_usage":[9629700],"user":0,"system":0},"cfs":{"periods":0,"throttled_periods":0,"throttled_time":0},"load_average":0},"has_diskio":true,"diskio":{},"has_memory":true,"memory":{"usage":61440,"cache":4096,"rss":57344,"swap":0,"working_set":61440,"failcnt":0,"container_data":{"pgfault":307,"pgmajfault":0},"hierarchical_data":{"pgfault":307,"pgmajfault":0}},"has_network":true,"network":{"interfaces":[{"name":"eth0","rx_bytes":21678,"rx_packets":221,"rx_errors":0,"rx_dropped":0,"tx_bytes":648,"tx_packets":8,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"has_filesystem":true,"filesystem":[{"device":"/dev/disk/by-uuid/3226d197-5a89-483c-aa7f-ca09183ee44f","type":"vfs","capacity":31571570688,"usage":0,"base_usage":0,"available":0,"has_inodes":false,"inodes":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"has_load":false,"load_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0},

volume IO for persistent volume "ca-vol-2"
"has_volumeio":true,"volumeio":[{"volume":"ca-vol-2","stats":{"avgInProgRds":"0","avgInProgWrs":"0","avgRd/s":"0","avgRdLat(ms)":"0","avgRdRqSz(bytes)":"0","avgWr/s":"0","avgWrLat(ms)":"0","avgWrRqSz(bytes)":"0","largeSeeks(\u003e8192 lbns)":"0","medSeeks(64 - 8192 lbns)":"0","rdLat(Âµs)":"0","smallSeeks(\u003c64 lbns)":"0","volRdRate(KBps)":"0","volWrRate(KBps)":"0","wrLat(Âµs)":"0"}}],

"has_custom_metrics":false},{"timestamp":"2016-10-25T21:44:02.671391794-07:00","has_cpu":true,"cpu":{"usage":{"total":9629700,"per_cpu_usage":[9629700],"user":0,"system":0},
......

---
