### PR TITLE
adaptive longOp for du operation

### DIFF
--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -51,7 +51,6 @@ type realFsHandler struct {
 }
 
 const (
-	longOp           = time.Second
 	timeout          = 2 * time.Minute
 	maxBackoffFactor = 20
 )
@@ -111,6 +110,7 @@ func (fh *realFsHandler) update() error {
 
 func (fh *realFsHandler) trackUsage() {
 	fh.update()
+	longOp := time.Second
 	for {
 		select {
 		case <-fh.stopChan:
@@ -128,7 +128,11 @@ func (fh *realFsHandler) trackUsage() {
 			}
 			duration := time.Since(start)
 			if duration > longOp {
-				glog.V(2).Infof("du and find on following dirs took %v: %v", duration, []string{fh.rootfs, fh.extraDir})
+				// adapt longOp time so that message doesn't continue to print
+				// if the long duration is persistent either because of slow
+				// disk or lots of containers.
+				longOp = longOp + time.Second
+				glog.V(2).Infof("du and find on following dirs took %v: %v; will not log again for this container unless duration exceeds %d seconds.", duration, []string{fh.rootfs, fh.extraDir}, longOp)
 			}
 		}
 	}


### PR DESCRIPTION
When running pod density tests on the order of 500 pods, the du operation in the fsHandler can take longer than a second, even if everything about the filesystem is cached.  This is a persistent condition that causes the message to continually print.

This PR makes `longOp` adaptive so if the long du duration is a persistent condition, the message won't continue in the logs forever.

https://bugzilla.redhat.com/show_bug.cgi?id=1498632

@dashpole @vishh @derekwaynecarr @ravisantoshgudimetla