### PR TITLE
Publish public version of release instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ assets:
 
 release:
 	@echo ">> building release binaries"
-	@RELEASE=true ./build/build.sh
+	@./build/release.sh
 
 docker:
 	@docker build -t cadvisor:$(shell git rev-parse --short HEAD) -f deploy/Dockerfile .

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+VERSION=$( git describe --tags --dirty --abbrev=14 | sed -E 's/-([0-9]+)-g/.\1+/' )
+# Only allow releases of tagged versions.
+TAGGED='^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)[0-9]*)?$'
+if [[ ! "$VERSION" =~ $TAGGED ]]; then
+  echo "Error: Only tagged versions are allowed for releases" >&2
+  echo "Found: $VERSION" >&2
+  exit 1
+fi
+
+# Don't include hostname with release builds
+if ! git_user="$(git config --get user.email)"; then
+  echo "Error: git user not set, use:"
+  echo "git config user.email <email>"
+  exit 1
+fi
+
+# Build the release.
+export BUILD_USER="$git_user"
+export BUILD_DATE=$( date +%Y%m%d ) # Release date is only to day-granularity
+export GO_CMD="build" # Don't use cached build objects for releases.
+export VERBOSE=true
+build/build.sh
+
+# Build the docker image
+echo ">> building cadvisor docker image"
+docker_tag="google/cadvisor:$VERSION"
+gcr_tag="gcr.io/google_containers/cadvisor:$VERSION"
+docker build -t $docker_tag -t $gcr_tag -f deploy/Dockerfile .
+
+echo
+echo "Release info:"
+echo "VERSION=$VERSION"
+sha1sum --tag cadvisor
+md5sum --tag cadvisor
+echo "docker image: $docker_tag"
+echo "gcr.io image: $gcr_tag"
+
+exit 0

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -47,28 +47,11 @@ Command: `make release`
 - Try to build it from the release branch, since we include that in the binary version
 - Verify the ldflags output, in particular check the Version, BuildUser, and GoVersion are expected
 
-Once the build is complete, record the sh1 and md5 hashes:
+Once the build is complete, check the VERSION and note the sha1 and md5 hashes.
 
-```
-$ sha1sum cadvisor
-$ md5sum cadvisor
-```
+## 4. Push the Docker images
 
-Update the github release by uploading the release binary, and filling in the hashes.
-
-## 4. Build & push the Docker images
-
-```
-$ VERSION=v0.23.1  # Example
-$ docker build -t google/cadvisor:$VERSION -f deploy/Dockerfile .
-...
-Successfully built a811aa33809f
-$ docker tag google/cadvisor:$VERSION \
-  gcr.io/google_containers/cadvisor:$VERSION
-```
-
-### 4.a Push to Docker Hub
-
+Docker Hub:
 ```
 $ docker login
 Username: ****
@@ -77,7 +60,7 @@ $ docker push google/cadvisor:$VERSION
 $ docker logout # Good practice with shared account
 ```
 
