### PR TITLE
Add runtime options for TLS support

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -41,6 +41,10 @@ import (
 )
 
 var ArgDockerEndpoint = flag.String("docker", "unix:///var/run/docker.sock", "docker endpoint")
+var ArgDockerTLS = flag.Bool("docker-tls", false, "use TLS to connect to docker")
+var ArgDockerCert = flag.String("docker-tls-cert", "cert.pem", "path to client certificate")
+var ArgDockerKey = flag.String("docker-tls-key", "key.pem", "path to private key")
+var ArgDockerCA = flag.String("docker-tls-ca", "ca.pem", "path to trusted CA")
 
 // The namespace under which Docker aliases are unique.
 const DockerNamespace = "docker"

--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -46,6 +46,10 @@ From [glog](https://github.com/golang/glog) here are some flags we find useful:
 --docker_env_metadata_whitelist="": a comma-separated list of environment variable keys that needs to be collected for docker containers
 --docker_only=false: Only report docker containers in addition to root stats
 --docker_root="/var/lib/docker": DEPRECATED: docker root is read from docker info (this is a fallback, default: /var/lib/docker) (default "/var/lib/docker")
+--docker-tls: use TLS to connect to docker
+--docker-tls-cert="cert.pem": client certificate for TLS-connection with docker
+--docker-tls-key="key.pem": private key for TLS-connection with docker
+--docker-tls-ca="ca.pem": trusted CA for TLS-connection with docker
 ```
 
 ## Housekeeping


### PR DESCRIPTION
Addresses #1631 by adding runtime options for using TLS to connect to docker. The -docker-tls flag enables TLS, the other three (-docker-tls-cert, -docker-tls-key, -docker-tls-ca) specify the keypair and CAs to use. This solution matches the existing interface in that it uses runtime options (like -docker) over environment variables (like DOCKER_HOST).

If -docker-tls is not set, the behaviour is the same as before.
Let me know if you have any feedback.