### PR TITLE
alpine linux thin-provisioning-tools thin_ls location

### DIFF
--- a/devicemapper/util.go
+++ b/devicemapper/util.go
@@ -39,7 +39,7 @@ func ThinLsBinaryPresent() (string, error) {
 		err        error
 	)
 
-	for _, path := range []string{"/bin", "/usr/sbin/", "/usr/bin"} {
+	for _, path := range []string{"/bin", "/sbin/", "/usr/sbin/", "/usr/bin"} {
 		// try paths for non-containerized operation
 		// note: thin_ls is most likely a symlink to pdata_tools
 		thinLsPath = filepath.Join(path, "thin_ls")


### PR DESCRIPTION
https://pkgs.alpinelinux.org/package/edge/testing/x86_64/thin-provisioning-tools install thin_ls in /sbin/

bash-4.3# which thin_ls
/sbin/thin_ls