### PR TITLE
Machine info introspects hugepages

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -94,6 +94,14 @@ func (self *Node) AddPerCoreCache(c Cache) {
 	}
 }
 
+type HugePagesInfo struct {
+	// huge page size (in kB)
+	PageSize uint64 `json:"page_size"`
+
+	// number of huge pages
+	NumPages uint64 `json:"num_pages"`
+}
+
 type DiskInfo struct {
 	// device name
 	Name string `json:"name"`
@@ -157,6 +165,9 @@ type MachineInfo struct {
 
 	// The amount of memory (in bytes) in this machine
 	MemoryCapacity uint64 `json:"memory_capacity"`
+
+	// HugePages on this machine.
+	HugePages []HugePagesInfo `json:"hugepages"`
 
 	// The machine id
 	MachineID string `json:"machine_id"`

--- a/info/v2/machine.go
+++ b/info/v2/machine.go
@@ -52,6 +52,9 @@ type Attributes struct {
 	// The system uuid
 	SystemUUID string `json:"system_uuid"`
 
+	// HugePages on this machine.
+	HugePages []v1.HugePagesInfo `json:"hugepages"`
+
 	// Filesystems on this machine.
 	Filesystems []v1.FsInfo `json:"filesystems"`
 

--- a/machine/info.go
+++ b/machine/info.go
@@ -17,8 +17,10 @@ package machine
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -30,6 +32,8 @@ import (
 
 	"github.com/golang/glog"
 )
+
+const hugepagesDirectory = "/sys/kernel/mm/hugepages/"
 
 var machineIdFilePath = flag.String("machine_id_file", "/etc/machine-id,/var/lib/dbus/machine-id", "Comma-separated list of files to check for machine-id. Use the first one that exists.")
 var bootIdFilePath = flag.String("boot_id_file", "/proc/sys/kernel/random/boot_id", "Comma-separated list of files to check for boot-id. Use the first one that exists.")
@@ -48,6 +52,43 @@ func getInfoFromFiles(filePaths string) string {
 	return ""
 }
 
+// GetHugePagesInfo returns information about pre-allocated huge pages
+func GetHugePagesInfo() ([]info.HugePagesInfo, error) {
+	var hugePagesInfo []info.HugePagesInfo
+	files, err := ioutil.ReadDir(hugepagesDirectory)
+	if err != nil {
+		return hugePagesInfo, err
+	}
+	for _, st := range files {
+		nameArray := strings.Split(st.Name(), "-")
+		pageSizeArray := strings.Split(nameArray[1], "kB")
+		pageSize, err := strconv.ParseUint(string(pageSizeArray[0]), 10, 64)
+		if err != nil {
+			return hugePagesInfo, err
+		}
+
+		numFile := hugepagesDirectory + st.Name() + "/nr_hugepages"
+		val, err := ioutil.ReadFile(numFile)
+		if err != nil {
+			return hugePagesInfo, err
+		}
+		var numPages uint64
+		// we use sscanf as the file as a new-line that trips up ParseUint
+		// it returns the number of tokens successfully parsed, so if
+		// n != 1, it means we were unable to parse a number from the file
+		n, err := fmt.Sscanf(string(val), "%d", &numPages)
+		if err != nil || n != 1 {
+			return hugePagesInfo, fmt.Errorf("could not parse file %v contents %q", numFile, string(val))
+		}
+
+		hugePagesInfo = append(hugePagesInfo, info.HugePagesInfo{
+			NumPages: numPages,
+			PageSize: pageSize,
+		})
+	}
+	return hugePagesInfo, nil
+}
+
 func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.MachineInfo, error) {
 	rootFs := "/"
 	if !inHostNamespace {
@@ -61,6 +102,11 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 	}
 
 	memoryCapacity, err := GetMachineMemoryCapacity()
+	if err != nil {
+		return nil, err
+	}
+
+	hugePagesInfo, err := GetHugePagesInfo()
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +145,7 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 		NumCores:       numCores,
 		CpuFrequency:   clockSpeed,
 		MemoryCapacity: memoryCapacity,
+		HugePages:      hugePagesInfo,
 		DiskMap:        diskMap,
 		NetworkDevices: netDevices,
 		Topology:       topology,


### PR DESCRIPTION
I plan to add support for pre-allocated huge pages in Kubernetes 1.8.

In order to add that support, I need the ability to introspect the supported set of huge pages on the node, and the number of them that are pre-allocated.

This adds that support.