### PR TITLE
Add memory reservation in prom `/metrics` endpoint.

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -794,6 +794,8 @@ func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric)
 			ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, specMemoryValue(container.Spec.Memory.Limit), values...)
 			desc = prometheus.NewDesc("container_spec_memory_swap_limit_bytes", "Memory swap limit for the container.", labels, nil)
 			ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, specMemoryValue(container.Spec.Memory.SwapLimit), values...)
+			desc = prometheus.NewDesc("container_spec_memory_reservation_limit_bytes", "Memory reservation limit for the container.", labels, nil)
+			ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, specMemoryValue(container.Spec.Memory.Reservation), values...)
 		}
 
 		// Now for the actual metrics

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -63,6 +63,11 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 					Period: 100000,
 					Quota:  10000,
 				},
+				Memory: info.MemorySpec{
+					Limit:       2048,
+					Reservation: 1024,
+					SwapLimit:   4096,
+				},
 				CreationTime: time.Unix(1257894000, 0),
 				Labels: map[string]string{
 					"foo.label": "bar",


### PR DESCRIPTION
Hi folks,

I'd like to take a PR to expose `container_spec_memory_reservation_limit_bytes` metric within the `/metrics` endpoint.

Currently, [memory reservation](https://github.com/google/cadvisor/blob/master/info/v1/container.go#L37) is collected but just not exposed to prometheus.

Thanks.