### PR TITLE
WIP: cut log spam associated with multiple-fs containers

### DIFF
--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -96,7 +96,7 @@ func MachineStatsFromV1(cont *v1.ContainerInfo) []MachineStats {
 	return stats
 }
 
-func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []*v1.ContainerStats) []*ContainerStats {
+func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []*v1.ContainerStats, firstCall bool) []*ContainerStats {
 	newStats := make([]*ContainerStats, 0, len(stats))
 	var last *v1.ContainerStats
 	for _, val := range stats {
@@ -131,7 +131,7 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 					BaseUsageBytes:  &val.Filesystem[0].BaseUsage,
 					InodeUsage:      &val.Filesystem[0].Inodes,
 				}
-			} else if len(val.Filesystem) > 1 && containerName != "/" {
+			} else if len(val.Filesystem) > 1 && containerName != "/" && firstCall {
 				// Cannot handle multiple devices per container.
 				glog.V(2).Infof("failed to handle multiple devices for container %s. Skipping Filesystem stats", containerName)
 			}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -464,7 +464,7 @@ func (self *manager) GetContainerInfoV2(containerName string, options v2.Request
 			continue
 		}
 
-		result.Stats = v2.ContainerStatsFromV1(containerName, &cinfo.Spec, stats)
+		result.Stats = v2.ContainerStatsFromV1(containerName, &cinfo.Spec, stats, false)
 		infos[name] = result
 	}
 


### PR DESCRIPTION
Attempt at cutting log spam associated with containers with multiple filesystems; posting early to see if it sticks.  It looks at this point like I would have to keep track of the containers in multiple places, since both the http handler and manager are plugged into this code path.

cc @derekwaynecarr 