### PR TITLE
Better support DIND environments - FStype overlay

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -541,6 +541,10 @@ func (self *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
 			return &DeviceInfo{mount.Source, uint(major), uint(minor)}, nil
 		}
 	}
+	if found && mount.Fstype == "overlay" {
+		return &DeviceInfo{mount.Source, uint(mount.Major), uint(mount.Minor)}, nil
+	}
+
 	return nil, fmt.Errorf("could not find device with major: %d, minor: %d in cached partitions map", major, minor)
 }
 


### PR DESCRIPTION
Found this while testing pull-kubernetes-local-e2e-containerized job in Kubernetes CI, 

```
F0419 14:04:45.019007   25226 kubelet.go:1280] Failed to start ContainerManager failed to get rootfs info: failed to get device for dir "/var/lib/kubelet": could not find device with major: 0, minor: 108 in cached partitions map
```
example log from : https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/62508/pull-kubernetes-local-e2e-containerized/24/artifacts/kubetest-local177551503/kubelet.log