### PR TITLE
Reduce log spam when unable to get network stats

### DIFF
--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -99,7 +99,7 @@ func GetStats(cgroupManager cgroups.Manager, rootFs string, pid int, ignoreMetri
 	if !ignoreMetrics.Has(container.NetworkUsageMetrics) {
 		netStats, err := networkStatsFromProc(rootFs, pid)
 		if err != nil {
-			glog.V(2).Infof("Unable to get network stats from pid %d: %v", pid, err)
+			glog.V(4).Infof("Unable to get network stats from pid %d: %v", pid, err)
 		} else {
 			stats.Network.Interfaces = append(stats.Network.Interfaces, netStats...)
 		}
@@ -107,14 +107,14 @@ func GetStats(cgroupManager cgroups.Manager, rootFs string, pid int, ignoreMetri
 	if !ignoreMetrics.Has(container.NetworkTcpUsageMetrics) {
 		t, err := tcpStatsFromProc(rootFs, pid, "net/tcp")
 		if err != nil {
-			glog.V(2).Infof("Unable to get tcp stats from pid %d: %v", pid, err)
+			glog.V(4).Infof("Unable to get tcp stats from pid %d: %v", pid, err)
 		} else {
 			stats.Network.Tcp = t
 		}
 
 		t6, err := tcpStatsFromProc(rootFs, pid, "net/tcp6")
 		if err != nil {
-			glog.V(2).Infof("Unable to get tcp6 stats from pid %d: %v", pid, err)
+			glog.V(4).Infof("Unable to get tcp6 stats from pid %d: %v", pid, err)
 		} else {
 			stats.Network.Tcp6 = t6
 		}
@@ -122,14 +122,14 @@ func GetStats(cgroupManager cgroups.Manager, rootFs string, pid int, ignoreMetri
 	if !ignoreMetrics.Has(container.NetworkUdpUsageMetrics) {
 		u, err := udpStatsFromProc(rootFs, pid, "net/udp")
 		if err != nil {
-			glog.V(2).Infof("Unable to get udp stats from pid %d: %v", pid, err)
+			glog.V(4).Infof("Unable to get udp stats from pid %d: %v", pid, err)
 		} else {
 			stats.Network.Udp = u
 		}
 
 		u6, err := udpStatsFromProc(rootFs, pid, "net/udp6")
 		if err != nil {
-			glog.V(2).Infof("Unable to get udp6 stats from pid %d: %v", pid, err)
+			glog.V(4).Infof("Unable to get udp6 stats from pid %d: %v", pid, err)
 		} else {
 			stats.Network.Udp6 = u6
 		}


### PR DESCRIPTION
I have multiple reports of this spamming logs and causing stability issues.

```
Unable to get network stats from pid 36618: couldn't read network stats: failure opening /proc/36618/net/dev: open /proc/36618/net/dev: no such file or directory
```

suspect the container process has exited but the cgroup still remained.