### PR TITLE
ZFS Filesystem stats support

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -33,6 +33,7 @@ import (
 	docker "github.com/docker/engine-api/client"
 	dockercontainer "github.com/docker/engine-api/types/container"
 	"github.com/golang/glog"
+	zfs "github.com/mistifyio/go-zfs"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	cgroupfs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	libcontainerconfigs "github.com/opencontainers/runc/libcontainer/configs"
@@ -185,6 +186,12 @@ func newDockerContainerHandler(
 		}
 
 		poolName = status.DriverStatus[dockerutil.DriverStatusPoolName]
+	case zfsStorageDriver:
+		status, err := Status()
+		if err != nil {
+			return nil, fmt.Errorf("unable to determine docker status: %v", err)
+		}
+		poolName = path.Join(status.DriverStatus[dockerutil.DriverStatusParentDataset], rwLayerID)
 	}
 
 	// TODO: extract object mother method
@@ -357,12 +364,19 @@ func (self *dockerContainerHandler) getFsStats(stats *info.ContainerStats) error
 		// Device has to be the pool name to correlate with the device name as
 		// set in the machine info filesystems.
 		device = self.poolName
-	case aufsStorageDriver, overlayStorageDriver, zfsStorageDriver:
+	case aufsStorageDriver, overlayStorageDriver:
 		deviceInfo, err := self.fsInfo.GetDirFsDevice(self.rootfsStorageDir)
 		if err != nil {
 			return fmt.Errorf("unable to determine device info for dir: %v: %v", self.rootfsStorageDir, err)
 		}
 		device = deviceInfo.Device
+	case zfsStorageDriver:
+		fsStat, err := self.getZFSFsStats()
+		if err != nil {
+			return fmt.Errorf("unable to determine filesystem stats for zfs: %v: %v", self.poolName, err)
+		}
+		stats.Filesystem = append(stats.Filesystem, fsStat)
+		return nil
 	default:
 		return nil
 	}
@@ -451,4 +465,20 @@ func (self *dockerContainerHandler) Exists() bool {
 
 func (self *dockerContainerHandler) Type() container.ContainerType {
 	return container.ContainerTypeDocker
+}
+
+func (self *dockerContainerHandler) getZFSFsStats() (info.FsStats, error) {
+	d, err := zfs.GetDataset(self.poolName)
+	if err != nil {
+		return info.FsStats{}, err
+	}
+	f := info.FsStats{
+		Device:    self.poolName,
+		Type:      "zfs",
+		Limit:     d.Avail,
+		Usage:     d.Referenced,
+		BaseUsage: d.Logicalused,
+	}
+
+	return f, nil
 }

--- a/utils/docker/docker.go
+++ b/utils/docker/docker.go
@@ -23,11 +23,12 @@ import (
 )
 
 const (
-	DockerInfoDriver         = "Driver"
-	DockerInfoDriverStatus   = "DriverStatus"
-	DriverStatusPoolName     = "Pool Name"
-	DriverStatusDataLoopFile = "Data loop file"
-	DriverStatusMetadataFile = "Metadata file"
+	DockerInfoDriver          = "Driver"
+	DockerInfoDriverStatus    = "DriverStatus"
+	DriverStatusPoolName      = "Pool Name"
+	DriverStatusDataLoopFile  = "Data loop file"
+	DriverStatusMetadataFile  = "Metadata file"
+	DriverStatusParentDataset = "Parent Dataset"
 )
 
 func DriverStatusValue(status [][2]string, target string) string {

--- a/vendor/github.com/mistifyio/go-zfs/utils.go
+++ b/vendor/github.com/mistifyio/go-zfs/utils.go
@@ -117,6 +117,8 @@ func (ds *Dataset) parseLine(line []string) error {
 		err = setUint(&ds.Written, val)
 	case "logicalused":
 		err = setUint(&ds.Logicalused, val)
+	case "referenced":
+		err = setUint(&ds.Referenced, val)
 	}
 	return err
 }

--- a/vendor/github.com/mistifyio/go-zfs/zfs.go
+++ b/vendor/github.com/mistifyio/go-zfs/zfs.go
@@ -35,6 +35,7 @@ type Dataset struct {
 	Usedbydataset uint64
 	Logicalused   uint64
 	Quota         uint64
+	Referenced    uint64
 }
 
 // InodeType is the type of inode as reported by Diff


### PR DESCRIPTION
This is a quick and dirty patch to get some ZFS filesystem stats. Without this, I get errors in getFsStats as rootfsStorageDir is not set in container/docker/handler.go 

This is just the bare minimum for usage stats.  I edited the vendored go-zfs to get the referenced field from zfs to get the full container disk usage.  I may be misunderstanding the meaning of that field in `info.FsStats`, however.  If this field - or others - are needed, I can do a separate PR to go-zf. (I worked on the initial implementation of go-zfs, FWIW.)

With ZFS, depending on your dataset, querying the underlying device is not actually useful.  I'm running on a raidz of 3-5 physical drives.