### PR TITLE
Container stats expose memory max usage

### DIFF
--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -509,6 +509,7 @@ func setDiskIoStats(s *cgroups.Stats, ret *info.ContainerStats) {
 
 func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	ret.Memory.Usage = s.MemoryStats.Usage.Usage
+	ret.Memory.MaxUsage = s.MemoryStats.Usage.MaxUsage
 	ret.Memory.Failcnt = s.MemoryStats.Usage.Failcnt
 	ret.Memory.Cache = s.MemoryStats.Stats["cache"]
 

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -330,6 +330,10 @@ type MemoryStats struct {
 	// Units: Bytes.
 	Usage uint64 `json:"usage"`
 
+	// Maximum memory usage recorded.
+	// Units: Bytes.
+	MaxUsage uint64 `json:"max_usage"`
+
 	// Number of bytes of page cache memory.
 	// Units: Bytes.
 	Cache uint64 `json:"cache"`

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -231,6 +231,14 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 				getValues: func(s *info.ContainerStats) metricValues {
 					return metricValues{{value: float64(s.Memory.Usage)}}
 				},
+			},
+			{
+				name:      "container_memory_max_usage_bytes",
+				help:      "Maximum memory usage recorded in bytes",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.MaxUsage)}}
+				},
 			}, {
 				name:      "container_memory_working_set_bytes",
 				help:      "Current working set in bytes.",

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -94,6 +94,7 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 					},
 					Memory: info.MemoryStats{
 						Usage:      8,
+						MaxUsage:   8,
 						WorkingSet: 9,
 						ContainerData: info.MemoryStatsMemoryData{
 							Pgfault:    10,

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -100,6 +100,9 @@ container_memory_failures_total{container_env_foo_env="prod",container_label_foo
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgmajfault",zone_name="hello"} 11
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgfault",zone_name="hello"} 12
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgmajfault",zone_name="hello"} 13
+# HELP container_memory_max_usage_bytes Maximum memory usage recorded in bytes
+# TYPE container_memory_max_usage_bytes gauge
+container_memory_max_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8
 # HELP container_memory_rss Size of RSS in bytes.
 # TYPE container_memory_rss gauge
 container_memory_rss{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 15


### PR DESCRIPTION
Expose `memory.max_usage_in_bytes` per container from memory cgroup.

Value is visible from REST API and Prometheus (container_memory_max_usage_bytes)

This is useful for understanding peak usage for a container over its life.

/cc @dashpole @sjenning @smarterclayton @dchen1107 @vishh 