### PR TITLE
doc about error `Privileged mode is incompatible with user namespaces…

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -18,6 +18,10 @@ sudo docker run \
 
 cAdvisor is now running (in the background) on `http://localhost:8080/`. The setup includes directories with Docker state cAdvisor needs to observe.
 
+**Note**: If docker daemon is running with [user namespace enabled](https://docs.docker.com/engine/reference/commandline/dockerd/#starting-the-daemon-with-user-namespaces-enabled),
+You need to add `--userns=host` option in order for cAdvisor to monitor Docker containers,
+otherwise cAdvisor can not connect to docker daemon.
+
 ## Latest Canary
 
 The latest cAdvisor canary release is continuously built from HEAD and available


### PR DESCRIPTION
Hi, i have my docker daemon run with user namespace enabled(All users in containers will be mapped to sub user of specified external user, see Starting the daemon with user namespaces enabled),

In this case, cadvisor can not list containers in manage web pages without explicit errors, it's confusing for users.

I know the reason is caused by the docker run `Privileged mode is incompatible with user namespaces` , so i added a statement in README.md.

hope helpful.