### PR TITLE
monitor only the upper directory for overlay

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -44,6 +44,7 @@ import (
 const (
 	// The read write layers exist here.
 	aufsRWLayer     = "diff"
+	overlayRWLayer  = "upper"
 	overlay2RWLayer = "diff"
 
 	// Path to the directory where docker stores log files if the json logging driver is enabled.
@@ -197,7 +198,7 @@ func newDockerContainerHandler(
 	case aufsStorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(aufsStorageDriver), aufsRWLayer, rwLayerID)
 	case overlayStorageDriver:
-		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID)
+		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID, overlayRWLayer)
 	case overlay2StorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID, overlay2RWLayer)
 	case zfsStorageDriver:


### PR DESCRIPTION
Issue: https://github.com/kubernetes/kubernetes/issues/59155

I have confirmed this fixes the issue, but don't know why yet.  I think this is along the same vein as the overlay2 bug (https://github.com/kubernetes/kubernetes/issues/47943), but I am surprised it wasn't caught earlier.
May have something to do with COS, or which things are mounted into the container.