### PR TITLE
Set ContinueOnError for prometheus http handler.

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -100,7 +100,7 @@ func RegisterPrometheusHandler(mux httpmux.Mux, containerManager manager.Manager
 		prometheus.NewGoCollector(),
 		prometheus.NewProcessCollector(os.Getpid(), ""),
 	)
-	mux.Handle(prometheusEndpoint, promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
+	mux.Handle(prometheusEndpoint, promhttp.HandlerFor(r, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
 }
 
 func staticHandlerNoAuth(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
PR https://github.com/google/cadvisor/pull/1460 upgraded prometheus to v0.8.0.

However, prometheus v0.8.0 [enforced some consistency check]( https://github.com/prometheus/client_golang/pull/214), which our current metrics could not pass, thus caused https://github.com/google/cadvisor/issues/1671 and https://github.com/kubernetes/kubernetes/issues/47744.

This PR configure prometheus http handler to `ContinueOnError` so that the metrics could be collected/exposed regardless of the error. This is also the solution suggested in https://github.com/prometheus/client_golang/pull/214.

This is only a quick fix for Kubernetes 1.7 release. We should figure out what in our metrics caused the inconsistency and fix it.

@dchen1107 @google/cadvisor @grobie 