### PR TITLE
Get rid of lock during list containers

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1100,7 +1100,7 @@ func (m *manager) getContainersDiff(containerName string) (added []info.Containe
 	m.containersLock.RUnlock()
 	allContainers, err := contHandler.ListContainers(container.ListRecursive)
 	m.containersLock.RLock()
-				       
+
 	if err != nil {
 		return nil, nil, err
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1086,25 +1086,25 @@ func (m *manager) destroyContainerLocked(containerName string) error {
 
 // Detect all containers that have been added or deleted from the specified container.
 func (m *manager) getContainersDiff(containerName string) (added []info.ContainerReference, removed []info.ContainerReference, err error) {
-	m.containersLock.RLock()
-	defer m.containersLock.RUnlock()
-
 	// Get all subcontainers recursively.
+	m.containersLock.RLock()
 	cont, ok := m.containers[namespacedContainerName{
 		Name: containerName,
 	}]
+	m.containersLock.RUnlock()
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to find container %q while checking for new containers", containerName)
 	}
 	contHandler := cont.handler
-	m.containersLock.RUnlock()
 	allContainers, err := contHandler.ListContainers(container.ListRecursive)
-	m.containersLock.RLock()
 
 	if err != nil {
 		return nil, nil, err
 	}
 	allContainers = append(allContainers, info.ContainerReference{Name: containerName})
+
+	m.containersLock.RLock()
+	defer m.containersLock.RUnlock()
 
 	// Determine which were added and which were removed.
 	allContainersSet := make(map[string]*containerData)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1095,8 +1095,7 @@ func (m *manager) getContainersDiff(containerName string) (added []info.Containe
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to find container %q while checking for new containers", containerName)
 	}
-	contHandler := cont.handler
-	allContainers, err := contHandler.ListContainers(container.ListRecursive)
+	allContainers, err := cont.handler.ListContainers(container.ListRecursive)
 
 	if err != nil {
 		return nil, nil, err

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1096,7 +1096,11 @@ func (m *manager) getContainersDiff(containerName string) (added []info.Containe
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to find container %q while checking for new containers", containerName)
 	}
-	allContainers, err := cont.handler.ListContainers(container.ListRecursive)
+	contHandler := cont.handler
+	m.containersLock.RUnlock()
+	allContainers, err := contHandler.ListContainers(container.ListRecursive)
+	m.containersLock.RLock()
+				       
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Sometimes, when reading of cgroups tree is too slow, manager.getContainersDiff during global housekeeping could block any other actions due to acquiring mmanager.containersLock for a long time.

To fix it, we could release lock while list cgroups tree and then acquire it again to get diff.