### PR TITLE
let the user who call this method to handle the error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/google/cadvisor/info/v1"
 
-	"github.com/golang/glog"
 	"time"
 )
 
@@ -229,8 +228,8 @@ func (self *Client) getEventStreamingData(url string, einfo chan *v1.Event) erro
 			if err == io.EOF {
 				break
 			}
-			// if called without &stream=true will not be able to parse event and will trigger fatal
-			glog.Fatalf("Received error %v", err)
+			// if called without &stream=true will not be able to parse event and let the user who call this method to handle this error
+			return fmt.Errorf("received error %v", err)
 		}
 		einfo <- m
 	}


### PR DESCRIPTION
## let the user to handle the problem when decode event stream data fail
- here should not be fatal if some error occur, because it will cause the program to exit. And if the error just return, after catch that, we can try again or do something else to deal with that.
- if cadvisor client is just the client, maybe you can choose which log package to use as you want. The whole client package, except test code, just here use the glog package, so, I want return the error instead.
- if just return the error, #1875 fix.