### PR TITLE
change stdout storage namespace to db name

### DIFF
--- a/storage/stdout/stdout.go
+++ b/storage/stdout/stdout.go
@@ -53,7 +53,7 @@ const (
 )
 
 func new() (storage.StorageDriver, error) {
-	return newStorage(*storage.ArgDbHost)
+	return newStorage(*storage.ArgDbName)
 }
 
 func (driver *stdoutStorage) containerStatsToValues(stats *info.ContainerStats) (series map[string]uint64) {


### PR DESCRIPTION
In statsd storage, we use `ArgDbName` as the namespace. 
In redis storage, we use `ArgDbName` as the redis key. 
I think we need to keep this to stdout storage, too. :)

/ping @timstclair 