-### 4.b Push to Google Container Registry
+Google Container Registry:
 
 ```
 $ gcloud auth login <account>
@@ -100,6 +83,7 @@ Go to https://github.com/google/cadvisor/releases and click "Draft a new release
 - Body should start with release notes (from CHANGELOG.md)
 - Next is the Docker image: `google/cadvisor:$VERSION`
 - Next are the binary hashes (from step 3)
+- Upload the binary build in step 3
 - If this is an alpha or beta release, mark the release as a "pre-release"
 - Click publish when done
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,3 +1,117 @@
 # cAdvisor Release Instructions
 
-See https://docs.google.com/a/google.com/document/d/102wNLDR9ls5NGRpBIfhQaD53q97DVLfmmuILLUE4AIk (Google internal-only)
+Google internal-only version: [cAdvisor Release Instructions](http://go/cadvisor-release-instructions)
+
+## 1. Send Release PR
+
+Example: https://github.com/google/cadvisor/pull/1281
+
+Add release notes to [CHANGELOG.md](../../CHANGELOG.md)
+
+- Tip: Use a github PR search to find changes since the last release
+  `is:pr is:merged merged:>2016-04-21`
+
+## 2. Create the release tag
+
+### 2.a Create the release branch (only for major/minor releases)
+
+Skip this step for patch releases.
+
+```
+# Sync to HEAD, or the commit to branch at
+$ git fetch upstream && git checkout upstream/master
+# Create the branch
+$ git branch release-v0.XX
+# Push it to upstream
+$ git push git@github.com:google/cadvisor.git release-v0.XX
+```
+
+### 2.b Tag the release
+
+For a release of minor version XX, patch version YY:
+
+```
+# Checkout the release branch
+$ git fetch upstream && git checkout upstream/release-v0.XX
+# Tag the release commit. If you aren't signing, ommit the -s
+$ git tag -s -a v0.XX.YY
+# Push it to upstream
+$ git push git@github.com:google/cadvisor.git v0.XX.YY
+```
+
+## 3. Build release binary
+
+Command: `make release`
+
+- Make sure your git client is synced to the release cut point
+- Try to build it from the release branch, since we include that in the binary version
+- Verify the ldflags output, in particular check the Version, BuildUser, and GoVersion are expected
+
+Once the build is complete, record the sh1 and md5 hashes:
+
+```
+$ sha1sum cadvisor
+$ md5sum cadvisor
+```
+
+Update the github release by uploading the release binary, and filling in the hashes.
+
+## 4. Build & push the Docker images
+
+```
+$ VERSION=v0.23.1  # Example
+$ docker build -t google/cadvisor:$VERSION -f deploy/Dockerfile .
+...
+Successfully built a811aa33809f
+$ docker tag google/cadvisor:$VERSION \
+  gcr.io/google_containers/cadvisor:$VERSION
+```
+
+### 4.a Push to Docker Hub
+
+```
+$ docker login
+Username: ****
+Password: ****
+$ docker push google/cadvisor:$VERSION
+$ docker logout # Good practice with shared account
+```
+
+### 4.b Push to Google Container Registry
+
+```
+$ gcloud auth login <account>
+...
+Go to the following link in your browser:
+
+    https://accounts.google.com/o/oauth2/auth?<redacted>
+
+Enter verification code: ****
+$ gcloud docker push gcr.io/google_containers/cadvisor:$VERSION
+$ gcloud auth revoke # Log out of shared account
+```
+
+## 5. Cut the release
+
+Go to https://github.com/google/cadvisor/releases and click "Draft a new release"
+
+- "Tag version" and "Release title" should be preceded by 'v' and then the version. Select the tag pushed in step 2.b
+- Copy an old release as a template (e.g. github.com/google/cadvisor/releases/tag/v0.23.1)
+- Body should start with release notes (from CHANGELOG.md)
+- Next is the Docker image: `google/cadvisor:$VERSION`
+- Next are the binary hashes (from step 3)
+- If this is an alpha or beta release, mark the release as a "pre-release"
+- Click publish when done
+
+## 6. Finalize the release
+
+Once you are satisfied with the release quality (consider waiting a week for bug reports to come in), it is time to promote the release to *latest*
+
+1. Edit the github release a final time, and uncheck the "Pre-release" checkbox
+2. Tag the docker & gcr.io releases with the latest version
+   ```
+   $ docker pull google/cadvisor:$VERSION
+   $ docker tag -f google/cadvisor:$VERSION google/cadvisor:latest
+   $ docker tag -f google/cadvisor:$VERSION gcr.io/google_containers/cadvisor:latest
+   ```
+3. Repeat steps 4.a and 4.b to push the image tagged with latest


### PR DESCRIPTION
I've gotten a lot of requests to share the release instructions document (publicly), so I scrubbed the google-internal details & converted to markdown. I kept a link to the internal version (which includes some details for Googlers who handle the push).