### PR TITLE
set envs when converting to v2 spec

### DIFF
--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -259,6 +259,7 @@ func ContainerSpecFromV1(specV1 *v1.ContainerSpec, aliases []string, namespace s
 		HasCustomMetrics: specV1.HasCustomMetrics,
 		Image:            specV1.Image,
 		Labels:           specV1.Labels,
+		Envs:             specV1.Envs,
 	}
 	if specV1.HasCpu {
 		specV2.Cpu.Limit = specV1.Cpu.Limit

--- a/info/v2/conversion_test.go
+++ b/info/v2/conversion_test.go
@@ -26,12 +26,14 @@ import (
 var (
 	timestamp = time.Date(1987, time.August, 10, 0, 0, 0, 0, time.UTC)
 	labels    = map[string]string{"foo": "bar"}
+	envs      = map[string]string{"foo": "bar"}
 )
 
 func TestContanierSpecFromV1(t *testing.T) {
 	v1Spec := v1.ContainerSpec{
 		CreationTime: timestamp,
 		Labels:       labels,
+		Envs:         envs,
 		HasCpu:       true,
 		Cpu: v1.CpuSpec{
 			Limit:    2048,
@@ -63,6 +65,7 @@ func TestContanierSpecFromV1(t *testing.T) {
 	expectedV2Spec := ContainerSpec{
 		CreationTime: timestamp,
 		Labels:       labels,
+		Envs:         envs,
 		HasCpu:       true,
 		Cpu: CpuSpec{
 			Limit:    2048,


### PR DESCRIPTION
The `Envs` field was never being set in the v1->v2 container spec conversion. 