### PR TITLE
Add an API to get FsStats from filesystem UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ sudo docker run \
   --volume=/var/run:/var/run:rw \
   --volume=/sys:/sys:ro \
   --volume=/var/lib/docker/:/var/lib/docker:ro \
+  --volume=/dev/disk/:/dev/disk:ro \
   --publish=8080:8080 \
   --detach=true \
   --name=cadvisor \

--- a/api/versions.go
+++ b/api/versions.go
@@ -420,23 +420,30 @@ func (self *version2_0) HandleRequest(requestType string, request []string, m ma
 		}
 		return writeResult(specs, w)
 	case storageApi:
-		var err error
-		fi := []v2.FsInfo{}
 		label := r.URL.Query().Get("label")
-		if len(label) == 0 {
-			// Get all global filesystems info.
-			fi, err = m.GetFsInfo("")
+		uuid := r.URL.Query().Get("uuid")
+		switch {
+		case uuid != "":
+			fi, err := m.GetFsInfoByFsUUID(uuid)
 			if err != nil {
 				return err
 			}
-		} else {
+			return writeResult(fi, w)
+		case label != "":
 			// Get a specific label.
-			fi, err = m.GetFsInfo(label)
+			fi, err := m.GetFsInfo(label)
 			if err != nil {
 				return err
 			}
+			return writeResult(fi, w)
+		default:
+			// Get all global filesystems info.
+			fi, err := m.GetFsInfo("")
+			if err != nil {
+				return err
+			}
+			return writeResult(fi, w)
 		}
-		return writeResult(fi, w)
 	case eventsApi:
 		return handleEventRequest(request, m, w, r)
 	case psApi:

--- a/fs/types.go
+++ b/fs/types.go
@@ -14,7 +14,10 @@
 
 package fs
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 type DeviceInfo struct {
 	Device string
@@ -59,6 +62,9 @@ type DiskStats struct {
 	WeightedIoTime  uint64
 }
 
+// ErrNoSuchDevice is the error indicating the requested device does not exist.
+var ErrNoSuchDevice = errors.New("cadvisor: no such device")
+
 type FsInfo interface {
 	// Returns capacity and free space, in bytes, of all the ext2, ext3, ext4 filesystems on the host.
 	GetGlobalFsInfo() ([]Fs, error)
@@ -71,6 +77,11 @@ type FsInfo interface {
 
 	// Returns number of inodes used by 'dir'.
 	GetDirInodeUsage(dir string, timeout time.Duration) (uint64, error)
+
+	// GetDeviceInfoByFsUUID returns the information of the device with the
+	// specified filesystem uuid. If no such device exists, this function will
+	// return the ErrNoSuchDevice error.
+	GetDeviceInfoByFsUUID(uuid string) (*DeviceInfo, error)
 
 	// Returns the block device info of the filesystem on which 'dir' resides.
 	GetDirFsDevice(dir string) (*DeviceInfo, error)

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -199,6 +199,9 @@ type DerivedStats struct {
 }
 
 type FsInfo struct {
+	// Time of generation of these stats.
+	Timestamp time.Time `json:"timestamp"`
+
 	// The block device name associated with the filesystem.
 	Device string `json:"device"`
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -101,6 +101,11 @@ type Manager interface {
 	// Get version information about different components we depend on.
 	GetVersionInfo() (*info.VersionInfo, error)
 
+	// GetFsInfoByFsUUID returns the information of the device having the
+	// specified filesystem uuid. If no such device with the UUID exists, this
+	// function will return the fs.ErrNoSuchDevice error.
+	GetFsInfoByFsUUID(uuid string) (v2.FsInfo, error)
+
 	// Get filesystem information for the filesystem that contains the given directory
 	GetDirFsInfo(dir string) (v2.FsInfo, error)
 
@@ -676,24 +681,19 @@ func (self *manager) getRequestedContainers(containerName string, options v2.Req
 }
 
 func (self *manager) GetDirFsInfo(dir string) (v2.FsInfo, error) {
-	dirDevice, err := self.fsInfo.GetDirFsDevice(dir)
+	device, err := self.fsInfo.GetDirFsDevice(dir)
 	if err != nil {
-		return v2.FsInfo{}, fmt.Errorf("error trying to get filesystem Device for dir %v: err: %v", dir, err)
+		return v2.FsInfo{}, fmt.Errorf("failed to get device for dir %q: %v", dir, err)
 	}
-	dirMountpoint, err := self.fsInfo.GetMountpointForDevice(dirDevice.Device)
-	if err != nil {
-		return v2.FsInfo{}, fmt.Errorf("error trying to get MountPoint for Root Device: %v, err: %v", dirDevice, err)
-	}
-	infos, err := self.GetFsInfo("")
+	return self.getFsInfoByDeviceName(device.Device)
+}
+
+func (self *manager) GetFsInfoByFsUUID(uuid string) (v2.FsInfo, error) {
+	device, err := self.fsInfo.GetDeviceInfoByFsUUID(uuid)
 	if err != nil {
 		return v2.FsInfo{}, err
 	}
-	for _, info := range infos {
-		if info.Mountpoint == dirMountpoint {
-			return info, nil
-		}
-	}
-	return v2.FsInfo{}, fmt.Errorf("did not find fs info for dir: %v", dir)
+	return self.getFsInfoByDeviceName(device.Device)
 }
 
 func (self *manager) GetFsInfo(label string) ([]v2.FsInfo, error) {
@@ -726,6 +726,7 @@ func (self *manager) GetFsInfo(label string) ([]v2.FsInfo, error) {
 		}
 
 		fi := v2.FsInfo{
+			Timestamp:  stats[0].Timestamp,
 			Device:     fs.Device,
 			Mountpoint: mountpoint,
 			Capacity:   fs.Limit,
@@ -1263,6 +1264,23 @@ func (m *manager) DebugInfo() map[string][]string {
 
 	debugInfo["Managed containers"] = lines
 	return debugInfo
+}
+
+func (self *manager) getFsInfoByDeviceName(deviceName string) (v2.FsInfo, error) {
+	mountPoint, err := self.fsInfo.GetMountpointForDevice(deviceName)
+	if err != nil {
+		return v2.FsInfo{}, fmt.Errorf("failed to get mount point for device %q: %v", deviceName, err)
+	}
+	infos, err := self.GetFsInfo("")
+	if err != nil {
+		return v2.FsInfo{}, err
+	}
+	for _, info := range infos {
+		if info.Mountpoint == mountPoint {
+			return info, nil
+		}
+	}
+	return v2.FsInfo{}, fmt.Errorf("cannot find filesystem info for device %q", deviceName)
 }
 
 func getVersionInfo() (*info.VersionInfo, error) {


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/46984

- Added `GetFsInfoByFsUUID(uuid string) (*v2.FsInfo, error)` in the manager.
- Added timestamp into `v2.FsInfo` so that we will know when the stats are sampled.

Tested manually:

```
$ docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro --volume=/var/lib/docker/:/var/lib/docker:ro --volume=/dev/disk:/dev/disk:ro --publish=8080:8080 --detach=true --name=cadvisor cadvisor:9e51697

$ curl http://127.0.0.1:8080/api/v2.0/storage?uuid=9eb3792d-3b9a-4e50-84e0-fb8e6119b9e1
{"timestamp":"2017-08-23T16:11:37.451208174Z","device":"/dev/dm-1","mountpoint":"/rootfs","capacity":58923675648,"available":35672920064,"usage":20234002432,"labels":[],"inodes":3662848,"inodes_free":3277799}

$ curl http://127.0.0.1:8080/api/v2.0/storage?uuid=123
cadvisor: no such device
```

/assign @dashpole 
/cc @yujuhong 