### PR TITLE
cadvisor: build: fix broken build with Makefile

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -17,7 +17,6 @@
 set -e
 
 GO_FLAGS=${GO_FLAGS:-"-tags netgo"}    # Extra go flags to use in the build.
-GO_CMD=${GO_CMD:-"install"}
 BUILD_USER=${BUILD_USER:-"${USER}@${HOSTNAME}"}
 BUILD_DATE=${BUILD_DATE:-$( date +%Y%m%d-%H:%M:%S )}
 VERBOSE=${VERBOSE:-}
@@ -50,6 +49,6 @@ if [ -n "$VERBOSE" ]; then
   echo "Building with -ldflags $ldflags"
 fi
 
-GOBIN=$PWD go "$GO_CMD" ${GO_FLAGS} -ldflags "${ldflags}" "${repo_path}"
+GOBIN=$PWD go build ${GO_FLAGS} -ldflags "${ldflags}" "${repo_path}"
 
 exit 0

--- a/build/release.sh
+++ b/build/release.sh
@@ -35,7 +35,6 @@ fi
 # Build the release.
 export BUILD_USER="$git_user"
 export BUILD_DATE=$( date +%Y%m%d ) # Release date is only to day-granularity
-export GO_CMD="build" # Don't use cached build objects for releases.
 export VERBOSE=true
 build/build.sh
 


### PR DESCRIPTION
When using `make build` to compile the source,
build fails with error/s. The reason is because
of GO_CMD variable is set to 'install' as default,
which is not valid when running `make build` or
`make`.

Depending on the valid git tag, release.sh will
set the GO_CMD variable. If valid git tag is
available e.g.: vx.y.z.beta1, then GO_CMD is
set to `build`.

If valid git tag is not available, release.sh
will any way bails out serving the puspose.
So drop using GO_CMD, to fix the default build.