### PR TITLE
Do not error out when /dev/disk/by-uuid is not found.

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -114,7 +114,9 @@ func NewFsInfo(context Context) (FsInfo, error) {
 
 	fsUUIDToDeviceName, err := getFsUUIDToDeviceNameMap()
 	if err != nil {
-		return nil, err
+		// UUID is not always avaiable across different OS distributions.
+		// Do not fail if there is an error.
+		glog.Warningf("Failed to get disk UUID mapping, getting disk info by uuid will not work: %v", err)
 	}
 
 	// Avoid devicemapper container mounts - these are tracked by the ThinPoolWatcher


### PR DESCRIPTION
We are switching off UUID in CRI. But I think it's still good to keep this feature.

However, Cadvisor shouldn't fail if `/dev/disk/by-uuid` is not found. Because `/dev/disk/by-uuid` is not always available on different OS distributions.

Signed-off-by: Lantao Liu <lantaol@google.com>