### PR TITLE
Add kubernetes metadata as prometheus labels

### DIFF
--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -68,7 +68,7 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 		{
 			ContainerReference: info.ContainerReference{
 				Name:    "testcontainer",
-				Aliases: []string{"testcontaineralias"},
+				Aliases: []string{"k8s_container_pod_namespace_uid_restart-count"},
 			},
 			Spec: info.ContainerSpec{
 				Image:  "test",

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -3,204 +3,204 @@
 cadvisor_version_info{cadvisorRevision="abcdef",cadvisorVersion="0.16.0",dockerVersion="1.8.1",kernelVersion="4.1.6-200.fc22.x86_64",osVersion="Fedora 22 (Twenty Two)"} 1
 # HELP container_accelerator_duty_cycle Percent of time over the past sample period during which the accelerator was actively processing.
 # TYPE container_accelerator_duty_cycle gauge
-container_accelerator_duty_cycle{acc_id="GPU-deadbeef-0123-4567-89ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-k80",name="testcontaineralias",zone_name="hello"} 6
-container_accelerator_duty_cycle{acc_id="GPU-deadbeef-1234-5678-90ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-p100",name="testcontaineralias",zone_name="hello"} 12
+container_accelerator_duty_cycle{acc_id="GPU-deadbeef-0123-4567-89ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-k80",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 6
+container_accelerator_duty_cycle{acc_id="GPU-deadbeef-1234-5678-90ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-p100",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 12
 # HELP container_accelerator_memory_total_bytes Total accelerator memory.
 # TYPE container_accelerator_memory_total_bytes gauge
-container_accelerator_memory_total_bytes{acc_id="GPU-deadbeef-0123-4567-89ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-k80",name="testcontaineralias",zone_name="hello"} 1.0203040506e+10
-container_accelerator_memory_total_bytes{acc_id="GPU-deadbeef-1234-5678-90ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-p100",name="testcontaineralias",zone_name="hello"} 2.0304050607e+10
+container_accelerator_memory_total_bytes{acc_id="GPU-deadbeef-0123-4567-89ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-k80",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 1.0203040506e+10
+container_accelerator_memory_total_bytes{acc_id="GPU-deadbeef-1234-5678-90ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-p100",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 2.0304050607e+10
 # HELP container_accelerator_memory_used_bytes Total accelerator memory allocated.
 # TYPE container_accelerator_memory_used_bytes gauge
-container_accelerator_memory_used_bytes{acc_id="GPU-deadbeef-0123-4567-89ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-k80",name="testcontaineralias",zone_name="hello"} 1.02030405e+09
-container_accelerator_memory_used_bytes{acc_id="GPU-deadbeef-1234-5678-90ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-p100",name="testcontaineralias",zone_name="hello"} 2.03040506e+09
+container_accelerator_memory_used_bytes{acc_id="GPU-deadbeef-0123-4567-89ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-k80",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 1.02030405e+09
+container_accelerator_memory_used_bytes{acc_id="GPU-deadbeef-1234-5678-90ab-feedfacecafe",container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",make="nvidia",model="tesla-p100",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 2.03040506e+09
 # HELP container_cpu_cfs_periods_total Number of elapsed enforcement period intervals.
 # TYPE container_cpu_cfs_periods_total counter
-container_cpu_cfs_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 723
+container_cpu_cfs_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 723
 # HELP container_cpu_cfs_throttled_periods_total Number of throttled period intervals.
 # TYPE container_cpu_cfs_throttled_periods_total counter
-container_cpu_cfs_throttled_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 18
+container_cpu_cfs_throttled_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 18
 # HELP container_cpu_cfs_throttled_seconds_total Total time duration the container has been throttled.
 # TYPE container_cpu_cfs_throttled_seconds_total counter
-container_cpu_cfs_throttled_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.724314
+container_cpu_cfs_throttled_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 1.724314
 # HELP container_cpu_load_average_10s Value of container cpu load average over the last 10 seconds.
 # TYPE container_cpu_load_average_10s gauge
-container_cpu_load_average_10s{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2
+container_cpu_load_average_10s{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 2
 # HELP container_cpu_schedstat_run_periods_total Number of times processes of the cgroup have run on the cpu
 # TYPE container_cpu_schedstat_run_periods_total counter
-container_cpu_schedstat_run_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 984285
+container_cpu_schedstat_run_periods_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 984285
 # HELP container_cpu_schedstat_run_seconds_total Time duration the processes of the container have run on the CPU.
 # TYPE container_cpu_schedstat_run_seconds_total counter
-container_cpu_schedstat_run_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.053643567
+container_cpu_schedstat_run_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 0.053643567
 # HELP container_cpu_schedstat_runqueue_seconds_total Time duration processes of the container have been waiting on a runqueue.
 # TYPE container_cpu_schedstat_runqueue_seconds_total counter
-container_cpu_schedstat_runqueue_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 479.424566378
+container_cpu_schedstat_runqueue_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 479.424566378
 # HELP container_cpu_system_seconds_total Cumulative system cpu time consumed in seconds.
 # TYPE container_cpu_system_seconds_total counter
-container_cpu_system_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 7e-09
+container_cpu_system_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 7e-09
 # HELP container_cpu_usage_seconds_total Cumulative cpu time consumed in seconds.
 # TYPE container_cpu_usage_seconds_total counter
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu00",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2e-09
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu01",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3e-09
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu02",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4e-09
-container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu03",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu00",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 2e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu01",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 3e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu02",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4e-09
+container_cpu_usage_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="cpu03",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 5e-09
 # HELP container_cpu_user_seconds_total Cumulative user cpu time consumed in seconds.
 # TYPE container_cpu_user_seconds_total counter
-container_cpu_user_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 6e-09
+container_cpu_user_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 6e-09
 # HELP container_fs_inodes_free Number of available Inodes
 # TYPE container_fs_inodes_free gauge
-container_fs_inodes_free{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 524288
-container_fs_inodes_free{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 262144
+container_fs_inodes_free{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 524288
+container_fs_inodes_free{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 262144
 # HELP container_fs_inodes_total Number of Inodes
 # TYPE container_fs_inodes_total gauge
-container_fs_inodes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2.097152e+06
-container_fs_inodes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2.097152e+06
+container_fs_inodes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 2.097152e+06
+container_fs_inodes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 2.097152e+06
 # HELP container_fs_io_current Number of I/Os currently in progress
 # TYPE container_fs_io_current gauge
-container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 42
-container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 47
+container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 42
+container_fs_io_current{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 47
 # HELP container_fs_io_time_seconds_total Cumulative count of seconds spent doing I/Os
 # TYPE container_fs_io_time_seconds_total counter
-container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.3e-08
-container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.8e-08
+container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4.3e-08
+container_fs_io_time_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4.8e-08
 # HELP container_fs_io_time_weighted_seconds_total Cumulative weighted I/O time in seconds
 # TYPE container_fs_io_time_weighted_seconds_total counter
-container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.4e-08
-container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.9e-08
+container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4.4e-08
+container_fs_io_time_weighted_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4.9e-08
 # HELP container_fs_limit_bytes Number of bytes that can be consumed by the container on this filesystem.
 # TYPE container_fs_limit_bytes gauge
-container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 22
-container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 37
+container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 22
+container_fs_limit_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 37
 # HELP container_fs_read_seconds_total Cumulative count of seconds spent reading
 # TYPE container_fs_read_seconds_total counter
-container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2.7e-08
-container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.2e-08
+container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 2.7e-08
+container_fs_read_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4.2e-08
 # HELP container_fs_reads_merged_total Cumulative count of reads merged
 # TYPE container_fs_reads_merged_total counter
-container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 25
-container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 40
+container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 25
+container_fs_reads_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 40
 # HELP container_fs_reads_total Cumulative count of reads completed
 # TYPE container_fs_reads_total counter
-container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 24
-container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 39
+container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 24
+container_fs_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 39
 # HELP container_fs_sector_reads_total Cumulative count of sector reads completed
 # TYPE container_fs_sector_reads_total counter
-container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 26
-container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 41
+container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 26
+container_fs_sector_reads_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 41
 # HELP container_fs_sector_writes_total Cumulative count of sector writes completed
 # TYPE container_fs_sector_writes_total counter
-container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 40
-container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 45
+container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 40
+container_fs_sector_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 45
 # HELP container_fs_usage_bytes Number of bytes that are consumed by the container on this filesystem.
 # TYPE container_fs_usage_bytes gauge
-container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 23
-container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 38
+container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 23
+container_fs_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 38
 # HELP container_fs_write_seconds_total Cumulative count of seconds spent writing
 # TYPE container_fs_write_seconds_total counter
-container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.1e-08
-container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 4.6e-08
+container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4.1e-08
+container_fs_write_seconds_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 4.6e-08
 # HELP container_fs_writes_merged_total Cumulative count of writes merged
 # TYPE container_fs_writes_merged_total counter
-container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 39
-container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 44
+container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 39
+container_fs_writes_merged_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 44
 # HELP container_fs_writes_total Cumulative count of writes completed
 # TYPE container_fs_writes_total counter
-container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 28
-container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 43
+container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda1",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 28
+container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 43
 # HELP container_last_seen Last time a container was seen by the exporter
 # TYPE container_last_seen gauge
-container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.426203694e+09
+container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 1.426203694e+09
 # HELP container_memory_cache Number of bytes of page cache memory.
 # TYPE container_memory_cache gauge
-container_memory_cache{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 14
+container_memory_cache{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 14
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
-container_memory_failcnt{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0
+container_memory_failcnt{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 0
 # HELP container_memory_failures_total Cumulative count of memory allocation failures.
 # TYPE container_memory_failures_total counter
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgfault",zone_name="hello"} 10
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="container",type="pgmajfault",zone_name="hello"} 11
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgfault",zone_name="hello"} 12
-container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",type="pgmajfault",zone_name="hello"} 13
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",scope="container",type="pgfault",zone_name="hello"} 10
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",scope="container",type="pgmajfault",zone_name="hello"} 11
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",scope="hierarchy",type="pgfault",zone_name="hello"} 12
+container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",scope="hierarchy",type="pgmajfault",zone_name="hello"} 13
 # HELP container_memory_max_usage_bytes Maximum memory usage recorded in bytes
 # TYPE container_memory_max_usage_bytes gauge
-container_memory_max_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8
+container_memory_max_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 8
 # HELP container_memory_rss Size of RSS in bytes.
 # TYPE container_memory_rss gauge
-container_memory_rss{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 15
+container_memory_rss{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 15
 # HELP container_memory_swap Container swap usage in bytes.
 # TYPE container_memory_swap gauge
-container_memory_swap{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8192
+container_memory_swap{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 8192
 # HELP container_memory_usage_bytes Current memory usage in bytes, including all memory regardless of when it was accessed
 # TYPE container_memory_usage_bytes gauge
-container_memory_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8
+container_memory_usage_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 8
 # HELP container_memory_working_set_bytes Current working set in bytes.
 # TYPE container_memory_working_set_bytes gauge
-container_memory_working_set_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 9
+container_memory_working_set_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 9
 # HELP container_network_receive_bytes_total Cumulative count of bytes received
 # TYPE container_network_receive_bytes_total counter
-container_network_receive_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 14
+container_network_receive_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 14
 # HELP container_network_receive_errors_total Cumulative count of errors encountered while receiving
 # TYPE container_network_receive_errors_total counter
-container_network_receive_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 16
+container_network_receive_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 16
 # HELP container_network_receive_packets_dropped_total Cumulative count of packets dropped while receiving
 # TYPE container_network_receive_packets_dropped_total counter
-container_network_receive_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 17
+container_network_receive_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 17
 # HELP container_network_receive_packets_total Cumulative count of packets received
 # TYPE container_network_receive_packets_total counter
-container_network_receive_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 15
+container_network_receive_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 15
 # HELP container_network_tcp_usage_total tcp connection usage statistic for container
 # TYPE container_network_tcp_usage_total gauge
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="close",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="closewait",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="closing",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="established",zone_name="hello"} 13
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="finwait1",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="finwait2",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="lastack",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="listen",zone_name="hello"} 3
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="synrecv",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="synsent",zone_name="hello"} 0
-container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="timewait",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="close",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="closewait",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="closing",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="established",zone_name="hello"} 13
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="finwait1",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="finwait2",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="lastack",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="listen",zone_name="hello"} 3
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="synrecv",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="synsent",zone_name="hello"} 0
+container_network_tcp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",tcp_state="timewait",zone_name="hello"} 0
 # HELP container_network_transmit_bytes_total Cumulative count of bytes transmitted
 # TYPE container_network_transmit_bytes_total counter
-container_network_transmit_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 18
+container_network_transmit_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 18
 # HELP container_network_transmit_errors_total Cumulative count of errors encountered while transmitting
 # TYPE container_network_transmit_errors_total counter
-container_network_transmit_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 20
+container_network_transmit_errors_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 20
 # HELP container_network_transmit_packets_dropped_total Cumulative count of packets dropped while transmitting
 # TYPE container_network_transmit_packets_dropped_total counter
-container_network_transmit_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 21
+container_network_transmit_packets_dropped_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 21
 # HELP container_network_transmit_packets_total Cumulative count of packets transmitted
 # TYPE container_network_transmit_packets_total counter
-container_network_transmit_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 19
+container_network_transmit_packets_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 19
 # HELP container_network_udp_usage_total udp connection usage statistic for container
 # TYPE container_network_udp_usage_total gauge
-container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="dropped",zone_name="hello"} 0
-container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="listen",zone_name="hello"} 0
-container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="rxqueued",zone_name="hello"} 0
-container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="txqueued",zone_name="hello"} 0
+container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",udp_state="dropped",zone_name="hello"} 0
+container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",udp_state="listen",zone_name="hello"} 0
+container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",udp_state="rxqueued",zone_name="hello"} 0
+container_network_udp_usage_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",udp_state="txqueued",zone_name="hello"} 0
 # HELP container_scrape_error 1 if there was an error while getting container metrics, 0 otherwise
 # TYPE container_scrape_error gauge
 container_scrape_error 0
 # HELP container_spec_cpu_period CPU period of the container.
 # TYPE container_spec_cpu_period gauge
-container_spec_cpu_period{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 100000
+container_spec_cpu_period{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 100000
 # HELP container_spec_cpu_quota CPU quota of the container.
 # TYPE container_spec_cpu_quota gauge
-container_spec_cpu_quota{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 10000
+container_spec_cpu_quota{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 10000
 # HELP container_spec_cpu_shares CPU share of the container.
 # TYPE container_spec_cpu_shares gauge
-container_spec_cpu_shares{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1000
+container_spec_cpu_shares{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 1000
 # HELP container_start_time_seconds Start time of the container since unix epoch in seconds.
 # TYPE container_start_time_seconds gauge
-container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
+container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",zone_name="hello"} 1.257894e+09
 # HELP container_tasks_state Number of tasks in given state
 # TYPE container_tasks_state gauge
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="iowaiting",zone_name="hello"} 54
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="running",zone_name="hello"} 51
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="sleeping",zone_name="hello"} 50
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="stopped",zone_name="hello"} 52
-container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="uninterruptible",zone_name="hello"} 53
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",state="iowaiting",zone_name="hello"} 54
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",state="running",zone_name="hello"} 51
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",state="sleeping",zone_name="hello"} 50
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",state="stopped",zone_name="hello"} 52
+container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="container",pod_id="uid",pod_name="pod",pod_namespace="namespace",state="uninterruptible",zone_name="hello"} 53
 # HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
 # TYPE http_request_duration_microseconds summary
 http_request_duration_microseconds{handler="prometheus",quantile="0.5"} 0


### PR DESCRIPTION
This adds three new labels to prometheus metrics for kubernetes-managed containers:
 * pod_name
 * pod_id
 * pod_namespace

While this technically relies on a kubelet implementation detail (the format of the container label used to store this information), this information would be very useful for those using cAdvisor with kubernetes.