### PR TITLE
Run find command with nice to reduce cpu load

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -601,7 +601,7 @@ func GetDirInodeUsage(dir string, timeout time.Duration) (uint64, error) {
 	}
 	var counter byteCounter
 	var stderr bytes.Buffer
-	findCmd := exec.Command("find", dir, "-xdev", "-printf", ".")
+	findCmd := exec.Command("ionice", "-c3", "nice", "-n", "19", "find", dir, "-xdev", "-printf", ".")
 	findCmd.Stdout, findCmd.Stderr = &counter, &stderr
 	if err := findCmd.Start(); err != nil {
 		return 0, fmt.Errorf("failed to exec cmd %v - %v; stderr: %v", findCmd.Args, err, stderr.String())


### PR DESCRIPTION
Reduce impact of running the "find" command when system is loaded. We
already use "nice" with the "du" command.