### PR TITLE
fix minor errors revealed by go 1.11

### DIFF
--- a/manager/watcher/raw/raw.go
+++ b/manager/watcher/raw/raw.go
@@ -87,7 +87,7 @@ func (self *rawContainerWatcher) Start(events chan watcher.ContainerEvent) error
 					glog.Warningf("Error while processing event (%+v): %v", event, err)
 				}
 			case err := <-self.watcher.Error():
-				glog.Warningf("Error while watching %q:", "/", err)
+				glog.Warningf("Error while watching %q: %v", "/", err)
 			case <-self.stopWatcher:
 				err := self.watcher.Close()
 				if err == nil {

--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -140,11 +140,11 @@ type glogAdapter struct{}
 var _ kmsgparser.Logger = glogAdapter{}
 
 func (glogAdapter) Infof(format string, args ...interface{}) {
-	glog.V(4).Infof(format, args)
+	glog.V(4).Infof(format, args...)
 }
 func (glogAdapter) Warningf(format string, args ...interface{}) {
-	glog.V(2).Infof(format, args)
+	glog.V(2).Infof(format, args...)
 }
 func (glogAdapter) Errorf(format string, args ...interface{}) {
-	glog.Warningf(format, args)
+	glog.Warningf(format, args...)
 }


### PR DESCRIPTION
This allows cadvisor to build/test properly with a 1.11 toolchain.