### PR TITLE
Dont watch "*.mount" cgroups

### DIFF
--- a/manager/watcher/raw/raw.go
+++ b/manager/watcher/raw/raw.go
@@ -110,6 +110,11 @@ func (self *rawContainerWatcher) Stop() error {
 // Watches the specified directory and all subdirectories. Returns whether the path was
 // already being watched and an error (if any).
 func (self *rawContainerWatcher) watchDirectory(events chan watcher.ContainerEvent, dir string, containerName string) (bool, error) {
+	// Don't watch .mount cgroups because they never have containers as sub-cgroups.  A single container
+	// can have many .mount cgroups associated with it which can quickly exhaust the inotify watches on a node.
+	if strings.HasSuffix(containerName, ".mount") {
+		return false, nil
+	}
 	alreadyWatching, err := self.watcher.AddWatch(containerName, dir)
 	if err != nil {
 		return alreadyWatching, err


### PR DESCRIPTION
We already [don't collect metrics on .mount cgroups](https://github.com/google/cadvisor/blob/master/container/systemd/factory.go#L39).  But watching each of the mount cgroups for sub-cgroups can use up all of the inotify watches on the node.  This change now makes the watcher ignore .mount cgroups.