### PR TITLE
add accelerator info to container spec

### DIFF
--- a/accelerators/types.go
+++ b/accelerators/types.go
@@ -25,8 +25,10 @@ type AcceleratorManager interface {
 	Setup()
 	Destroy()
 	GetCollector(deviceCgroup string) (AcceleratorCollector, error)
+	GetAllDevicesCollector() (AcceleratorCollector, error)
 }
 
 type AcceleratorCollector interface {
 	UpdateStats(*info.ContainerStats) error
+	UpdateSpec(spec *info.ContainerSpec) error
 }

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -41,6 +41,21 @@ type MemorySpec struct {
 	SwapLimit uint64 `json:"swap_limit,omitempty"`
 }
 
+type AcceleratorSpec struct {
+	// Make of the accelerator (nvidia, amd, google etc.)
+	Make string `json:"make"`
+
+	// Model of the accelerator (tesla-p100, tesla-k80 etc.)
+	Model string `json:"model"`
+
+	// ID of the accelerator.
+	ID string `json:"id"`
+
+	// Total accelerator memory.
+	// unit: bytes
+	MemoryTotal uint64 `json:"memory_total"`
+}
+
 type ContainerSpec struct {
 	// Time at which the container was created.
 	CreationTime time.Time `json:"creation_time,omitempty"`
@@ -55,6 +70,9 @@ type ContainerSpec struct {
 
 	HasMemory bool       `json:"has_memory"`
 	Memory    MemorySpec `json:"memory,omitempty"`
+
+	HasAccelerators bool              `json:"has_accelerators"`
+	Accelerators    []AcceleratorSpec `json:"accelerators,omitempty"`
 
 	HasNetwork bool `json:"has_network"`
 

--- a/manager/container.go
+++ b/manager/container.go
@@ -526,6 +526,9 @@ func (c *containerData) updateSpec() error {
 		}
 		return err
 	}
+	if c.nvidiaCollector != nil {
+		c.nvidiaCollector.UpdateSpec(&spec)
+	}
 
 	customMetrics, err := c.collectorManager.GetSpec()
 	if err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -971,7 +971,11 @@ func (m *manager) createContainerLocked(containerName string, watchSource watche
 	if err != nil {
 		glog.Warningf("Error getting devices cgroup path: %v", err)
 	} else {
-		cont.nvidiaCollector, err = m.nvidiaManager.GetCollector(devicesCgroupPath)
+		if containerName == "/" {
+			cont.nvidiaCollector, err = m.nvidiaManager.GetAllDevicesCollector()
+		} else {
+			cont.nvidiaCollector, err = m.nvidiaManager.GetCollector(devicesCgroupPath)
+		}
 		if err != nil {
 			glog.V(4).Infof("GPU metrics may be unavailable/incomplete for container %q: %v", cont.info.Name, err)
 		}
@@ -999,6 +1003,9 @@ func (m *manager) createContainerLocked(containerName string, watchSource watche
 	contSpec, err := cont.handler.GetSpec()
 	if err != nil {
 		return err
+	}
+	if cont.nvidiaCollector != nil {
+		cont.nvidiaCollector.UpdateSpec(&contSpec)
 	}
 
 	contRef, err := cont.handler.ContainerReference()


### PR DESCRIPTION
Since accelerators have been merged into cadvisor, we need to add some spec of accelerators into the container spec, such as the memory_total of GPU.
PTAL if this pr is appropriate. I will commit the test cases after the first round :)