### PR TITLE
Update partition regex to match NVME disks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,57 @@
+#!/usr/bin/groovy
+@Library('github.com/fabric8io/fabric8-pipeline-library@master')
+def canaryVersion = "1.0.${env.BUILD_NUMBER}"
+def utils = new io.fabric8.Utils()
+def stashName = "buildpod.${env.JOB_NAME}.${env.BUILD_NUMBER}".replace('-', '_').replace('/', '_')
+def envStage = utils.environmentNamespace('stage')
+def envProd = utils.environmentNamespace('run')
+
+mavenNode {
+  checkout scm
+  if (utils.isCI()){
+
+    mavenCI{}
+    
+  } else if (utils.isCD()){
+    echo 'NOTE: running pipelines for the first time will take longer as build and base docker images are pulled onto the node'
+    container(name: 'maven') {
+
+      stage('Build Release'){
+        mavenCanaryRelease {
+          version = canaryVersion
+        }
+        //stash deployment manifests
+        stash includes: '**/*.yml', name: stashName
+      }
+
+      stage('Rollout to Stage'){
+        apply{
+          environment = envStage
+        }
+      }
+    }
+  }
+}
+
+if (utils.isCD()){
+  node {
+    stage('Approve'){
+       approve {
+         room = null
+         version = canaryVersion
+         environment = 'Stage'
+       }
+     }
+  }
+
+  clientsNode{
+    container(name: 'clients') {
+      stage('Rollout to Run'){
+        unstash stashName
+        apply{
+          environment = envProd
+        }
+      }
+    }
+  }
+}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -438,7 +438,7 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
 	return filesystems, nil
 }
 
-var partitionRegex = regexp.MustCompile(`^(?:(?:s|v|xv)d[a-z]+\d*|dm-\d+)$`)
+var partitionRegex = regexp.MustCompile(`^(?:(?:s|v|xv)d[a-z]+\d*|dm-\d+|nvme\d+n\d+)$`)
 
 func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
 	diskStatsMap := make(map[string]DiskStats)


### PR DESCRIPTION
Partition regexp should match nvme disks which are presented to the OS as e.g:  /dev/nvme0n1