### PR TITLE
Update documentation to make /var/run read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To quickly tryout cAdvisor on your machine with Docker, we have a Docker image t
 ```
 sudo docker run \
   --volume=/:/rootfs:ro \
-  --volume=/var/run:/var/run:rw \
+  --volume=/var/run:/var/run:ro \
   --volume=/sys:/sys:ro \
   --volume=/var/lib/docker/:/var/lib/docker:ro \
   --volume=/dev/disk/:/dev/disk:ro \

--- a/deploy/kubernetes/base/daemonset.yaml
+++ b/deploy/kubernetes/base/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
         - name: docker
           mountPath: /var/lib/docker
           readOnly: true
+        - name: disk
+          mountPath: /dev/disk
+          readOnly: true
         ports:
           - name: http
             containerPort: 8080
@@ -49,3 +52,6 @@ spec:
       - name: docker
         hostPath:
           path: /var/lib/docker
+      - name: disk
+        hostPath:
+          path: /dev/disk


### PR DESCRIPTION
Fixes https://github.com/google/cadvisor/issues/1955, and makes the kustomize base equivalent to the `docker run` docs.

/assign @tallclair 