### PR TITLE
Add cpu load and tcp/udp usage statistics in prom `/metrics` endpoint

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -418,6 +418,22 @@ type TcpStat struct {
 	Closing uint64
 }
 
+func (t *TcpStat) TcpStatMap() map[string]uint64 {
+	return map[string]uint64{
+		"tcp_established": t.Established,
+		"tcp_synsent":     t.SynSent,
+		"tcp_synrecv":     t.SynRecv,
+		"tcp_finwait1":    t.FinWait1,
+		"tcp_finwait2":    t.FinWait2,
+		"tcp_timewait":    t.TimeWait,
+		"tcp_close":       t.Close,
+		"tcp_closewait":   t.CloseWait,
+		"tcp_lastack":     t.LastAck,
+		"tcp_listen":      t.Listen,
+		"tcp_closing":     t.Closing,
+	}
+}
+
 type UdpStat struct {
 	// Count of UDP sockets in state "Listen"
 	Listen uint64
@@ -430,6 +446,15 @@ type UdpStat struct {
 
 	// Count of packets Queued for Transmit
 	TxQueued uint64
+}
+
+func (u *UdpStat) UdpStatMap() map[string]uint64 {
+	return map[string]uint64{
+		"udp_listen":   u.Listen,
+		"udp_dropped":  u.Dropped,
+		"udp_rxqueued": u.RxQueued,
+		"udp_txqueued": u.TxQueued,
+	}
 }
 
 type FsStats struct {

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -262,6 +262,22 @@ type TcpStat struct {
 	Closing     uint64
 }
 
+func (t *TcpStat) TcpStatMap() map[string]uint64 {
+	return map[string]uint64{
+		"tcp_established": t.Established,
+		"tcp_synsent":     t.SynSent,
+		"tcp_synrecv":     t.SynRecv,
+		"tcp_finwait1":    t.FinWait1,
+		"tcp_finwait2":    t.FinWait2,
+		"tcp_timewait":    t.TimeWait,
+		"tcp_close":       t.Close,
+		"tcp_closewait":   t.CloseWait,
+		"tcp_lastack":     t.LastAck,
+		"tcp_listen":      t.Listen,
+		"tcp_closing":     t.Closing,
+	}
+}
+
 type NetworkStats struct {
 	// Network stats by interface.
 	Interfaces []v1.InterfaceStats `json:"interfaces,omitempty"`

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -190,6 +190,13 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 					return metricValues{{value: float64(s.Cpu.CFS.ThrottledTime) / float64(time.Second)}}
 				},
 			}, {
+				name:      "container_cpu_load_average_10s",
+				help:      "Value of container cpu load average over the last 10 seconds.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Cpu.LoadAverage)}}
+				},
+			}, {
 				name:      "container_memory_cache",
 				help:      "Number of bytes of page cache memory.",
 				valueType: prometheus.GaugeValue,
@@ -579,6 +586,38 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 					return values
 				},
 			}, {
+				name:        "container_network_tcp_usage_total",
+				help:        "tcp connection usage statistic for container",
+				valueType:   prometheus.GaugeValue,
+				extraLabels: []string{"tcp_state"},
+				getValues: func(s *info.ContainerStats) metricValues {
+					tcpStatMap := s.Network.Tcp.TcpStatMap()
+					values := make(metricValues, 0, len(tcpStatMap))
+					for tcpState, stateCount := range tcpStatMap {
+						values = append(values, metricValue{
+							value:  float64(stateCount),
+							labels: []string{tcpState},
+						})
+					}
+					return values
+				},
+			}, {
+				name:        "container_network_udp_usage_total",
+				help:        "udp connection usage statistic for container",
+				valueType:   prometheus.GaugeValue,
+				extraLabels: []string{"udp_state"},
+				getValues: func(s *info.ContainerStats) metricValues {
+					udpStatMap := s.Network.Udp.UdpStatMap()
+					values := make(metricValues, 0, len(udpStatMap))
+					for udpState, stateCount := range udpStatMap {
+						values = append(values, metricValue{
+							value:  float64(stateCount),
+							labels: []string{udpState},
+						})
+					}
+					return values
+				},
+			}, {
 				name:        "container_tasks_state",
 				help:        "Number of tasks in given state",
 				extraLabels: []string{"state"},
@@ -610,6 +649,7 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 			},
 		},
 	}
+
 	return c
 }
 


### PR DESCRIPTION
Hi folks,

Related to #1670 , I'd like to take a PR to expose more about `container_cpu_load_average_10s`, `container_network_tcp_usage_total`, `container_network_udp_usage_total` metric within the `/metrics` endpoint.

Currently, tcp/udp usage will be disabled via `disable_metrics` flag by default, thus `/metrics` would show zero values. Due to [ContainerSpec](https://github.com/google/cadvisor/blob/master/info/v2/container.go#L67) has no `ignoreMetrics` flag, I don't know how to handle this...

Thanks.