### PR TITLE
Allow finding docker containers by short name

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -566,9 +566,24 @@ func (self *manager) getDockerContainer(containerName string) (*containerData, e
 		Namespace: docker.DockerNamespace,
 		Name:      containerName,
 	}]
+
+	// Look for container by short prefix name if no exact match found.
 	if !ok {
-		return nil, fmt.Errorf("unable to find Docker container %q", containerName)
+		for contName, c := range self.containers {
+			if contName.Namespace == docker.DockerNamespace && strings.HasPrefix(contName.Name, containerName) {
+				if cont == nil {
+					cont = c
+				} else {
+					return nil, fmt.Errorf("unable to find container. Container %q is not unique", containerName)
+				}
+			}
+		}
+
+		if cont == nil {
+			return nil, fmt.Errorf("unable to find Docker container %q", containerName)
+		}
 	}
+
 	return cont, nil
 }
 

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -280,7 +280,8 @@ func TestSubcontainersInfo(t *testing.T) {
 
 func TestDockerContainersInfo(t *testing.T) {
 	containers := []string{
-		"/docker/c1",
+		"/docker/c1a",
+		"/docker/c2a",
 	}
 
 	query := &info.ContainerInfoRequest{
@@ -289,12 +290,26 @@ func TestDockerContainersInfo(t *testing.T) {
 
 	m, _, _ := expectManagerWithContainers(containers, query, t)
 
-	result, err := m.DockerContainer("c1", query)
+	result, err := m.DockerContainer("c1a", query)
 	if err != nil {
 		t.Fatalf("expected to succeed: %s", err)
 	}
 	if result.Name != containers[0] {
 		t.Errorf("Unexpected container %q in result. Expected container %q", result.Name, containers[0])
+	}
+
+	result, err = m.DockerContainer("c2", query)
+	if err != nil {
+		t.Fatalf("expected to succeed: %s", err)
+	}
+	if result.Name != containers[1] {
+		t.Errorf("Unexpected container %q in result. Expected container %q", result.Name, containers[1])
+	}
+
+	result, err = m.DockerContainer("c", query)
+	expectedError := "unable to find container. Container \"c\" is not unique"
+	if err == nil {
+		t.Errorf("expected error %q but received %q", expectedError, err)
 	}
 }
 


### PR DESCRIPTION
Allow docker containers to be found by a short prefix name to match
the behavior of the docker daemon. This change now matches the examples
on the API docs.

Return an error if the given short, prefix name of a container is not
unique.

---

Resolves https://github.com/google/cadvisor/issues/1164
 
I'm not sure about all the contexts that `DockerContainer` is being called in and am slightly concerned about iterating through all the containers if an exact match is not found.

I'm pretty new to golang so I welcome all feedback.