### PR TITLE
use glog.Warningf when a format string is passed

### DIFF
--- a/devicemapper/thin_ls_client.go
+++ b/devicemapper/thin_ls_client.go
@@ -80,7 +80,7 @@ func parseThinLsOutput(output []byte) map[string]uint64 {
 		deviceID := fields[0]
 		usage, err := strconv.ParseUint(fields[1], 10, 64)
 		if err != nil {
-			glog.Warning("unexpected error parsing thin_ls output: %v", err)
+			glog.Warningf("unexpected error parsing thin_ls output: %v", err)
 			continue
 		}
 


### PR DESCRIPTION
ref:
https://godoc.org/github.com/golang/glog#Warningf
https://godoc.org/github.com/golang/glog#Warning