### PR TITLE
fix long du duration message

### DIFF
--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -132,7 +132,7 @@ func (fh *realFsHandler) trackUsage() {
 				// if the long duration is persistent either because of slow
 				// disk or lots of containers.
 				longOp = longOp + time.Second
-				glog.V(2).Infof("du and find on following dirs took %v: %v; will not log again for this container unless duration exceeds %d seconds.", duration, []string{fh.rootfs, fh.extraDir}, longOp)
+				glog.V(2).Infof("du and find on following dirs took %v: %v; will not log again for this container unless duration exceeds %v", duration, []string{fh.rootfs, fh.extraDir}, longOp)
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/google/cadvisor/pull/1766 introduced a message that prints out in nanoseconds.  This fixes up that message.

@derekwaynecarr @dashpole