### PR TITLE
Fix os release parsing

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -347,6 +347,11 @@
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
+			"ImportPath": "github.com/docker/docker/pkg/parsers/operatingsystem",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
+			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
+		},
+		{
 			"ImportPath": "github.com/docker/docker/pkg/system",
 			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
@@ -493,6 +498,11 @@
 		{
 			"ImportPath": "github.com/kr/text",
 			"Rev": "6807e777504f54ad073ecef66747de158294b639"
+		},
+		{
+			"ImportPath": "github.com/mattn/go-shellwords",
+			"Comment": "v1.0.3-18-g39dbbfa",
+			"Rev": "39dbbfa24bbc39559b61cae9b20b0e8db0e55525"
 		},
 		{
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",

--- a/machine/info.go
+++ b/machine/info.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/utils/cloudinfo"
@@ -173,20 +174,11 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 }
 
 func ContainerOsVersion() string {
-	container_os := "Unknown"
-	os_release, err := ioutil.ReadFile("/etc/os-release")
-	if err == nil {
-		// We might be running in a busybox or some hand-crafted image.
-		// It's useful to know why cadvisor didn't come up.
-		for _, line := range strings.Split(string(os_release), "\n") {
-			parsed := strings.Split(line, "\"")
-			if len(parsed) == 3 && parsed[0] == "PRETTY_NAME=" {
-				container_os = parsed[1]
-				break
-			}
-		}
+	os, err := operatingsystem.GetOperatingSystem()
+	if err != nil {
+		os = "Unknown"
 	}
-	return container_os
+	return os
 }
 
 func KernelVersion() string {

--- a/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_linux.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_linux.go
@@ -1,0 +1,77 @@
+// Package operatingsystem provides helper function to get the operating system
+// name for different platforms.
+package operatingsystem
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+)
+
+var (
+	// file to use to detect if the daemon is running in a container
+	proc1Cgroup = "/proc/1/cgroup"
+
+	// file to check to determine Operating System
+	etcOsRelease = "/etc/os-release"
+
+	// used by stateless systems like Clear Linux
+	altOsRelease = "/usr/lib/os-release"
+)
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+	osReleaseFile, err := os.Open(etcOsRelease)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("Error opening %s: %v", etcOsRelease, err)
+		}
+		osReleaseFile, err = os.Open(altOsRelease)
+		if err != nil {
+			return "", fmt.Errorf("Error opening %s: %v", altOsRelease, err)
+		}
+	}
+	defer osReleaseFile.Close()
+
+	var prettyName string
+	scanner := bufio.NewScanner(osReleaseFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "PRETTY_NAME=") {
+			data := strings.SplitN(line, "=", 2)
+			prettyNames, err := shellwords.Parse(data[1])
+			if err != nil {
+				return "", fmt.Errorf("PRETTY_NAME is invalid: %s", err.Error())
+			}
+			if len(prettyNames) != 1 {
+				return "", fmt.Errorf("PRETTY_NAME needs to be enclosed by quotes if they have spaces: %s", data[1])
+			}
+			prettyName = prettyNames[0]
+		}
+	}
+	if prettyName != "" {
+		return prettyName, nil
+	}
+	// If not set, defaults to PRETTY_NAME="Linux"
+	// c.f. http://www.freedesktop.org/software/systemd/man/os-release.html
+	return "Linux", nil
+}
+
+// IsContainerized returns true if we are running inside a container.
+func IsContainerized() (bool, error) {
+	b, err := ioutil.ReadFile(proc1Cgroup)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range bytes.Split(b, []byte{'\n'}) {
+		if len(line) > 0 && !bytes.HasSuffix(line, []byte{'/'}) && !bytes.HasSuffix(line, []byte("init.scope")) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_solaris.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_solaris.go
@@ -1,0 +1,37 @@
+// +build solaris,cgo
+
+package operatingsystem
+
+/*
+#include <zone.h>
+*/
+import "C"
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+)
+
+var etcOsRelease = "/etc/release"
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+	b, err := ioutil.ReadFile(etcOsRelease)
+	if err != nil {
+		return "", err
+	}
+	if i := bytes.Index(b, []byte("\n")); i >= 0 {
+		b = bytes.Trim(b[:i], " ")
+		return string(b), nil
+	}
+	return "", errors.New("release not found")
+}
+
+// IsContainerized returns true if we are running inside a container.
+func IsContainerized() (bool, error) {
+	if C.getzoneid() != 0 {
+		return true, nil
+	}
+	return false, nil
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_unix.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_unix.go
@@ -1,0 +1,25 @@
+// +build freebsd darwin
+
+package operatingsystem
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+	cmd := exec.Command("uname", "-s")
+	osName, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(osName), nil
+}
+
+// IsContainerized returns true if we are running inside a container.
+// No-op on FreeBSD and Darwin, always returns false.
+func IsContainerized() (bool, error) {
+	// TODO: Implement jail detection for freeBSD
+	return false, errors.New("Cannot detect if we are in container")
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_windows.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/operatingsystem/operatingsystem_windows.go
@@ -1,0 +1,50 @@
+package operatingsystem
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// See https://code.google.com/p/go/source/browse/src/pkg/mime/type_windows.go?r=d14520ac25bf6940785aabb71f5be453a286f58c
+// for a similar sample
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+
+	var h windows.Handle
+
+	// Default return value
+	ret := "Unknown Operating System"
+
+	if err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE,
+		windows.StringToUTF16Ptr(`SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\`),
+		0,
+		windows.KEY_READ,
+		&h); err != nil {
+		return ret, err
+	}
+	defer windows.RegCloseKey(h)
+
+	var buf [1 << 10]uint16
+	var typ uint32
+	n := uint32(len(buf) * 2) // api expects array of bytes, not uint16
+
+	if err := windows.RegQueryValueEx(h,
+		windows.StringToUTF16Ptr("ProductName"),
+		nil,
+		&typ,
+		(*byte)(unsafe.Pointer(&buf[0])),
+		&n); err != nil {
+		return ret, err
+	}
+	ret = windows.UTF16ToString(buf[:])
+
+	return ret, nil
+}
+
+// IsContainerized returns true if we are running inside a container.
+// No-op on Windows, always returns false.
+func IsContainerized() (bool, error) {
+	return false, nil
+}

--- a/vendor/github.com/mattn/go-shellwords/.travis.yml
+++ b/vendor/github.com/mattn/go-shellwords/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+  - tip
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+script:
+    - $HOME/gopath/bin/goveralls -repotoken 2FMhp57u8LcstKL9B190fLTcEnBtAAiEL

--- a/vendor/github.com/mattn/go-shellwords/LICENSE
+++ b/vendor/github.com/mattn/go-shellwords/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mattn/go-shellwords/README.md
+++ b/vendor/github.com/mattn/go-shellwords/README.md
@@ -1,0 +1,47 @@
+# go-shellwords
+
+[![Coverage Status](https://coveralls.io/repos/mattn/go-shellwords/badge.png?branch=master)](https://coveralls.io/r/mattn/go-shellwords?branch=master)
+[![Build Status](https://travis-ci.org/mattn/go-shellwords.svg?branch=master)](https://travis-ci.org/mattn/go-shellwords)
+
+Parse line as shell words.
+
+## Usage
+
+```go
+args, err := shellwords.Parse("./foo --bar=baz")
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+os.Setenv("FOO", "bar")
+p := shellwords.NewParser()
+p.ParseEnv = true
+args, err := p.Parse("./foo $FOO")
+// args should be ["./foo", "bar"]
+```
+
+```go
+p := shellwords.NewParser()
+p.ParseBacktick = true
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+```go
+shellwords.ParseBacktick = true
+p := shellwords.NewParser()
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+# Thanks
+
+This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).
+
+# License
+
+under the MIT License: http://mattn.mit-license.org/2017
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/vendor/github.com/mattn/go-shellwords/shellwords.go
+++ b/vendor/github.com/mattn/go-shellwords/shellwords.go
@@ -1,0 +1,178 @@
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"regexp"
+)
+
+var (
+	ParseEnv      bool = false
+	ParseBacktick bool = false
+)
+
+var envRe = regexp.MustCompile(`\$({[a-zA-Z0-9_]+}|[a-zA-Z0-9_]+)`)
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\r', '\n':
+		return true
+	}
+	return false
+}
+
+func replaceEnv(s string) string {
+	return envRe.ReplaceAllStringFunc(s, func(s string) string {
+		s = s[1:]
+		if s[0] == '{' {
+			s = s[1 : len(s)-1]
+		}
+		return os.Getenv(s)
+	})
+}
+
+type Parser struct {
+	ParseEnv      bool
+	ParseBacktick bool
+	Position      int
+}
+
+func NewParser() *Parser {
+	return &Parser{ParseEnv, ParseBacktick, 0}
+}
+
+func (p *Parser) Parse(line string) ([]string, error) {
+	args := []string{}
+	buf := ""
+	var escaped, doubleQuoted, singleQuoted, backQuote, dollarQuote bool
+	backtick := ""
+
+	pos := -1
+	got := false
+
+loop:
+	for i, r := range line {
+		if escaped {
+			buf += string(r)
+			escaped = false
+			continue
+		}
+
+		if r == '\\' {
+			if singleQuoted {
+				buf += string(r)
+			} else {
+				escaped = true
+			}
+			continue
+		}
+
+		if isSpace(r) {
+			if singleQuoted || doubleQuoted || backQuote || dollarQuote {
+				buf += string(r)
+				backtick += string(r)
+			} else if got {
+				if p.ParseEnv {
+					buf = replaceEnv(buf)
+				}
+				args = append(args, buf)
+				buf = ""
+				got = false
+			}
+			continue
+		}
+
+		switch r {
+		case '`':
+			if !singleQuoted && !doubleQuoted && !dollarQuote {
+				if p.ParseBacktick {
+					if backQuote {
+						out, err := shellRun(backtick)
+						if err != nil {
+							return nil, err
+						}
+						buf = out
+					}
+					backtick = ""
+					backQuote = !backQuote
+					continue
+				}
+				backtick = ""
+				backQuote = !backQuote
+			}
+		case ')':
+			if !singleQuoted && !doubleQuoted && !backQuote {
+				if p.ParseBacktick {
+					if dollarQuote {
+						out, err := shellRun(backtick)
+						if err != nil {
+							return nil, err
+						}
+						buf = out
+					}
+					backtick = ""
+					dollarQuote = !dollarQuote
+					continue
+				}
+				backtick = ""
+				dollarQuote = !dollarQuote
+			}
+		case '(':
+			if !singleQuoted && !doubleQuoted && !backQuote {
+				if !dollarQuote && len(buf) > 0 && buf == "$" {
+					dollarQuote = true
+					buf += "("
+					continue
+				} else {
+					return nil, errors.New("invalid command line string")
+				}
+			}
+		case '"':
+			if !singleQuoted && !dollarQuote {
+				doubleQuoted = !doubleQuoted
+				continue
+			}
+		case '\'':
+			if !doubleQuoted && !dollarQuote {
+				singleQuoted = !singleQuoted
+				continue
+			}
+		case ';', '&', '|', '<', '>':
+			if !(escaped || singleQuoted || doubleQuoted || backQuote) {
+				if r == '>' {
+					if c := buf[0]; '0' <= c && c <= '9' {
+						i -= 1
+						got = false
+					}
+				}
+				pos = i
+				break loop
+			}
+		}
+
+		got = true
+		buf += string(r)
+		if backQuote || dollarQuote {
+			backtick += string(r)
+		}
+	}
+
+	if got {
+		if p.ParseEnv {
+			buf = replaceEnv(buf)
+		}
+		args = append(args, buf)
+	}
+
+	if escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote {
+		return nil, errors.New("invalid command line string")
+	}
+
+	p.Position = pos
+
+	return args, nil
+}
+
+func Parse(line string) ([]string, error) {
+	return NewParser().Parse(line)
+}

