### PR TITLE
add check for cpu cfs bandwidth in validate endpoint

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 
@@ -133,6 +134,23 @@ func areCgroupsPresent(available map[string]int, desired []string) (bool, string
 	return true, ""
 }
 
+func validateCpuCfsBandwidth(available_cgroups map[string]int) string {
+	ok, _ := areCgroupsPresent(available_cgroups, []string{"cpu"})
+	if !ok {
+		return "\tCpu cfs bandwidth status unknown: cpu cgroup not enabled.\n"
+	}
+	mnt, err := cgroups.FindCgroupMountpoint("cpu")
+	if err != nil {
+		return "\tCpu cfs bandwidth status unknown: cpu cgroup not mounted.\n"
+	}
+	_, err = os.Stat(path.Join(mnt, "cpu.cfs_period_us"))
+	if os.IsNotExist(err) {
+		return "\tCpu cfs bandwidth is disabled. Recompile kernel with \"CONFIG_CFS_BANDWIDTH\" enabled.\n"
+	}
+
+	return "\tCpu cfs bandwidth is enabled.\n"
+}
+
 func validateMemoryAccounting(available_cgroups map[string]int) string {
 	ok, _ := areCgroupsPresent(available_cgroups, []string{"memory"})
 	if !ok {
@@ -181,6 +199,7 @@ func validateCgroups() (string, string) {
 	out = fmt.Sprintf("Available cgroups: %v\n", available_cgroups)
 	out += desc
 	out += validateMemoryAccounting(available_cgroups)
+	out += validateCpuCfsBandwidth(available_cgroups)
 	return Recommended, out
 }
 


### PR DESCRIPTION
Fix #1428 .

This PR will add cpu cfs bandwidth check for validate endpoint. With this we can know that whether `cpu.cfs_period_us` and `cpu.cfs_quota_us` are available and we can set `--cpu-period` and `--cpu-quota` to `docker run`.

/cc @dashpole @tallclair @tallclair 