### PR TITLE
Memory leak in fs.go

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -603,10 +603,11 @@ func GetDirInodeUsage(dir string, timeout time.Duration) (uint64, error) {
 		glog.Infof("killing cmd %v due to timeout(%s)", findCmd.Args, timeout.String())
 		findCmd.Process.Kill()
 	})
-	if err := findCmd.Wait(); err != nil {
+	err := findCmd.Wait()
+	timer.Stop()
+	if err != nil {
 		return 0, fmt.Errorf("cmd %v failed. stderr: %s; err: %v", findCmd.Args, stderr.String(), err)
 	}
-	timer.Stop()
 	return counter.bytesWritten, nil
 }
 


### PR DESCRIPTION
We have 400+ containers per host, each with 2GB+ container filesystems. Running cadvisor on this hosts is not possible because it get OOM'ed after short period (1min) because of:

```
Tasks: 2921 total,   2 running, 2919 sleeping,   0 stopped,   0 zombie
%Cpu(s): 68.5 us, 16.1 sy,  0.0 ni, 13.6 id,  0.4 wa,  0.0 hi,  1.3 si,  0.0 st
KiB Mem : 32781868 total,   254724 free, 27097596 used,  5429548 buff/cache
KiB Swap:  5242876 total,        0 free,  5242876 used.  3512320 avail Mem

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
11234 root      20   0 9862.7m 8.491g   6304 S 532.0 27.2   8:22.50 cadvisor
   60 root      20   0       0      0      0 S  22.7  0.0   2086:31 kswapd0
```

We can fix this behavior by adding
```
--disable_metrics=disk
```
but thats not what we want. 
After digging through the fs.go implementation we found this small inconsistency in 

`GetDirInodeUsage`
compared to
`GetDirDiskUsage`
regarding the handling of stopping the time.AfterFunc go routine.

With this fix applied, and making both functions behave equally we cannot reproduce the memory leak anymore.
I cant explain why TBH.
