### PR TITLE
Ignore unused cpus in Prometheus metrics

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -130,10 +130,12 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 				getValues: func(s *info.ContainerStats) metricValues {
 					values := make(metricValues, 0, len(s.Cpu.Usage.PerCpu))
 					for i, value := range s.Cpu.Usage.PerCpu {
-						values = append(values, metricValue{
-							value:  float64(value) / float64(time.Second),
-							labels: []string{fmt.Sprintf("cpu%02d", i)},
-						})
+						if value > 0 {
+							values = append(values, metricValue{
+								value:  float64(value) / float64(time.Second),
+								labels: []string{fmt.Sprintf("cpu%02d", i)},
+							})
+						}
 					}
 					return values
 				},


### PR DESCRIPTION
Only include cpu's in the Prometheus metrics endpoint that were used.

In recent kernels the `cpuacct.statcpus` behavior has changed to include all possible cpu's. See kernel commit [5ca3726af7f66a8cc71ce4414cfeb86deb784491](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=5ca3726af7f66a8cc71ce4414cfeb86deb784491) for details.

This can results in a high number of metrics in the Prometheus endpoint. For example, with VMware ESXi the kernel detects 128 hot swappable cpu's, adding >100 metrics per container for most machines. With a couple of VM's running >10 containers this quickly blows up a Prometheus server and makes most dashboards unmanageable.