### PR TITLE
 Add Prometheus total CPU metric and allow per-cpu stats to be disabled

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -72,6 +72,7 @@ var (
 		container.NetworkUsageMetrics:    struct{}{},
 		container.NetworkTcpUsageMetrics: struct{}{},
 		container.NetworkUdpUsageMetrics: struct{}{},
+		container.PerCpuUsageMetrics:     struct{}{},
 	}
 )
 
@@ -103,7 +104,7 @@ func (ml *metricSetValue) Set(value string) error {
 }
 
 func init() {
-	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'disk', 'network', 'tcp', 'udp'. Note: tcp and udp are disabled by default due to high CPU usage.")
+	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'disk', 'network', 'tcp', 'udp', 'percpu'. Note: tcp and udp are disabled by default due to high CPU usage.")
 
 	// Default logging verbosity to V(2)
 	flag.Set("v", "2")

--- a/container/factory.go
+++ b/container/factory.go
@@ -42,6 +42,7 @@ type MetricKind string
 
 const (
 	CpuUsageMetrics        MetricKind = "cpu"
+	PerCpuUsageMetrics     MetricKind = "percpu"
 	MemoryUsageMetrics     MetricKind = "memory"
 	CpuLoadMetrics         MetricKind = "cpuLoad"
 	DiskIOMetrics          MetricKind = "diskIO"

--- a/container/libcontainer/helpers_test.go
+++ b/container/libcontainer/helpers_test.go
@@ -122,7 +122,7 @@ func TestMorePossibleCPUs(t *testing.T) {
 		},
 	}
 	var ret info.ContainerStats
-	setCpuStats(s, &ret)
+	setCpuStats(s, &ret, true)
 
 	expected := info.ContainerStats{
 		Cpu: info.CpuStats{
@@ -130,7 +130,7 @@ func TestMorePossibleCPUs(t *testing.T) {
 				PerCpu: perCpuUsage[0:realNumCPUs],
 				User:   s.CpuStats.CpuUsage.UsageInUsermode,
 				System: s.CpuStats.CpuUsage.UsageInKernelmode,
-				Total:  8562955455524 * uint64(realNumCPUs),
+				Total:  33802947350272,
 			},
 		},
 	}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -150,10 +150,18 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 				},
 			}, {
 				name:        "container_cpu_usage_seconds_total",
-				help:        "Cumulative cpu time consumed per cpu in seconds.",
+				help:        "Cumulative cpu time consumed in seconds.",
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"cpu"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if len(s.Cpu.Usage.PerCpu) == 0 {
+						if s.Cpu.Usage.Total > 0 {
+							return metricValues{{
+								value:  float64(s.Cpu.Usage.Total) / float64(time.Second),
+								labels: []string{"total"},
+							}}
+						}
+					}
 					values := make(metricValues, 0, len(s.Cpu.Usage.PerCpu))
 					for i, value := range s.Cpu.Usage.PerCpu {
 						if value > 0 {

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -28,7 +28,7 @@ container_cpu_load_average_10s{container_env_foo_env="prod",container_label_foo_
 # HELP container_cpu_system_seconds_total Cumulative system cpu time consumed in seconds.
 # TYPE container_cpu_system_seconds_total counter
 container_cpu_system_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 7e-09
-# HELP container_cpu_usage_seconds_total Cumulative cpu time consumed per cpu in seconds.
+# HELP container_cpu_usage_seconds_total Cumulative cpu time consumed in seconds.
 # TYPE container_cpu_usage_seconds_total counter
 container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu00",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2e-09
 container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu01",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3e-09


### PR DESCRIPTION
Fixes #1513 

I'm a little uneasy that disabling the per-cpu stats means we use a different source for the data.
I could have it still go through the loop, but is that necessary?

cc @dashpole 