### PR TITLE
fix gce error logging

### DIFF
--- a/utils/cloudinfo/gce.go
+++ b/utils/cloudinfo/gce.go
@@ -32,7 +32,7 @@ const (
 func onGCE() bool {
 	data, err := ioutil.ReadFile(gceProductName)
 	if err != nil {
-		glog.V(2).Infof("Error while reading product_name: %v", err)
+		glog.Errorf("Error while reading product_name: %v", err)
 		return false
 	}
 	return strings.Contains(string(data), google)


### PR DESCRIPTION
Error message should be logged with `glog.Errorf` instead of `glog.Infof`.

/ping @timstclair