### PR TITLE
apt-get update, not apt-cache update

### DIFF
--- a/deploy/canary/Dockerfile
+++ b/deploy/canary/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:latest
 MAINTAINER vmarmol@google.com
 
-RUN apt-cache update && apt-get install -y git dmsetup && apt-get clean
+RUN apt-get update && apt-get install -y git dmsetup && apt-get clean
 RUN git clone https://github.com/google/cadvisor.git /go/src/github.com/google/cadvisor
 RUN cd /go/src/github.com/google/cadvisor && make
 


### PR DESCRIPTION
failure: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-cadvisor-canarypush/298
follow-up to #1751
cc @ixdy