### PR TITLE
marshal device name to json output

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -307,7 +307,7 @@ type CpuStats struct {
 }
 
 type PerDiskStats struct {
-	Device string            `json:"-"`
+	Device string            `json:"device"`
 	Major  uint64            `json:"major"`
 	Minor  uint64            `json:"minor"`
 	Stats  map[string]uint64 `json:"stats"`


### PR DESCRIPTION
This PR will make `device` available when json marshal disk stats as we will use device name as a label in heapster when adding disk io metrics in [heapster #1450](https://github.com/kubernetes/heapster/pull/1450)

Since @smarterclayton added `device` to cadivsor in #1642 , so could you please take a look at this.

/cc @dashpole @derekwaynecarr 