### PR TITLE
fix: ./deploy/build.sh can not find Dockerfile

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -19,4 +19,4 @@ set -x
 
 make build
 
-docker build -t google/cadvisor:beta .
+docker build -t google/cadvisor:beta -f $(dirname $0)/Dockerfile .

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -8,7 +8,7 @@ Building the cAdvisor Docker container is simple, just run:
 $ ./deploy/build.sh
 ```
 
-Which will statically build the cAdvisor binary and then build the Docker image. The resulting Docker image will be called `google/cadvisor:canary`. This image is very bare, containing the cAdvisor binary and nothing else.
+Which will statically build the cAdvisor binary and then build the Docker image. The resulting Docker image will be called `google/cadvisor:beta`. This image is very bare, containing the cAdvisor binary and nothing else.
 
 ## Deploying
 


### PR DESCRIPTION

- `git clone` from master branch latest commit (b1535b8)
- `./deploy/build.sh` failed

```
[#15#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$./deploy/build.sh
+ make build
>> building assets
>> building binaries
>> building cadvisor
+ docker build -t google/cadvisor:beta .
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /go/src/github.com/moooofly/cadvisor/Dockerfile: no such file or directory
[#16#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$
```

- fix by adding `-f $(dirname $0)/Dockerfile`

```
[#16#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$vi ./deploy/build.sh
[#17#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$
[#17#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$git diff
diff --git a/deploy/build.sh b/deploy/build.sh
index 4869ee0..a5657cd 100755
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -19,4 +19,4 @@ set -x

 make build

-docker build -t google/cadvisor:beta .
+docker build -t google/cadvisor:beta -f $(dirname $0)/Dockerfile .
[#18#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$
```

- works fine to me.

```
[#18#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$./deploy/build.sh
+ make build
>> building assets
>> building binaries
>> building cadvisor
+ docker build -t google/cadvisor:beta -f deploy/Dockerfile .
Sending build context to Docker daemon   74.3MB
Step 1/7 : FROM alpine:3.7
 ---> 3fd9065eaf02
Step 2/7 : MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 ---> Using cache
 ---> a92175d342a6
Step 3/7 : ENV GLIBC_VERSION "2.27-r0"
 ---> Using cache
 ---> bc822a9e7e8c
Step 4/7 : RUN apk --no-cache add ca-certificates wget device-mapper findutils &&     apk --no-cache add zfs --repository http://dl-3.alpinelinux.org/alpine/edge/main/ &&     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ &&     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub &&     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk &&     wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk &&     apk add glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk &&     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib &&     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf &&     rm -rf /var/cache/apk/*
 ---> Using cache
 ---> 2ced18032556
Step 5/7 : ADD cadvisor /usr/bin/cadvisor
 ---> df83d9714cc7
Step 6/7 : EXPOSE 8080
 ---> Running in 2c4da1dbfd72
Removing intermediate container 2c4da1dbfd72
 ---> d440afb468ed
Step 7/7 : ENTRYPOINT ["/usr/bin/cadvisor", "-logtostderr"]
 ---> Running in 67e5369d0f2e
Removing intermediate container 67e5369d0f2e
 ---> 23322fdd7de5
Successfully built 23322fdd7de5
Successfully tagged google/cadvisor:beta
[#19#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$
[#19#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$docker images google/cadvisor
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
google/cadvisor     beta                23322fdd7de5        14 seconds ago      64MB
google/cadvisor     latest              75f88e3ec333        6 months ago        62.2MB
[#20#root@ubuntu-1604 /go/src/github.com/moooofly/cadvisor]$
```