### PR TITLE
Support tmpfs in processMounts

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -125,6 +125,7 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 	supportedFsType := map[string]bool{
 		// all ext systems are checked through prefix.
 		"btrfs": true,
+		"tmpfs": true,
 		"xfs":   true,
 		"zfs":   true,
 	}


### PR DESCRIPTION
Helps with the situation in kubernetes where /var/lib/kubelet is
mounted using tmpfs.