### PR TITLE
Fixes partion name, v2 TCP stats

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -346,7 +346,7 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
 	return filesystems, nil
 }
 
-var partitionRegex = regexp.MustCompile(`^(?:(?:s|xv)d[a-z]+\d*|dm-\d+)$`)
+var partitionRegex = regexp.MustCompile(`^(?:(?:s|v|xv)d[a-z]+\d*|dm-\d+)$`)
 
 func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
 	diskStatsMap := make(map[string]DiskStats)

--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -119,6 +119,8 @@ func ContainerStatsFromV1(spec *v1.ContainerSpec, stats []*v1.ContainerStats) []
 		if spec.HasNetwork {
 			// TODO: Handle TcpStats
 			stat.Network = &NetworkStats{
+				Tcp:        TcpStat(val.Network.Tcp),
+				Tcp6:       TcpStat(val.Network.Tcp6),
 				Interfaces: val.Network.Interfaces,
 			}
 		}


### PR DESCRIPTION
1. Fix https://github.com/google/cadvisor/issues/1523 - partitionRegex can not fit usual device name
2. Fix https://github.com/google/cadvisor/issues/1546 - cadvisor do gather but not copy tcpstat of container
3. Handle restarting a Manager instance. This may be necessary if a new disk device is mounted after the cAdvisor manager is started.