### PR TITLE
Check the length before using container.Stats

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -953,6 +953,9 @@ func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric)
 		}
 
 		// Now for the actual metrics
+		if len(container.Stats) == 0 {
+			continue
+		}
 		stats := container.Stats[0]
 		for _, cm := range c.containerMetrics {
 			if cm.condition != nil && !cm.condition(container.Spec) {


### PR DESCRIPTION
Issue detail is https://github.com/kubernetes/kubernetes/issues/66366

I found the only code is,

```
// Now for the actual metrics
stats := container.Stats[0]
```