### PR TITLE
Set ContinueOnError for prometheus http handler.

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -100,7 +100,7 @@ func RegisterPrometheusHandler(mux httpmux.Mux, containerManager manager.Manager
 		prometheus.NewGoCollector(),
 		prometheus.NewProcessCollector(os.Getpid(), ""),
 	)
-	mux.Handle(prometheusEndpoint, promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
+	mux.Handle(prometheusEndpoint, promhttp.HandlerFor(r, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
 }
 
 func staticHandlerNoAuth(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Cherrypick https://github.com/google/cadvisor/pull/1679 to v0.26.