### PR TITLE
Drop container vm from testing.

### DIFF
--- a/build/jenkins_e2e.sh
+++ b/build/jenkins_e2e.sh
@@ -40,15 +40,10 @@ docker run --rm \
 # Nodes that are currently stable. When tests fail on a specific node, and the failure is not remedied within a week, that node will be removed from this list.
 golden_nodes=(
   e2e-cadvisor-ubuntu-trusty
-  e2e-cadvisor-container-vm-v20151215
-  e2e-cadvisor-container-vm-v20160127
   e2e-cadvisor-rhel-7
 )
 
 # TODO: Add test on GCI
-
-# TODO: Add test for kubernetes default image
-# e2e-cadvisor-container-vm-v20160321
 
 # TODO: Temporarily disabled for #1344
 # e2e-cadvisor-coreos-beta


### PR DESCRIPTION
We are migrating the vms from the jenkins project to a new project, since jenkins is not being used anymore.
To make this slightly easier, remove container vm, which we aren't testing against anymore.

cc @tallclair 