### PR TITLE
Add cadvisor daemonset using kustomize

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ cAdvisor is now running (in the background) on `http://localhost:8080`. The setu
 
 We have detailed [instructions](docs/running.md#standalone) on running cAdvisor standalone outside of Docker. cAdvisor [running options](docs/runtime_options.md) may also be interesting for advanced usecases. If you want to build your own cAdvisor Docker image see our [deployment](docs/deploy.md) page.
 
+For [Kubernetes](https://github.com/kubernetes/kubernetes) users, cAdvisor can be run as a daemonset.  See the [instructions](deploy/kubernetes) for how to get started, and for how to kustomize it to fit your needs.
+
 ## Building and Testing
 
 See the more detailed instructions in the [build page](docs/development/build.md). This includes instructions for building and deploying the cAdvisor Docker image.

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,36 @@
+# cAdvisor Kubernetes Daemonset
+
+cAdvisor uses [Kustomize](https://github.com/kubernetes-sigs/kustomize) to manage kubernetes yaml files.  See the [Kustomize](https://github.com/kubernetes-sigs/kustomize) readme for installation instructions, and for a description of how it works.
+
+## Usage
+
+From the cadvisor/ directory, to generate the base daemonset:
+```
+kustomize build deploy/kubernetes/base
+```
+
+To apply the base daemonset to your cluster:
+```
+kustomize build deploy/kubernetes/base | kubectl apply -f -
+```
+
+To generate the daemonset with example patches applied:
+```
+kustomize build deploy/kubernetes/overlays/examples
+```
+
+To apply the daemonset to your cluster with example patches applied:
+```
+kustomize build deploy/kubernetes/overlays/examples | kubectl apply -f -
+```
+
+## Kustomization
+
+On your own fork of cAdvisor, create your own overlay directoy with your patches.  Copy patches from the example folder if you intend to use them, but don't modify the originals.  Commit your changes in your local branch, and use git to manage them the same way you would any other piece of code.
+
+To run the daemonset with your patches applied:
+```
+kustomize build deploy/kubernetes/overlays/<my_custom_overlays> | kubectl apply -f -
+```
+
+To get changes made to the upstream cAdvisor daemonset, simply rebase your fork of cAdvisor on top of upstream.  Since you didn't make changes to the originals, you won't have any conflicts.

--- a/deploy/kubernetes/base/daemonset.yaml
+++ b/deploy/kubernetes/base/daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: cadvisor
+  annotations:
+      seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  template:
+    spec:
+      containers:
+      - name: cadvisor
+        image: k8s.gcr.io/cadvisor:v0.30.2
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 150m
+          limits:
+            cpu: 300m
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,0 +1,5 @@
+commonLabels:
+  app: cadvisor
+resources:
+- namespace.yaml
+- daemonset.yaml

--- a/deploy/kubernetes/base/namespace.yaml
+++ b/deploy/kubernetes/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cadvisor

--- a/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
+++ b/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
@@ -1,0 +1,19 @@
+# This patch is an example of setting arguments for the cAdvisor container.
+# This set of arguments mirrors what the kubelet currently uses for cAdvisor, 
+# enables only cpu, memory, and diskIO metrics, and shows only container metrics.
+apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: cadvisor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cadvisor
+        args:
+          - --housekeeping_interval=10s                   # kubernetes default args
+          - --max_housekeeping_interval=15s
+          - --event_storage_event_limit=default=0
+          - --event_storage_age_limit=default=0
+          - --disable_metrics=percpu,disk,network,tcp,udp # enable only diskIO, cpu, memory
+          - --docker_only                                 # only show stats for docker containers

--- a/deploy/kubernetes/overlays/examples/critical-priority.yaml
+++ b/deploy/kubernetes/overlays/examples/critical-priority.yaml
@@ -1,0 +1,15 @@
+# This patch sets the priorityClass to system-node-critical, the highest priority available.
+apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: cadvisor
+spec:
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"

--- a/deploy/kubernetes/overlays/examples/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+- ../../base
+patches:
+- stackdriver-sidecar.yaml
+- critical-priority.yaml
+- cadvisor-args.yaml

--- a/deploy/kubernetes/overlays/examples/stackdriver-sidecar.yaml
+++ b/deploy/kubernetes/overlays/examples/stackdriver-sidecar.yaml
@@ -1,0 +1,33 @@
+# This patch adds a sidecar which pushes all metrics to stackdriver
+apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: cadvisor
+spec:
+  template:
+    spec:
+      containers:
+      - name: prometheus-to-sd
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.6
+        ports:
+          - name: profiler
+            containerPort: 6061
+        command:
+          - /monitor
+          - --stackdriver-prefix=custom.googleapis.com
+          - --source=cadvisor:http://localhost:8080
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
Adds the base cAdvisor daemonset in the base directory, and includes examples on how to mark it "critical", how to limit the metrics cadvisor collects, and how to add a prom-to-sd sidecar container to put metrics in stackdriver