### PR TITLE
reduce labels for container info

### DIFF
--- a/cache/memory/memory.go
+++ b/cache/memory/memory.go
@@ -70,16 +70,16 @@ type InMemoryCache struct {
 	backend           storage.StorageDriver
 }
 
-func (self *InMemoryCache) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+func (self *InMemoryCache) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
 	var cstore *containerCache
 	var ok bool
 
 	func() {
 		self.lock.Lock()
 		defer self.lock.Unlock()
-		if cstore, ok = self.containerCacheMap[ref.Name]; !ok {
-			cstore = newContainerStore(ref, self.maxAge)
-			self.containerCacheMap[ref.Name] = cstore
+		if cstore, ok = self.containerCacheMap[cInfo.ContainerReference.Name]; !ok {
+			cstore = newContainerStore(cInfo.ContainerReference, self.maxAge)
+			self.containerCacheMap[cInfo.ContainerReference.Name] = cstore
 		}
 	}()
 
@@ -87,7 +87,7 @@ func (self *InMemoryCache) AddStats(ref info.ContainerReference, stats *info.Con
 		// TODO(monnand): To deal with long delay write operations, we
 		// may want to start a pool of goroutines to do write
 		// operations.
-		if err := self.backend.AddStats(ref, stats); err != nil {
+		if err := self.backend.AddStats(cInfo, stats); err != nil {
 			glog.Error(err)
 		}
 	}

--- a/cache/memory/memory_test.go
+++ b/cache/memory/memory_test.go
@@ -27,8 +27,10 @@ import (
 const containerName = "/container"
 
 var (
-	containerRef = info.ContainerReference{Name: containerName}
-	zero         time.Time
+	cInfo = info.ContainerInfo{
+		ContainerReference: info.ContainerReference{Name: containerName},
+	}
+	zero time.Time
 )
 
 // Make stats with the specified identifier.
@@ -51,15 +53,17 @@ func TestAddStats(t *testing.T) {
 	memoryCache := New(60*time.Second, nil)
 
 	assert := assert.New(t)
-	assert.Nil(memoryCache.AddStats(containerRef, makeStat(0)))
-	assert.Nil(memoryCache.AddStats(containerRef, makeStat(1)))
-	assert.Nil(memoryCache.AddStats(containerRef, makeStat(2)))
-	assert.Nil(memoryCache.AddStats(containerRef, makeStat(0)))
-	containerRef2 := info.ContainerReference{
-		Name: "/container2",
+	assert.Nil(memoryCache.AddStats(&cInfo, makeStat(0)))
+	assert.Nil(memoryCache.AddStats(&cInfo, makeStat(1)))
+	assert.Nil(memoryCache.AddStats(&cInfo, makeStat(2)))
+	assert.Nil(memoryCache.AddStats(&cInfo, makeStat(0)))
+	cInfo2 := info.ContainerInfo{
+		ContainerReference: info.ContainerReference{
+			Name: "/container2",
+		},
 	}
-	assert.Nil(memoryCache.AddStats(containerRef2, makeStat(0)))
-	assert.Nil(memoryCache.AddStats(containerRef2, makeStat(1)))
+	assert.Nil(memoryCache.AddStats(&cInfo2, makeStat(0)))
+	assert.Nil(memoryCache.AddStats(&cInfo2, makeStat(1)))
 }
 
 func TestRecentStatsNoRecentStats(t *testing.T) {
@@ -74,7 +78,7 @@ func makeWithStats(n int) *InMemoryCache {
 	memoryCache := New(60*time.Second, nil)
 
 	for i := 0; i < n; i++ {
-		memoryCache.AddStats(containerRef, makeStat(i))
+		memoryCache.AddStats(&cInfo, makeStat(i))
 	}
 	return memoryCache
 }

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -148,7 +148,6 @@ func (self *containerdContainerHandler) ContainerReference() (info.ContainerRefe
 		Id:        self.id,
 		Name:      self.name,
 		Namespace: k8sContainerdNamespace,
-		Labels:    self.labels,
 		Aliases:   self.aliases,
 	}, nil
 }

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -89,7 +89,6 @@ func TestHandler(t *testing.T) {
 				Name:      "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
 				Aliases:   []string{"40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"},
 				Namespace: k8sContainerdNamespace,
-				Labels:    map[string]string{"io.cri-containerd.kind": "sandbox"},
 			},
 		},
 	} {

--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -209,7 +209,6 @@ func (self *crioContainerHandler) ContainerReference() (info.ContainerReference,
 		Name:      self.name,
 		Aliases:   self.aliases,
 		Namespace: CrioNamespace,
-		Labels:    self.labels,
 	}, nil
 }
 

--- a/container/crio/handler_test.go
+++ b/container/crio/handler_test.go
@@ -99,7 +99,6 @@ func TestHandler(t *testing.T) {
 				Name:      "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f",
 				Aliases:   []string{"test", "81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f"},
 				Namespace: CrioNamespace,
-				Labels:    map[string]string{"io.kubernetes.container.name": "POD"},
 			},
 		},
 	} {

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -369,7 +369,6 @@ func (self *dockerContainerHandler) ContainerReference() (info.ContainerReferenc
 		Name:      self.name,
 		Aliases:   self.aliases,
 		Namespace: DockerNamespace,
-		Labels:    self.labels,
 	}, nil
 }
 

