### PR TITLE
Adds whitelisting of docker labels [#1730]

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -314,7 +314,7 @@ func ensureThinLsKernelVersion(kernelVersion string) error {
 }
 
 // Register root container before running this function!
-func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics container.MetricSet, enforceLabelWhitelist bool, labelsWhiteList []string) error {
+func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics container.MetricSet, enforceLabelWhitelist bool, labelWhiteList []string) error {
 	client, err := Client()
 	if err != nil {
 		return fmt.Errorf("unable to communicate with docker daemon: %v", err)
@@ -364,7 +364,7 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics c
 		dockerVersion:         dockerVersion,
 		dockerAPIVersion:      dockerAPIVersion,
 		enforceLabelWhitelist: enforceLabelWhitelist,
-		labelWhitelist:        labelsWhiteList,
+		labelWhitelist:        labelWhiteList,
 		fsInfo:                fsInfo,
 		machineInfoFactory:    factory,
 		storageDriver:         storageDriver(dockerInfo.Driver),

--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -54,6 +54,8 @@ const DockerNamespace = "docker"
 var dockerCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
 
 var dockerEnvWhitelist = flag.String("docker_env_metadata_whitelist", "", "a comma-separated list of environment variable keys that needs to be collected for docker containers")
+var dockerLabelWhitelist = flag.String("docker_label_metadata_whitelist", "", "a comma-separated list of label keys that needs to be collected for docker containers")
+var dockerNoLabels = flag.Bool("docker_no_labels", false, "whether to retrieve all container labels")
 
 var (
 	// Basepath to all container specific information that libcontainer stores.
@@ -128,6 +130,7 @@ func (self *dockerFactory) NewContainerHandler(name string, inHostNamespace bool
 		return
 	}
 
+	metadataLabels := strings.Split(*dockerLabelWhitelist, ",")
 	metadataEnvs := strings.Split(*dockerEnvWhitelist, ",")
 
 	handler, err = newDockerContainerHandler(
@@ -145,6 +148,8 @@ func (self *dockerFactory) NewContainerHandler(name string, inHostNamespace bool
 		self.thinPoolName,
 		self.thinPoolWatcher,
 		self.zfsWatcher,
+		*dockerNoLabels,
+		metadataLabels,
 	)
 	return
 }

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -410,7 +410,7 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec.Labels = self.labels
 
 	// Only adds restartcount label if it's greater than 0 and is
-	// a whitelisted label in case noLabels is set.
+	// a whitelisted label in case enforceWhitelist is set.
 	if self.enforceLabelWhitelist {
 		for _, label := range self.labelWhitelist {
 			if label != "restartCount" {

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -408,9 +408,15 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, self.needNet(), hasFilesystem)
 
 	spec.Labels = self.labels
+	spec.Envs = self.envs
+	spec.Image = self.image
 
 	// Only adds restartcount label if it's greater than 0 and is
 	// a whitelisted label in case enforceWhitelist is set.
+	if self.restartCount < 1 {
+		return spec, err
+	}
+
 	if self.enforceLabelWhitelist {
 		for _, label := range self.labelWhitelist {
 			if label != "restartCount" {
@@ -422,9 +428,6 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	} else {
 		spec.Labels["restartcount"] = strconv.Itoa(self.restartCount)
 	}
-
-	spec.Envs = self.envs
-	spec.Image = self.image
 
 	return spec, err
 }

--- a/container/rkt/factory.go
+++ b/container/rkt/factory.go
@@ -33,6 +33,10 @@ type rktFactory struct {
 
 	cgroupSubsystems *libcontainer.CgroupSubsystems
 
+	enforceLabelWhitelist bool
+
+	labelWhitelist []string
+
 	fsInfo fs.FsInfo
 
 	ignoreMetrics container.MetricSet
@@ -67,7 +71,7 @@ func (self *rktFactory) DebugInfo() map[string][]string {
 	return map[string][]string{}
 }
 
-func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics container.MetricSet) error {
+func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics container.MetricSet, enforceLabelWhitelist bool, labelsWhiteList []string) error {
 	_, err := Client()
 	if err != nil {
 		return fmt.Errorf("unable to communicate with Rkt api service: %v", err)
@@ -88,11 +92,13 @@ func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, igno
 
 	glog.Infof("Registering Rkt factory")
 	factory := &rktFactory{
-		machineInfoFactory: machineInfoFactory,
-		fsInfo:             fsInfo,
-		cgroupSubsystems:   &cgroupSubsystems,
-		ignoreMetrics:      ignoreMetrics,
-		rktPath:            rktPath,
+		machineInfoFactory:    machineInfoFactory,
+		fsInfo:                fsInfo,
+		enforceLabelWhitelist: enforceLabelWhitelist,
+		labelWhitelist:        labelsWhiteList,
+		cgroupSubsystems:      &cgroupSubsystems,
+		ignoreMetrics:         ignoreMetrics,
+		rktPath:               rktPath,
 	}
 	container.RegisterContainerHandlerFactory(factory, []watcher.ContainerWatchSource{watcher.Rkt})
 	return nil

--- a/container/rkt/factory.go
+++ b/container/rkt/factory.go
@@ -58,7 +58,7 @@ func (self *rktFactory) NewContainerHandler(name string, inHostNamespace bool) (
 	if !inHostNamespace {
 		rootFs = "/rootfs"
 	}
-	return newRktContainerHandler(name, client, self.rktPath, self.cgroupSubsystems, self.machineInfoFactory, self.fsInfo, rootFs, self.ignoreMetrics)
+	return newRktContainerHandler(name, client, self.rktPath, self.cgroupSubsystems, self.machineInfoFactory, self.fsInfo, rootFs, self.ignoreMetrics, self.enforceLabelWhitelist, self.labelWhitelist)
 }
 
 func (self *rktFactory) CanHandleAndAccept(name string) (bool, bool, error) {

--- a/container/rkt/factory.go
+++ b/container/rkt/factory.go
@@ -71,7 +71,7 @@ func (self *rktFactory) DebugInfo() map[string][]string {
 	return map[string][]string{}
 }
 
-func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics container.MetricSet, enforceLabelWhitelist bool, labelsWhiteList []string) error {
+func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics container.MetricSet, enforceLabelWhitelist bool, labelWhiteList []string) error {
 	_, err := Client()
 	if err != nil {
 		return fmt.Errorf("unable to communicate with Rkt api service: %v", err)
@@ -95,7 +95,7 @@ func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, igno
 		machineInfoFactory:    machineInfoFactory,
 		fsInfo:                fsInfo,
 		enforceLabelWhitelist: enforceLabelWhitelist,
-		labelWhitelist:        labelsWhiteList,
+		labelWhitelist:        labelWhiteList,
 		cgroupSubsystems:      &cgroupSubsystems,
 		ignoreMetrics:         ignoreMetrics,
 		rktPath:               rktPath,

--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -39,6 +39,16 @@ From [glog](https://github.com/golang/glog) here are some flags we find useful:
 --vmodule=: comma-separated list of pattern=N settings for file-filtered logging
 ```
 
+## Labels
+
+Both Docker and Rkt labels support restricting the amount of labels collected by `cadvisor`. 
+
+```
+--enforce_label_whitelist=false: whether or not to enforce whitelisting of labels
+--label_whitelist="": comma-separated list of label keys that are allowed to be collected
+```
+
+
 ## Docker
 
 ```

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -54,7 +54,7 @@ import (
 var globalHousekeepingInterval = flag.Duration("global_housekeeping_interval", 1*time.Minute, "Interval between global housekeepings")
 var logCadvisorUsage = flag.Bool("log_cadvisor_usage", false, "Whether to log the usage of the cAdvisor container")
 var enforceLabelWhitelist = flag.Bool("enforce_label_whitelist", false, "enforces label whitelisting")
-var labelWhitelist = flag.String("label_whitelist", "", "comma-separated list of label keys that needs to be collected for docker containers")
+var labelWhitelist = flag.String("label_whitelist", "", "comma-separated list of label keys that are allowed to be collected for docker and rkt containers")
 var eventStorageAgeLimit = flag.String("event_storage_age_limit", "default=24h", "Max length of time for which to store events (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or \"default\" and the value is a duration. Default is applied to all non-specified event types")
 var eventStorageEventLimit = flag.String("event_storage_event_limit", "default=100000", "Max number of events to store (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or \"default\" and the value is an integer. Default is applied to all non-specified event types")
 var applicationMetricsCountLimit = flag.Int("application_metrics_count_limit", 100, "Max number of application metrics to store (per container)")


### PR DESCRIPTION
Hey,

going after #1730, the PR adds two flags:

- `-docker_no_labels`: forces no retrieval of labels
- `-docker_label_whitelist`: whitelists labels to be retrieved in case `docker_no_labels` is set

The first flag is useful not only for a proper implementation of the second but also for those that don't need labels at all but receive them in push-based systems (like InfluxDB).

Do you think it makes sense to keep them separate? I wondered if we could force `docker_no_labels` via `docker_label_whitelist=""`  (empty slice), but that didn't feel very right (I prefer the explicitness of having both).

Also, should I add an integration test for this behavior? Should I add a handler test?

Thanks! 

---

Without `docker_no_labels`, we expect receiving all the labels:

```
container_tasks_state{container_label_com_docker_compose_config_hash="92efcf747964251a5581db4f85ed470d74c4f7362294627a351bf0b1b5ff1964",container_label_com_docker_compose_container_number="1",container_label_com_docker_compose_oneoff="False",container_label_com_docker_compose_project="influx",container_label_com_docker_compose_service="influxdb",container_label_com_docker_compose_version="1.15.0",id="/docker/a0d5ca740222dec2d0d17b04b77aa14a0c123b6a8d272c38d9e5c8896f76df74",image="influxdb:alpine",name="influx_influxdb_1",state="uninterruptible"} 0
```

With `docker_no_labels`, 0 labels:

```
container_tasks_state{id="/docker/a0d5ca740222dec2d0d17b04b77aa14a0c123b6a8d272c38d9e5c8896f76df74",image="influxdb:alpine",name="influx_influxdb_1",state="iowaiting"} 0
```

With `docker_no_labels` and `docker_label_metadata_whitelist=com.docker.compose.service` we expect receiving only the label whitelisted:

```
container_tasks_state{container_label_com_docker_compose_service="influxdb",id="/docker/a0d5ca740222dec2d0d17b04b77aa14a0c123b6a8d272c38d9e5c8896f76df74",image="influxdb:alpine",name="influx_influxdb_1",state="iowaiting"} 0
```

With `docker_label_metadata_whitelist` but no `docker_no_labels` we expect receiving all labels:

```
container_tasks_state{container_label_com_docker_compose_config_hash="92efcf747964251a5581db4f85ed470d74c4f7362294627a351bf0b1b5ff1964",container_label_com_docker_compose_container_number="1",container_label_com_docker_compose_oneoff="False",container_label_com_docker_compose_project="influx",container_label_com_docker_compose_service="influxdb",container_label_com_docker_compose_version="1.15.0",id="/docker/a0d5ca740222dec2d0d17b04b77aa14a0c123b6a8d272c38d9e5c8896f76df74",image="influxdb:alpine",name="influx_influxdb_1",state="uninterruptible"} 0
```