### PR TITLE
CRI-O: fix handling of overlay2 storage

### DIFF
--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -18,6 +18,7 @@ package crio
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -142,6 +143,12 @@ func newCrioContainerHandler(
 	// get device ID from root, otherwise, it's going to error out as overlay
 	// mounts doesn't have fixed dev ids.
 	rootfsStorageDir = strings.TrimSuffix(rootfsStorageDir, "/merged")
+	switch storageDriver {
+	case overlayStorageDriver, overlay2StorageDriver:
+		// overlay and overlay2 driver are the same "overlay2" driver so treat
+		// them the same.
+		rootfsStorageDir = filepath.Join(rootfsStorageDir, "diff")
+	}
 
 	// TODO: extract object mother method
 	handler := &crioContainerHandler{


### PR DESCRIPTION
Verified we're now reading the `diff` dir in container's storage:
```json
      "rootfs": {
       "time": "2017-10-13T08:27:45Z",
       "availableBytes": 10798333952,
       "capacityBytes": 52710469632,
       "usedBytes": 90112,
       "inodesFree": 2659325,
       "inodes": 3276800,
       "inodesUsed": 16
      },
```
```sh
[root@runcom 4f4cc46320d76a12e9a833a7708ad62d5d5c8359911553cb3a25e0b12d6c3f75]# pwd
/var/lib/containers/storage/overlay2/4f4cc46320d76a12e9a833a7708ad62d5d5c8359911553cb3a25e0b12d6c3f75
[root@runcom 4f4cc46320d76a12e9a833a7708ad62d5d5c8359911553cb3a25e0b12d6c3f75]# du -s -B1 ./diff/
90112   ./diff/
```

@derekwaynecarr @mrunalp @dashpole PTAL

related to #1770 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>