### PR TITLE
make lack of hugepages support non-fatal

### DIFF
--- a/machine/info.go
+++ b/machine/info.go
@@ -57,7 +57,9 @@ func GetHugePagesInfo() ([]info.HugePagesInfo, error) {
 	var hugePagesInfo []info.HugePagesInfo
 	files, err := ioutil.ReadDir(hugepagesDirectory)
 	if err != nil {
-		return hugePagesInfo, err
+		// treat as non-fatal since kernels and machine can be
+		// configured to disable hugepage support
+		return hugePagesInfo, nil
 	}
 	for _, st := range files {
 		nameArray := strings.Split(st.Name(), "-")


### PR DESCRIPTION
Attempts to merge this in kube are failing because the test nodes disable hugepages at the OS level meaning that /sys/kernel/mm/hugepages does not exist.

Treat this situation as non-fatal.

@derekwaynecarr @dashpole 