### PR TITLE
Control whether container labels are exported as prometheus metrics.

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -842,6 +842,19 @@ func DefaultContainerLabels(container *info.ContainerInfo) map[string]string {
 	return set
 }
 
+// BaseContainerLabels implements ContainerLabelsFunc. It only exports the
+// container name, first alias, and image name.
+func BaseContainerLabels(container *info.ContainerInfo) map[string]string {
+	set := map[string]string{LabelID: container.Name}
+	if len(container.Aliases) > 0 {
+		set[LabelName] = container.Aliases[0]
+	}
+	if image := container.Spec.Image; len(image) > 0 {
+		set[LabelImage] = image
+	}
+	return set
+}
+
 func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric) {
 	containers, err := c.infoProvider.SubcontainersInfo("/", &info.ContainerInfoRequest{NumStats: 1})
 	if err != nil {


### PR DESCRIPTION
See #1951 for context.

when cadvisor exports metrics for docker containers, there is a root cgroup (/) and cgroup for a docker container (/docker/uuid).
If docker container has a label on it, then this label is applied to all containers including the root container. Because some containers don't have that label, the label will have an empty value. The reason for this is that Prometheus does not allow sending a metric with the same name, but different labels, so cadvisor uses empty label values based on the set of all labels for a given metric. This can result in many docker containers getting a large number of empty labels because another container has that label.

If large number of docker labels vary a lot across images, then the set of labels will be enormous, where most of the labels will be empty and have no value as prometheus metrics. To avoid this problem, a flag is provided that allows a user to disable exporting docker labels as metrics.