### PR TITLE
Lower verbosity level for spamming log

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -509,7 +509,7 @@ func (self *version2_1) HandleRequest(requestType string, request []string, m ma
 			}
 			contStats[name] = v2.ContainerInfo{
 				Spec:  v2.ContainerSpecFromV1(&cont.Spec, cont.Aliases, cont.Namespace),
-				Stats: v2.ContainerStatsFromV1(&cont.Spec, cont.Stats),
+				Stats: v2.ContainerStatsFromV1(name, &cont.Spec, cont.Stats),
 			}
 		}
 		return writeResult(contStats, w)

--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -96,7 +96,7 @@ func MachineStatsFromV1(cont *v1.ContainerInfo) []MachineStats {
 	return stats
 }
 
-func ContainerStatsFromV1(spec *v1.ContainerSpec, stats []*v1.ContainerStats) []*ContainerStats {
+func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []*v1.ContainerStats) []*ContainerStats {
 	newStats := make([]*ContainerStats, 0, len(stats))
 	var last *v1.ContainerStats
 	for _, val := range stats {
@@ -131,9 +131,9 @@ func ContainerStatsFromV1(spec *v1.ContainerSpec, stats []*v1.ContainerStats) []
 					BaseUsageBytes:  &val.Filesystem[0].BaseUsage,
 					InodeUsage:      &val.Filesystem[0].Inodes,
 				}
-			} else if len(val.Filesystem) > 1 {
+			} else if len(val.Filesystem) > 1 && containerName != "/" {
 				// Cannot handle multiple devices per container.
-				glog.V(2).Infof("failed to handle multiple devices for container. Skipping Filesystem stats")
+				glog.V(2).Infof("failed to handle multiple devices for container %s. Skipping Filesystem stats", containerName)
 			}
 		}
 		if spec.HasDiskIo {

--- a/info/v2/conversion_test.go
+++ b/info/v2/conversion_test.go
@@ -189,7 +189,7 @@ func TestContainerStatsFromV1(t *testing.T) {
 		},
 	}
 
-	v2Stats := ContainerStatsFromV1(&v1Spec, []*v1.ContainerStats{&v1Stats})
+	v2Stats := ContainerStatsFromV1("test", &v1Spec, []*v1.ContainerStats{&v1Stats})
 	actualV2Stats := *v2Stats[0]
 
 	if !reflect.DeepEqual(expectedV2Stats, actualV2Stats) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -464,7 +464,7 @@ func (self *manager) GetContainerInfoV2(containerName string, options v2.Request
 			continue
 		}
 
-		result.Stats = v2.ContainerStatsFromV1(&cinfo.Spec, stats)
+		result.Stats = v2.ContainerStatsFromV1(containerName, &cinfo.Spec, stats)
 		infos[name] = result
 	}
 


### PR DESCRIPTION
Addresses [Kubernetes #22586](https://github.com/kubernetes/kubernetes/issues/22586).  The log line in question is designed to alert users that containers cannot span multiple filesystem devices.  However, it is being triggered when gathering information for the "/" (root) filesystem device, which includes all devices on the image.  Images configured to use multiple filesystem devices (coreos, GCI, to name a few) spam the logs with the line: "conversion.go:128 failed to handle multiple devices for container. Skipping Filesystem stats"

For this particular device ("/"), kubernetes does not consume the filesystem stats, making this log message unimportant.  Lowering the verbosity level is appropriate in this case.

cc: @derekwaynecarr (I messaged you about this in december) @timstclair 