### PR TITLE
Fix build errors for mesos

### DIFF
--- a/container/mesos/client.go
+++ b/container/mesos/client.go
@@ -100,7 +100,8 @@ func (self *client) getContainer(id string) (*mContainer, error) {
 	// Check if there is a container with given id and return the container
 	for _, c := range cntrs.Containers {
 		if c.ContainerID.Value == id {
-			return &c, nil
+			container := mContainer(c)
+			return &container, nil
 		}
 	}
 	return nil, fmt.Errorf("can't locate container %s", id)

--- a/container/mesos/mesos_agent.go
+++ b/container/mesos/mesos_agent.go
@@ -30,7 +30,7 @@ const (
 )
 
 type mContainers *agent.Response_GetContainers
-type mContainer = agent.Response_GetContainers_Container
+type mContainer agent.Response_GetContainers_Container
 
 type (
 	state struct {


### PR DESCRIPTION
This fixes errors when building with `godep go build .`
I'm not sure why we didn't catch this in #1965, which added the initial implementation.  Is it possible 

@sashankreddya, can you review this?