### PR TITLE
add hugepages info to attributes

### DIFF
--- a/info/v2/machine.go
+++ b/info/v2/machine.go
@@ -87,6 +87,7 @@ func GetAttributes(mi *v1.MachineInfo, vi *v1.VersionInfo) Attributes {
 		MemoryCapacity:     mi.MemoryCapacity,
 		MachineID:          mi.MachineID,
 		SystemUUID:         mi.SystemUUID,
+		HugePages:          mi.HugePages,
 		Filesystems:        mi.Filesystems,
 		DiskMap:            mi.DiskMap,
 		NetworkDevices:     mi.NetworkDevices,


### PR DESCRIPTION
the hugepages info in "_/attributes_" should be equal to "_/machine_"