### PR TITLE
Add memory_rss in influxdb.go

### DIFF
--- a/storage/influxdb/influxdb.go
+++ b/storage/influxdb/influxdb.go
@@ -60,6 +60,8 @@ const (
 	serMemoryUsage string = "memory_usage"
 	// Working set size
 	serMemoryWorkingSet string = "memory_working_set"
+        // Memory-rss usage
+        serMemoryRss string = "memory_rss"
 	// Cumulative count of bytes received.
 	serRxBytes string = "rx_bytes"
 	// Cumulative count of receive errors encountered.
@@ -201,6 +203,9 @@ func (self *influxdbStorage) containerStatsToPoints(
 
 	// Working Set Size
 	points = append(points, makePoint(serMemoryWorkingSet, stats.Memory.WorkingSet))
+
+        // Memory-rss Usage
+        points = append(points, makePoint(serMemoryRss, stats.Memory.RSS))
 
 	// Network Stats
 	points = append(points, makePoint(serRxBytes, stats.Network.RxBytes))


### PR DESCRIPTION
Writing again #1899 ...

When InfluxDB is set as backend storage, memory related data is collected in two measurements.
(1) memory_usage
(2) memory_working_set

According to #638 ,
memory_usage = rss + cache
memory_working_set = memory_usage - inactive (inactive file + inactive anon)

But in many cases, memory except cache (only rss) will necessary because memory rss is consistent with docker stats API, so I propose to add a feature to push memory_rss measurement into influxdb backend storage.

alicek106/cadvisor@d620d74

It can be resolved by just adding two simple line in influxdb.go :D