--- a/vendor/github.com/mattn/go-shellwords/util_go15.go
+++ b/vendor/github.com/mattn/go-shellwords/util_go15.go
@@ -1,0 +1,24 @@
+// +build !go1.6
+
+package shellwords
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	var b []byte
+	var err error
+	if runtime.GOOS == "windows" {
+		b, err = exec.Command(os.Getenv("COMSPEC"), "/c", line).Output()
+	} else {
+		b, err = exec.Command(os.Getenv("SHELL"), "-c", line).Output()
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/github.com/mattn/go-shellwords/util_posix.go
+++ b/vendor/github.com/mattn/go-shellwords/util_posix.go
@@ -1,0 +1,22 @@
+// +build !windows,go1.6
+
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("SHELL")
+	b, err := exec.Command(shell, "-c", line).Output()
+	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/github.com/mattn/go-shellwords/util_windows.go
+++ b/vendor/github.com/mattn/go-shellwords/util_windows.go
@@ -1,0 +1,22 @@
+// +build windows,go1.6
+
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("COMSPEC")
+	b, err := exec.Command(shell, "/c", line).Output()
+	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}


### PR DESCRIPTION
The current `/etc/os-release` parsing code is not robust and assumes that the value of `PRETTY_NAME` is in double quotes when bash env var rules do not require it.  In such cases, the parsing fails.

Docker has a function for this already that does it in a more robust way.  This PR converts to using that method.  The new rules are double quotes and single quotes work and required if the value has spaces.  If no spaces, not quotes are required.

Notes: other options include fixing the code in place or copy-pasting that function from docker.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1521087

@dashpole @derekwaynecarr 