### PR TITLE
Skip subcontainer update on v2 calls

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -113,16 +113,18 @@ func (c *containerData) allowErrorLogging() bool {
 	return false
 }
 
-func (c *containerData) GetInfo() (*containerInfo, error) {
+func (c *containerData) GetInfo(shouldUpdateSubcontainers bool) (*containerInfo, error) {
 	// Get spec and subcontainers.
 	if time.Since(c.lastUpdatedTime) > 5*time.Second {
 		err := c.updateSpec()
 		if err != nil {
 			return nil, err
 		}
-		err = c.updateSubcontainers()
-		if err != nil {
-			return nil, err
+		if shouldUpdateSubcontainers {
+			err = c.updateSubcontainers()
+			if err != nil {
+				return nil, err
+			}
 		}
 		c.lastUpdatedTime = time.Now()
 	}

--- a/manager/container_test.go
+++ b/manager/container_test.go
@@ -174,7 +174,7 @@ func TestGetInfo(t *testing.T) {
 	)
 	mockHandler.Aliases = []string{"a1", "a2"}
 
-	info, err := cd.GetInfo()
+	info, err := cd.GetInfo(true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -400,7 +400,7 @@ func (self *manager) GetContainerSpec(containerName string, options v2.RequestOp
 	var errs partialFailure
 	specs := make(map[string]v2.ContainerSpec)
 	for name, cont := range conts {
-		cinfo, err := cont.GetInfo()
+		cinfo, err := cont.GetInfo(false)
 		if err != nil {
 			errs.append(name, "GetInfo", err)
 		}
@@ -449,7 +449,7 @@ func (self *manager) GetContainerInfoV2(containerName string, options v2.Request
 	infos := make(map[string]v2.ContainerInfo, len(containers))
 	for name, container := range containers {
 		result := v2.ContainerInfo{}
-		cinfo, err := container.GetInfo()
+		cinfo, err := container.GetInfo(false)
 		if err != nil {
 			errs.append(name, "GetInfo", err)
 			infos[name] = result
@@ -473,7 +473,7 @@ func (self *manager) GetContainerInfoV2(containerName string, options v2.Request
 
 func (self *manager) containerDataToContainerInfo(cont *containerData, query *info.ContainerInfoRequest) (*info.ContainerInfo, error) {
 	// Get the info from the container.
-	cinfo, err := cont.GetInfo()
+	cinfo, err := cont.GetInfo(true)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -124,6 +124,48 @@ func expectManagerWithContainers(containers []string, query *info.ContainerInfoR
 	return m, infosMap, handlerMap
 }
 
+// Expect a manager with the specified containers and query. Returns the manager, map of ContainerInfo objects,
+// and map of MockContainerHandler objects.}
+func expectManagerWithContainersV2(containers []string, query *info.ContainerInfoRequest, t *testing.T) (*manager, map[string]*info.ContainerInfo, map[string]*containertest.MockContainerHandler) {
+	infosMap := make(map[string]*info.ContainerInfo, len(containers))
+	handlerMap := make(map[string]*containertest.MockContainerHandler, len(containers))
+
+	for _, container := range containers {
+		infosMap[container] = itest.GenerateRandomContainerInfo(container, 4, query, 1*time.Second)
+	}
+
+	memoryCache := memory.New(time.Duration(query.NumStats)*time.Second, nil)
+	sysfs := &fakesysfs.FakeSysFs{}
+	m := createManagerAndAddContainers(
+		memoryCache,
+		sysfs,
+		containers,
+		func(h *containertest.MockContainerHandler) {
+			cinfo := infosMap[h.Name]
+			ref, err := h.ContainerReference()
+			if err != nil {
+				t.Error(err)
+			}
+			for _, stat := range cinfo.Stats {
+				err = memoryCache.AddStats(ref, stat)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			spec := cinfo.Spec
+
+			h.On("GetSpec").Return(
+				spec,
+				nil,
+			).Once()
+			handlerMap[h.Name] = h
+		},
+		t,
+	)
+
+	return m, infosMap, handlerMap
+}
+
 func TestGetContainerInfo(t *testing.T) {
 	containers := []string{
 		"/c1",
@@ -173,7 +215,7 @@ func TestGetContainerInfoV2(t *testing.T) {
 		NumStats: 2,
 	}
 
-	m, _, handlerMap := expectManagerWithContainers(containers, query, t)
+	m, _, handlerMap := expectManagerWithContainersV2(containers, query, t)
 
 	infos, err := m.GetContainerInfoV2("/", options)
 	if err != nil {


### PR DESCRIPTION
Currently `GetInfo()` updates both the spec and the subcontainers.  The subcontainer walk is VERY expensive as it does a stat syscall on basically every directory and file in the cgroupfs tree via `ioutil.Readdir()`.  This uses lots of CPU directly and also allocates a TON of objects that have to be GCed later, consuming even more CPU.

AFAICT, the v2 api does not need to do this subcontainer update at all since the v2 ContainerInfo doesn't have a subcontainers field:
https://github.com/sjenning/cadvisor/blob/master/info/v1/container.go#L128-L139
https://github.com/sjenning/cadvisor/blob/master/info/v2/container.go#L59-L65

The code supports this conclusion as v2 go paths look like this
```
cinfo, err := container.GetInfo(false)
...
result.Spec = self.getV2Spec(cinfo)
```
The `Subcontainers` in the `containerInfo` is discarded.

This is a huge performance win.  In Kubernetes, `GetContainerInfoV2()` is called every 10s from the summaryProvider.  It is currently one of the top ~5 hot paths in steady-state kubelet.

@derekwaynecarr @smarterclayton @dashpole @vishh @tallclair