### PR TITLE
Adding /proc/<pid>/schedstat

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -64,6 +64,7 @@ var (
 	ignoreMetrics metricSetValue = metricSetValue{container.MetricSet{
 		container.NetworkTcpUsageMetrics: struct{}{},
 		container.NetworkUdpUsageMetrics: struct{}{},
+		container.ProcessSchedulerMetrics: struct{}{},
 	}}
 
 	// List of metrics that can be ignored.
@@ -73,6 +74,7 @@ var (
 		container.NetworkTcpUsageMetrics: struct{}{},
 		container.NetworkUdpUsageMetrics: struct{}{},
 		container.PerCpuUsageMetrics:     struct{}{},
+		container.ProcessSchedulerMetrics: struct{}{},
 	}
 )
 

--- a/container/factory.go
+++ b/container/factory.go
@@ -41,16 +41,17 @@ type ContainerHandlerFactory interface {
 type MetricKind string
 
 const (
-	CpuUsageMetrics        MetricKind = "cpu"
-	PerCpuUsageMetrics     MetricKind = "percpu"
-	MemoryUsageMetrics     MetricKind = "memory"
-	CpuLoadMetrics         MetricKind = "cpuLoad"
-	DiskIOMetrics          MetricKind = "diskIO"
-	DiskUsageMetrics       MetricKind = "disk"
-	NetworkUsageMetrics    MetricKind = "network"
-	NetworkTcpUsageMetrics MetricKind = "tcp"
-	NetworkUdpUsageMetrics MetricKind = "udp"
-	AppMetrics             MetricKind = "app"
+	CpuUsageMetrics         MetricKind = "cpu"
+	ProcessSchedulerMetrics MetricKind = "sched"
+	PerCpuUsageMetrics      MetricKind = "percpu"
+	MemoryUsageMetrics      MetricKind = "memory"
+	CpuLoadMetrics          MetricKind = "cpuLoad"
+	DiskIOMetrics           MetricKind = "diskIO"
+	DiskUsageMetrics        MetricKind = "disk"
+	NetworkUsageMetrics     MetricKind = "network"
+	NetworkTcpUsageMetrics  MetricKind = "tcp"
+	NetworkUdpUsageMetrics  MetricKind = "udp"
+	AppMetrics              MetricKind = "app"
 )
 
 func (mk MetricKind) String() string {

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -297,7 +297,6 @@ type CpuCFS struct {
 type CpuSchedstat struct {
 	// https://www.kernel.org/doc/Documentation/scheduler/sched-stats.txt
 
-	// These numbers are summed up over all processes in a cgroup and can therefore not capture processes after they are gone.
 	// time spent on the cpu
 	RunTime uint64 `json:"run_time"`
 	// time spent waiting on a runqueue

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -293,10 +293,24 @@ type CpuCFS struct {
 	ThrottledTime uint64 `json:"throttled_time"`
 }
 
+// Cpu Aggregated scheduler statistics
+type CpuSchedstat struct {
+	// https://www.kernel.org/doc/Documentation/scheduler/sched-stats.txt
+
+	// These numbers are summed up over all processes in a cgroup and can therefore not capture processes after they are gone.
+	// time spent on the cpu
+	RunTime uint64 `json:"run_time"`
+	// time spent waiting on a runqueue
+	RunqueueTime uint64 `json:"runqueue_time"`
+	// # of timeslices run on this cpu
+	RunPeriods uint64 `json:"run_periods"`
+}
+
 // All CPU usage metrics are cumulative from the creation of the container
 type CpuStats struct {
-	Usage CpuUsage `json:"usage"`
-	CFS   CpuCFS   `json:"cfs"`
+	Usage     CpuUsage     `json:"usage"`
+	CFS       CpuCFS       `json:"cfs"`
+	Schedstat CpuSchedstat `json:"schedstat"`
 	// Smoothed average of number of runnable threads x 1000.
 	// We multiply by thousand to avoid using floats, but preserving precision.
 	// Load is smoothed over the last 10 seconds. Instantaneous value can be read

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -198,6 +198,27 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 					return metricValues{{value: float64(s.Cpu.CFS.ThrottledTime) / float64(time.Second)}}
 				},
 			}, {
+				name:      "container_cpu_schedstat_run_seconds_total",
+				help:      "Time duration the processes of the container have run on the CPU.",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Cpu.Schedstat.RunTime) / float64(time.Second)}}
+				},
+			}, {
+				name:      "container_cpu_schedstat_runqueue_seconds_total",
+				help:      "Time duration processes of the container have been waiting on a runqueue.",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Cpu.Schedstat.RunqueueTime) / float64(time.Second)}}
+				},
+			}, {
+				name:      "container_cpu_schedstat_run_periods_total",
+				help:      "Number of times processes of the cgroup have run on the cpu",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Cpu.Schedstat.RunPeriods)}}
+				},
+			}, {
 				name:      "container_cpu_load_average_10s",
 				help:      "Value of container cpu load average over the last 10 seconds.",
 				valueType: prometheus.GaugeValue,

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -90,6 +90,11 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 							ThrottledPeriods: 18,
 							ThrottledTime:    1724314000,
 						},
+						Schedstat: info.CpuSchedstat{
+							RunTime:      53643567,
+							RunqueueTime: 479424566378,
+							RunPeriods:   984285,
+						},
 						LoadAverage: 2,
 					},
 					Memory: info.MemoryStats{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -25,6 +25,15 @@ container_cpu_cfs_throttled_seconds_total{container_env_foo_env="prod",container
 # HELP container_cpu_load_average_10s Value of container cpu load average over the last 10 seconds.
 # TYPE container_cpu_load_average_10s gauge
 container_cpu_load_average_10s{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2
+# HELP container_cpu_schedstat_run_periods_total Number of times processes of the cgroup have run on the cpu
+# TYPE container_cpu_schedstat_run_periods_total counter
+container_cpu_schedstat_run_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 984285
+# HELP container_cpu_schedstat_run_seconds_total Time duration the processes of the container have run on the CPU.
+# TYPE container_cpu_schedstat_run_seconds_total counter
+container_cpu_schedstat_run_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.053643567
+# HELP container_cpu_schedstat_runqueue_seconds_total Time duration processes of the container have been waiting on a runqueue.
+# TYPE container_cpu_schedstat_runqueue_seconds_total counter
+container_cpu_schedstat_runqueue_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 479.424566378
 # HELP container_cpu_system_seconds_total Cumulative system cpu time consumed in seconds.
 # TYPE container_cpu_system_seconds_total counter
 container_cpu_system_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 7e-09


### PR DESCRIPTION
Adding scheduler statistics of all processes in a container as discussed in #1865 . 

I will try this out in the coming days see how useful these are in reality and whether anything else pops up.

@dashpole 