### PR TITLE
do not look in rootfs for thin_ls binary

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,6 +5,7 @@ ENV GLIBC_VERSION "2.23-r3"
 
 RUN apk --no-cache add ca-certificates wget device-mapper && \
     apk --no-cache add zfs --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
+    apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
     wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk && \

--- a/devicemapper/util.go
+++ b/devicemapper/util.go
@@ -22,14 +22,10 @@ import (
 // ThinLsBinaryPresent returns the location of the thin_ls binary in the mount
 // namespace cadvisor is running in or an error.  The locations checked are:
 //
+// - /sbin/
 // - /bin/
 // - /usr/sbin/
 // - /usr/bin/
-//
-// ThinLsBinaryPresent checks these paths relative to:
-//
-// 1. For non-containerized operation - `/`
-// 2. For containerized operation - `/rootfs`
 //
 // The thin_ls binary is provided by the device-mapper-persistent-data
 // package.
@@ -39,17 +35,10 @@ func ThinLsBinaryPresent() (string, error) {
 		err        error
 	)
 
-	for _, path := range []string{"/bin", "/usr/sbin/", "/usr/bin"} {
+	for _, path := range []string{"/sbin", "/bin", "/usr/sbin/", "/usr/bin"} {
 		// try paths for non-containerized operation
 		// note: thin_ls is most likely a symlink to pdata_tools
 		thinLsPath = filepath.Join(path, "thin_ls")
-		_, err = os.Stat(thinLsPath)
-		if err == nil {
-			return thinLsPath, nil
-		}
-
-		// try paths for containerized operation
-		thinLsPath = filepath.Join("/rootfs", thinLsPath)
 		_, err = os.Stat(thinLsPath)
 		if err == nil {
 			return thinLsPath, nil


### PR DESCRIPTION
xref
https://github.com/openshift/origin/issues/10940
https://github.com/openshift/origin/pull/12753

We should not look in `/rootfs` for the `thin_ls` binary as it is not statically linked and the dependent libraries might not be present in the container.

@derekwaynecarr @ncdc @pmorie @lukegb