### PR TITLE
Add memory rss to statsd storage

### DIFF
--- a/storage/statsd/statsd.go
+++ b/storage/statsd/statsd.go
@@ -41,6 +41,8 @@ const (
 	colMemoryUsage string = "memory_usage"
 	// Working set size
 	colMemoryWorkingSet string = "memory_working_set"
+	// Resident set size
+	colMemoryRSS string = "memory_rss"
 	// Cumulative count of bytes received.
 	colRxBytes string = "rx_bytes"
 	// Cumulative count of receive errors encountered.
@@ -79,6 +81,9 @@ func (self *statsdStorage) containerStatsToValues(
 
 	// Working set size
 	series[colMemoryWorkingSet] = stats.Memory.WorkingSet
+
+	// Resident set size
+	series[colMemoryRSS] = stats.Memory.RSS
 
 	// Network stats.
 	series[colRxBytes] = stats.Network.RxBytes


### PR DESCRIPTION
Solves same issue as https://github.com/google/cadvisor/issues/1899 for statsd storage.