### PR TITLE
Initial setup for building aarch64

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -43,11 +43,23 @@ ldflags="
   -X ${repo_path}/version.BuildDate${ldseparator}${BUILD_DATE}
   -X ${repo_path}/version.GoVersion${ldseparator}${go_version}"
 
-echo ">> building cadvisor"
+echo ">> building cadvisor for ${ARCH}"
+
+if [ "${ARCH}" == "arm64" ]; then
+  ldflags="${ldflags} -extldflags '-static'"
+fi
 
 if [ -n "$VERBOSE" ]; then
   echo "Building with -ldflags $ldflags"
 fi
+
+if [ "${ARCH}" == "arm64" ]; then
+   CGO_ENABLED=1 CC=aarch64-linux-gnu-gccgo GOARCH=$ARCH GOBIN=$PWD go build ${GO_FLAGS} -o cadvisor.${ARCH} -ldflags "${ldflags}" "${repo_path}"
+else
+   GOARCH=$ARCH GOBIN=$PWD go build ${GO_FLAGS} -o cadvisor.${ARCH} -ldflags "${ldflags}" "${repo_path}"
+fi
+
+echo "Successfully built $(stat -c '%n - %z' cadvisor.${ARCH})" && exit 0
 
 GOBIN=$PWD go build ${GO_FLAGS} -ldflags "${ldflags}" "${repo_path}"
 

--- a/build/docker.sh
+++ b/build/docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "Building docker image for ${ARCH} using tags: ${TAGS}"
+docker build ${TAGS} -f deploy/Dockerfile.${ARCH} .
+

--- a/build/prow_e2e.sh
+++ b/build/prow_e2e.sh
@@ -35,7 +35,7 @@ if [[ ! -z "$(git diff --name-only pages)" ]]; then
   exit 1
 fi
 
-make all
+ARCH=amd64 make all
 
 # compile integration tests so they can be run without go installed
 go test -c github.com/google/cadvisor/integration/tests/api

--- a/build/release.sh
+++ b/build/release.sh
@@ -36,13 +36,13 @@ fi
 export BUILD_USER="$git_user"
 export BUILD_DATE=$( date +%Y%m%d ) # Release date is only to day-granularity
 export VERBOSE=true
-build/build.sh
+ARCH=${ARCH} build/build.sh
 
 # Build the docker image
 echo ">> building cadvisor docker image"
-docker_tag="google/cadvisor:$VERSION"
-gcr_tag="gcr.io/google_containers/cadvisor:$VERSION"
-docker build -t $docker_tag -t $gcr_tag -f deploy/Dockerfile .
+docker_tag="google/cadvisor:$VERSION-$ARCH"
+gcr_tag="gcr.io/google_containers/cadvisor:$VERSION-$ARCH"
+ARCH=${ARCH} TAGS="-t $docker_tag -t $gcr_tag" build/docker.sh
 
 echo
 echo "Release info:"

--- a/deploy/Dockerfile.amd64
+++ b/deploy/Dockerfile.amd64
@@ -15,7 +15,7 @@ RUN apk --no-cache add ca-certificates wget device-mapper findutils && \
     rm -rf /var/cache/apk/*
 
 # Grab cadvisor from the staging directory.
-ADD cadvisor /usr/bin/cadvisor
+ADD cadvisor.amd64 /usr/bin/cadvisor
 
 EXPOSE 8080
 ENTRYPOINT ["/usr/bin/cadvisor", "-logtostderr"]

--- a/deploy/Dockerfile.arm64
+++ b/deploy/Dockerfile.arm64
@@ -1,0 +1,10 @@
+FROM multiarch/alpine:aarch64-edge
+
+MAINTAINER jorge.niedbalski@linaro.org
+RUN apk --upgrade add libc6-compat
+
+# Grab cadvisor from the staging directory.
+ADD cadvisor.arm64 /usr/bin/cadvisor
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/bin/cadvisor", "-logtostderr"]


### PR DESCRIPTION
This patch modifies the build scripts to allow other
architectures such as aarch64 to be build.

Particularly, for the aarch64 case, the following changes are included:

- Modified the Makefiles and build/*.sh scripts to allow the ARCH variable to be passed.

- gccgo-aarch64-linux-gnu: is required for building aarch64 binaries , added as the default CC for arm64.
(sudo apt-get install gccgo-aarch64-linux-gnu).

- Added a Dockerfile under deploy/Dockerfile.arm64 that uses multiarch/alpine:aarch64-edge as the base image.

** What we are missing:

- A travis meta-build system integration for running the build jobs for each architecture.
- Integration on the github releases process.