--- a/container/rkt/handler.go
+++ b/container/rkt/handler.go
@@ -178,7 +178,6 @@ func (handler *rktContainerHandler) ContainerReference() (info.ContainerReferenc
 		Name:      handler.name,
 		Aliases:   handler.aliases,
 		Namespace: RktNamespace,
-		Labels:    handler.labels,
 	}, nil
 }
 

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -85,8 +85,6 @@ type ContainerReference struct {
 	// Namespace under which the aliases of a container are unique.
 	// An example of a namespace is "docker" for Docker containers.
 	Namespace string `json:"namespace,omitempty"`
-
-	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Sorts by container name.

--- a/manager/container.go
+++ b/manager/container.go
@@ -615,7 +615,12 @@ func (c *containerData) updateStats() error {
 		}
 		return err
 	}
-	err = c.memoryCache.AddStats(ref, stats)
+
+	cInfo := info.ContainerInfo{
+		ContainerReference: ref,
+	}
+
+	err = c.memoryCache.AddStats(&cInfo, stats)
 	if err != nil {
 		return err
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -102,8 +102,12 @@ func expectManagerWithContainers(containers []string, query *info.ContainerInfoR
 			if err != nil {
 				t.Error(err)
 			}
+
+			cInfo := info.ContainerInfo{
+				ContainerReference: ref,
+			}
 			for _, stat := range cinfo.Stats {
-				err = memoryCache.AddStats(ref, stat)
+				err = memoryCache.AddStats(&cInfo, stat)
 				if err != nil {
 					t.Error(err)
 				}
@@ -148,8 +152,13 @@ func expectManagerWithContainersV2(containers []string, query *info.ContainerInf
 			if err != nil {
 				t.Error(err)
 			}
+
+			cInfo := info.ContainerInfo{
+				ContainerReference: ref,
+			}
+
 			for _, stat := range cinfo.Stats {
-				err = memoryCache.AddStats(ref, stat)
+				err = memoryCache.AddStats(&cInfo, stat)
 				if err != nil {
 					t.Error(err)
 				}

--- a/storage/bigquery/bigquery.go
+++ b/storage/bigquery/bigquery.go
@@ -193,7 +193,7 @@ func (self *bigqueryStorage) GetSchema() *bigquery.TableSchema {
 }
 
 func (self *bigqueryStorage) containerStatsToRows(
-	ref info.ContainerReference,
+	cInfo *info.ContainerInfo,
 	stats *info.ContainerStats,
 ) (row map[string]interface{}) {
 	row = make(map[string]interface{})
@@ -205,9 +205,9 @@ func (self *bigqueryStorage) containerStatsToRows(
 	row[colMachineName] = self.machineName
 
 	// Container name
-	name := ref.Name
-	if len(ref.Aliases) > 0 {
-		name = ref.Aliases[0]
+	name := cInfo.ContainerReference.Name
+	if len(cInfo.ContainerReference.Aliases) > 0 {
+		name = cInfo.ContainerReference.Aliases[0]
 	}
 	row[colContainerName] = name
 
@@ -250,7 +250,7 @@ func (self *bigqueryStorage) containerStatsToRows(
 }
 
 func (self *bigqueryStorage) containerFilesystemStatsToRows(
-	ref info.ContainerReference,
+	cInfo *info.ContainerInfo,
 	stats *info.ContainerStats,
 ) (rows []map[string]interface{}) {
 	for _, fsStat := range stats.Filesystem {
@@ -263,13 +263,13 @@ func (self *bigqueryStorage) containerFilesystemStatsToRows(
 	return rows
 }
 
-func (self *bigqueryStorage) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+func (self *bigqueryStorage) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
 	if stats == nil {
 		return nil
 	}
 	rows := make([]map[string]interface{}, 0)
-	rows = append(rows, self.containerStatsToRows(ref, stats))
-	rows = append(rows, self.containerFilesystemStatsToRows(ref, stats)...)
+	rows = append(rows, self.containerStatsToRows(cInfo, stats))
+	rows = append(rows, self.containerFilesystemStatsToRows(cInfo, stats)...)
 	for _, row := range rows {
 		err := self.client.InsertRow(row)
 		if err != nil {

--- a/storage/elasticsearch/elasticsearch.go
+++ b/storage/elasticsearch/elasticsearch.go
@@ -68,13 +68,13 @@ func new() (storage.StorageDriver, error) {
 }
 
 func (self *elasticStorage) containerStatsAndDefaultValues(
-	ref info.ContainerReference, stats *info.ContainerStats) *detailSpec {
+	cInfo *info.ContainerInfo, stats *info.ContainerStats) *detailSpec {
 	timestamp := stats.Timestamp.UnixNano() / 1E3
 	var containerName string
-	if len(ref.Aliases) > 0 {
-		containerName = ref.Aliases[0]
+	if len(cInfo.ContainerReference.Aliases) > 0 {
+		containerName = cInfo.ContainerReference.Aliases[0]
 	} else {
-		containerName = ref.Name
+		containerName = cInfo.ContainerReference.Name
 	}
 	detail := &detailSpec{
 		Timestamp:      timestamp,
@@ -85,7 +85,7 @@ func (self *elasticStorage) containerStatsAndDefaultValues(
 	return detail
 }
 
-func (self *elasticStorage) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+func (self *elasticStorage) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
 	if stats == nil {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (self *elasticStorage) AddStats(ref info.ContainerReference, stats *info.Co
 		self.lock.Lock()
 		defer self.lock.Unlock()
 		// Add some default params based on ContainerStats
-		detail := self.containerStatsAndDefaultValues(ref, stats)
+		detail := self.containerStatsAndDefaultValues(cInfo, stats)
 		// Index a cadvisor (using JSON serialization)
 		_, err := self.client.Index().
 			Index(self.indexName).

--- a/storage/influxdb/influxdb_test.go
+++ b/storage/influxdb/influxdb_test.go
@@ -47,9 +47,9 @@ func (self *influxDbTestStorageDriver) readyToFlush() bool {
 	return self.count >= self.buffer
 }
 
-func (self *influxDbTestStorageDriver) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+func (self *influxDbTestStorageDriver) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
 	self.count++
-	return self.base.AddStats(ref, stats)
+	return self.base.AddStats(cInfo, stats)
 }
 
 func (self *influxDbTestStorageDriver) Close() error {

--- a/storage/kafka/kafka.go
+++ b/storage/kafka/kafka.go
@@ -60,11 +60,11 @@ type detailSpec struct {
 	ContainerStats  *info.ContainerStats `json:"container_stats,omitempty"`
 }
 
-func (driver *kafkaStorage) infoToDetailSpec(ref info.ContainerReference, stats *info.ContainerStats) *detailSpec {
+func (driver *kafkaStorage) infoToDetailSpec(cInfo *info.ContainerInfo, stats *info.ContainerStats) *detailSpec {
 	timestamp := time.Now()
-	containerID := ref.Id
-	containerLabels := ref.Labels
-	containerName := container.GetPreferredName(ref)
+	containerID := cInfo.ContainerReference.Id
+	containerLabels := cInfo.Spec.Labels
+	containerName := container.GetPreferredName(cInfo.ContainerReference)
 
 	detail := &detailSpec{
 		Timestamp:       timestamp,
@@ -77,8 +77,8 @@ func (driver *kafkaStorage) infoToDetailSpec(ref info.ContainerReference, stats 
 	return detail
 }
 
-func (driver *kafkaStorage) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
-	detail := driver.infoToDetailSpec(ref, stats)
+func (driver *kafkaStorage) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
+	detail := driver.infoToDetailSpec(cInfo, stats)
 	b, err := json.Marshal(detail)
 
 	driver.producer.Input() <- &kafka.ProducerMessage{

--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -65,13 +65,13 @@ func (self *redisStorage) defaultReadyToFlush() bool {
 }
 
 // We must add some default params (for example: MachineName,ContainerName...)because containerStats do not include them
-func (self *redisStorage) containerStatsAndDefaultValues(ref info.ContainerReference, stats *info.ContainerStats) *detailSpec {
+func (self *redisStorage) containerStatsAndDefaultValues(cInfo *info.ContainerInfo, stats *info.ContainerStats) *detailSpec {
 	timestamp := stats.Timestamp.UnixNano() / 1E3
 	var containerName string
-	if len(ref.Aliases) > 0 {
-		containerName = ref.Aliases[0]
+	if len(cInfo.ContainerReference.Aliases) > 0 {
+		containerName = cInfo.ContainerReference.Aliases[0]
 	} else {
-		containerName = ref.Name
+		containerName = cInfo.ContainerReference.Name
 	}
 	detail := &detailSpec{
 		Timestamp:      timestamp,
@@ -83,7 +83,7 @@ func (self *redisStorage) containerStatsAndDefaultValues(ref info.ContainerRefer
 }
 
 // Push the data into redis
-func (self *redisStorage) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+func (self *redisStorage) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
 	if stats == nil {
 		return nil
 	}
@@ -93,7 +93,7 @@ func (self *redisStorage) AddStats(ref info.ContainerReference, stats *info.Cont
 		self.lock.Lock()
 		defer self.lock.Unlock()
 		// Add some default params based on containerStats
-		detail := self.containerStatsAndDefaultValues(ref, stats)
+		detail := self.containerStatsAndDefaultValues(cInfo, stats)
 		// To json
 		b, _ := json.Marshal(detail)
 		if self.readyToFlush() {

--- a/storage/statsd/statsd.go
+++ b/storage/statsd/statsd.go
@@ -105,16 +105,16 @@ func (self *statsdStorage) containerFsStatsToValues(
 }
 
 // Push the data into redis
-func (self *statsdStorage) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+func (self *statsdStorage) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
 	if stats == nil {
 		return nil
 	}
 
 	var containerName string
-	if len(ref.Aliases) > 0 {
-		containerName = ref.Aliases[0]
+	if len(cInfo.ContainerReference.Aliases) > 0 {
+		containerName = cInfo.ContainerReference.Aliases[0]
 	} else {
-		containerName = ref.Name
+		containerName = cInfo.ContainerReference.Name
 	}
 
 	series := self.containerStatsToValues(stats)

--- a/storage/stdout/stdout.go
+++ b/storage/stdout/stdout.go
@@ -89,14 +89,14 @@ func (driver *stdoutStorage) containerFsStatsToValues(series *map[string]uint64,
 	}
 }
 
-func (driver *stdoutStorage) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
+func (driver *stdoutStorage) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
 	if stats == nil {
 		return nil
 	}
 
-	containerName := ref.Name
-	if len(ref.Aliases) > 0 {
-		containerName = ref.Aliases[0]
+	containerName := cInfo.ContainerReference.Name
+	if len(cInfo.ContainerReference.Aliases) > 0 {
+		containerName = cInfo.ContainerReference.Aliases[0]
 	}
 
 	var buffer bytes.Buffer

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,7 +22,7 @@ import (
 )
 
 type StorageDriver interface {
-	AddStats(ref info.ContainerReference, stats *info.ContainerStats) error
+	AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error
 
 	// Close will clear the state of the storage driver. The elements
 	// stored in the underlying storage may or may not be deleted depending

--- a/storage/test/mock.go
+++ b/storage/test/mock.go
@@ -25,8 +25,8 @@ type MockStorageDriver struct {
 	MockCloseMethod bool
 }
 
-func (self *MockStorageDriver) AddStats(ref info.ContainerReference, stats *info.ContainerStats) error {
-	args := self.Called(ref, stats)
+func (self *MockStorageDriver) AddStats(cInfo *info.ContainerInfo, stats *info.ContainerStats) error {
+	args := self.Called(cInfo.ContainerReference, stats)
 	return args.Error(0)
 }
 

--- a/storage/test/storagetests.go
+++ b/storage/test/storagetests.go
@@ -123,14 +123,16 @@ func StorageDriverFillRandomStatsFunc(
 
 	samplePeriod := 1 * time.Second
 
-	ref := info.ContainerReference{
-		Name: containerName,
+	cInfo := info.ContainerInfo{
+		ContainerReference: info.ContainerReference{
+			Name: containerName,
+		},
 	}
 
 	trace := buildTrace(cpuTrace, memTrace, samplePeriod)
 
 	for _, stats := range trace {
-		err := driver.AddStats(ref, stats)
+		err := driver.AddStats(&cInfo, stats)
 		if err != nil {
 			t.Fatalf("unable to add stats: %v", err)
 		}


### PR DESCRIPTION
Currently there are two `labels` fields in `ContainerInfo`. One is in `ContainerReference` and the other is in `ContainerSpec`. By leaving only one `labels`, it is should be good to reduce the output when requesting container info api.


/cc @dashpole @tallclair 