### PR TITLE
Allow on-demand container metrics in prometheus endpoint

### DIFF
--- a/api/versions.go
+++ b/api/versions.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"time"
 
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/info/v2"
@@ -313,7 +314,7 @@ func (self *version2_0) SupportedRequestTypes() []string {
 }
 
 func (self *version2_0) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
-	opt, err := getRequestOptions(r)
+	opt, err := GetRequestOptions(r)
 	if err != nil {
 		return err
 	}
@@ -482,7 +483,7 @@ func (self *version2_1) SupportedRequestTypes() []string {
 
 func (self *version2_1) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
 	// Get the query request.
-	opt, err := getRequestOptions(r)
+	opt, err := GetRequestOptions(r)
 	if err != nil {
 		return err
 	}
@@ -525,7 +526,7 @@ func (self *version2_1) HandleRequest(requestType string, request []string, m ma
 	}
 }
 
-func getRequestOptions(r *http.Request) (v2.RequestOptions, error) {
+func GetRequestOptions(r *http.Request) (v2.RequestOptions, error) {
 	supportedTypes := map[string]bool{
 		v2.TypeName:   true,
 		v2.TypeDocker: true,
@@ -554,6 +555,13 @@ func getRequestOptions(r *http.Request) (v2.RequestOptions, error) {
 	recursive := r.URL.Query().Get("recursive")
 	if recursive == "true" {
 		opt.Recursive = true
+	}
+	if maxAgeString := r.URL.Query().Get("max_age"); len(maxAgeString) > 0 {
+		maxAge, err := time.ParseDuration(maxAgeString)
+		if err != nil {
+			return opt, fmt.Errorf("failed to parse 'max_age' option: %v", err)
+		}
+		opt.MaxAge = &maxAge
 	}
 	return opt, nil
 }


### PR DESCRIPTION
Fix #1989 

This does the following
- adds `max_age` parsing to `getRequestOptions`.
- expose `GetRequestOptions` so we can use it in prometheus handler.
- update prometheus `infoProvider` interface to use `GetRequestedContainersInfo`
so we can leverage `v2.RequestOptions`, namely `MaxAge` property to signal that we
are interested in on-demand collection of container metrics.

Signed-off-by: Daniel Dao <dqminh89@gmail.com>