### PR TITLE
fix centurylink labs link to prometheus integration

### DIFF
--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -6,6 +6,6 @@ To monitor cAdvisor with Prometheus, simply configure one or more jobs in Promet
 
 # Examples
 
-* [CenturyLink Labs](https://labs.ctl.io/) did an excellent write up on [Monitoring Docker services with Prometheus +cAdvisor](https://labs.ctl.io/monitoring-docker-services-with-prometheus/), while it is great to get a better overview of cAdvisor integration with Prometheus, the PromDash GUI part is outdated as it has been deprecated for Grafana.
+* [CenturyLink Labs](https://labs.ctl.io/) did an excellent write up on [Monitoring Docker services with Prometheus +cAdvisor](https://www.ctl.io/developers/blog/post/monitoring-docker-services-with-prometheus/), while it is great to get a better overview of cAdvisor integration with Prometheus, the PromDash GUI part is outdated as it has been deprecated for Grafana.
 
 * [vegasbrianc](https://github.com/vegasbrianc) provides a [starter project](https://github.com/vegasbrianc/prometheus) for cAdvisor and Prometheus monitoring, alongide a ready-to-use [Grafana dashboard](https://github.com/vegasbrianc/grafana_dashboard).


### PR DESCRIPTION
`labs.ctl.io` -> `www.ctl.io`