### PR TITLE
Lower log verbosity for statfs failures, fixes #1772

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -422,7 +422,7 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
 				}
 			}
 			if err != nil {
-				glog.Errorf("Stat fs failed. Error: %v", err)
+				glog.V(4).Infof("Stat fs failed. Error: %v", err)
 			} else {
 				deviceSet[device] = struct{}{}
 				fs.DeviceInfo = DeviceInfo{


### PR DESCRIPTION
This fixes #1772. I considered having the log verbosity be different for devicemapper/zfs vs other filesystems, but this error doesn't seem serious to me in any case, so I didn't see a compelling reason to make the log verbosity be a function of the filesystem or mount type.