### PR TITLE
Initialize NVML on demand.

### DIFF
--- a/accelerators/nvidia_test.go
+++ b/accelerators/nvidia_test.go
@@ -71,17 +71,29 @@ func TestGetCollector(t *testing.T) {
 		return []int{2, 3}, nil
 	}
 	parseDevicesCgroup = mockParser
+	originalInitializeNVML := initializeNVML
+	initializeNVML = func(_ *NvidiaManager) {}
 	defer func() {
 		parseDevicesCgroup = originalParser
+		initializeNVML = originalInitializeNVML
 	}()
 
 	nm := &NvidiaManager{}
 
-	// When nvmlInitialized is false, empty collector should be returned.
+	// When devicesPresent is false, empty collector should be returned.
 	ac, err := nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
 	nc, ok := ac.(*NvidiaCollector)
+	assert.True(t, ok)
+	assert.Equal(t, 0, len(nc.Devices))
+
+	// When nvmlInitialized is false, empty collector should be returned.
+	nm.devicesPresent = true
+	ac, err = nm.GetCollector("does-not-matter")
+	assert.Nil(t, err)
+	assert.NotNil(t, ac)
+	nc, ok = ac.(*NvidiaCollector)
 	assert.True(t, ok)
 	assert.Equal(t, 0, len(nc.Devices))
 


### PR DESCRIPTION
Earlier if the NVIDIA driver was not installed when cAdvisor was started
we would start a goroutine to try to initialize NVML every minute.

This resulted in a race. We can have a situation where:
- goroutine tries to initialize NVML but fails. So, it sleeps for a minute.
- the driver is installed.
- a container that uses NVIDIA devices is started.
This container would not get GPU stats because a minute has not passed
since the last failed initialization attempt and so NVML is not
initialized.