### PR TITLE
resetting max memory usage after reading it

### DIFF
--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go
@@ -299,6 +299,10 @@ func getMemoryData(path, name string) (cgroups.MemoryData, error) {
 		}
 		return cgroups.MemoryData{}, fmt.Errorf("failed to parse %s - %v", failcnt, err)
 	}
+	err = setCgroupParamUint(path, maxUsage, 0)
+	if err != nil {
+		return cgroups.MemoryData{}, fmt.Errorf("failed to reset max_usage_in_bytes")
+	}
 	memoryData.Failcnt = value
 	value, err = getCgroupParamUint(path, limit)
 	if err != nil {

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/utils.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/utils.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"encoding/binary"
 )
 
 var (
@@ -65,6 +66,22 @@ func getCgroupParamUint(cgroupPath, cgroupFile string) (uint64, error) {
 		return res, fmt.Errorf("unable to parse %q as a uint from Cgroup file %q", string(contents), fileName)
 	}
 	return res, nil
+}
+
+// Sets a single uint64 value from the specified cgroup file.
+func setCgroupParamUint(cgroupPath, cgroupFile string, value uint64) (error) {
+        fileName := filepath.Join(cgroupPath, cgroupFile)
+
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, value)
+
+        err := ioutil.WriteFile(fileName, b, 0)
+
+        if err != nil {
+                return err
+        }
+
+        return nil
 }
 
 // Gets a string value from the specified cgroup file


### PR DESCRIPTION
Hi,
tracking max_memory_usage would be potentially much more useful if we were resetting it every time we read it. This gives a better view of the max memory usage between each point we collect the data while at the same time not doing so for the entire lifetime of the app / container (the original time series can still be recovered with a sliding max operator).

What do you guys think?
