### PR TITLE
add docker_only_prefix_whitelist

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -62,18 +62,18 @@ var (
 	// Metrics to be ignored.
 	// Tcp metrics are ignored by default.
 	ignoreMetrics metricSetValue = metricSetValue{container.MetricSet{
-		container.NetworkTcpUsageMetrics: struct{}{},
-		container.NetworkUdpUsageMetrics: struct{}{},
+		container.NetworkTcpUsageMetrics:  struct{}{},
+		container.NetworkUdpUsageMetrics:  struct{}{},
 		container.ProcessSchedulerMetrics: struct{}{},
 	}}
 
 	// List of metrics that can be ignored.
 	ignoreWhitelist = container.MetricSet{
-		container.DiskUsageMetrics:       struct{}{},
-		container.NetworkUsageMetrics:    struct{}{},
-		container.NetworkTcpUsageMetrics: struct{}{},
-		container.NetworkUdpUsageMetrics: struct{}{},
-		container.PerCpuUsageMetrics:     struct{}{},
+		container.DiskUsageMetrics:        struct{}{},
+		container.NetworkUsageMetrics:     struct{}{},
+		container.NetworkTcpUsageMetrics:  struct{}{},
+		container.NetworkUdpUsageMetrics:  struct{}{},
+		container.PerCpuUsageMetrics:      struct{}{},
 		container.ProcessSchedulerMetrics: struct{}{},
 	}
 )
@@ -132,7 +132,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet, &collectorHttpClient)
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, ignoreMetrics.MetricSet, &collectorHttpClient, []string{"/"})
 	if err != nil {
 		glog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -367,7 +367,7 @@ func TestDockerContainersInfo(t *testing.T) {
 }
 
 func TestNewNilManager(t *testing.T) {
-	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient)
+	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient, []string{"/"})
 	if err == nil {
 		t.Fatalf("Expected nil manager to return error")
 	}


### PR DESCRIPTION
Partially fix https://github.com/kubernetes/kubernetes/issues/61994

This PR adds `docker_only_prefix_whitelist` to cadvisor to specify `A comma-separated list of cgroup path prefix that needs to be collected even docker-only is specified`.


/cc @dashpole @tallclair 