### PR TITLE
Fix journalctl leak

### DIFF
--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"regexp"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/google/cadvisor/utils"
@@ -167,6 +168,9 @@ func (self *OomParser) StreamOoms(outStream chan *OomInstance) {
 
 func callJournalctl() (io.ReadCloser, error) {
 	cmd := exec.Command("journalctl", "-k", "-f")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
 	readcloser, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the journalctl leak that occurs when a process that uses
cadvisor exits. See issues #1725 and https://github.com/kubernetes/kubernetes/issues/34965.

I tested this by changing the Kubelet configuration 100 times (which causes 100 restarts of cadvisor). After this, there were no leaked inotify nodes:
```
root@test-cos-beta-61-9765-31-0:~# for foo in /proc/*/fd/*; do readlink -f $foo; done | grep inotify | sort | uniq -c | sort -nr | awk '{print $2}' | cut -d/ -f 3 | xargs ps -p
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:01 /usr/lib/systemd/systemd noresume noswap cros_efi
  383 ?        Ss     0:00 /usr/lib/systemd/systemd-udevd
  516 ?        Ssl    0:00 /usr/lib/systemd/systemd-timesyncd
  579 ?        Ss     0:00 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
  617 ?        Ss     0:00 /usr/lib/systemd/systemd-resolved
  631 ?        Ss+    0:00 /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
```

whereas before there were many journalctl processes associated with leaked nodes.