### PR TITLE
Add context to docker API to timeout requests

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -201,7 +201,7 @@ func newDockerContainerHandler(
 	case overlay2StorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID, overlay2RWLayer)
 	case zfsStorageDriver:
-		status, err := Status()
+		status, err := Status(DefaultContext())
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine docker status: %v", err)
 		}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -154,7 +154,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 		dockerStatus info.DockerStatus
 		rktPath      string
 	)
-	if tempDockerStatus, err := docker.Status(); err != nil {
+	if tempDockerStatus, err := docker.Status(docker.DefaultContext()); err != nil {
 		glog.V(5).Infof("Docker not connected: %v", err)
 	} else {
 		dockerStatus = tempDockerStatus
@@ -1280,11 +1280,11 @@ func parseEventsStoragePolicy() events.StoragePolicy {
 }
 
 func (m *manager) DockerImages() ([]info.DockerImage, error) {
-	return docker.Images()
+	return docker.Images(docker.DefaultContext())
 }
 
 func (m *manager) DockerInfo() (info.DockerStatus, error) {
-	return docker.Status()
+	return docker.Status(docker.DefaultContext())
 }
 
 func (m *manager) DebugInfo() map[string][]string {
@@ -1343,8 +1343,14 @@ func getVersionInfo() (*info.VersionInfo, error) {
 
 	kernel_version := machine.KernelVersion()
 	container_os := machine.ContainerOsVersion()
-	docker_version := docker.VersionString()
-	docker_api_version := docker.APIVersionString()
+	docker_version, err := docker.VersionString(docker.DefaultContext())
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve docker version: %v", err)
+	}
+	docker_api_version, err := docker.APIVersionString(docker.DefaultContext())
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve docker API version: %v", err)
+	}
 
 	return &info.VersionInfo{
 		KernelVersion:      kernel_version,

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -185,7 +185,7 @@ func validateCgroups() (string, string) {
 }
 
 func validateDockerInfo() (string, string) {
-	info, err := docker.ValidateInfo()
+	info, err := docker.ValidateInfo(docker.DefaultContext())
 	if err != nil {
 		return Unsupported, fmt.Sprintf("Docker setup is invalid: %v", err)
 	}


### PR DESCRIPTION
Docker requests can hang sometimes. Add a context so clients of the
docker API can timeout the requests and retry, or some other action.

To fix https://github.com/kubernetes/kubernetes/issues/53207