### PR TITLE
Avoid too many mesos errors in logs when mesos is not present

### DIFF
--- a/container/mesos/client.go
+++ b/container/mesos/client.go
@@ -70,6 +70,11 @@ func Client() (mesosAgentClient, error) {
 			),
 		}
 	})
+
+	_, err := mesosClient.getVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get version")
+	}
 	return mesosClient, nil
 }
 
@@ -132,6 +137,20 @@ func (self *client) getContainer(id string) (*mContainer, error) {
 		}
 	}
 	return nil, fmt.Errorf("can't locate container %s", id)
+}
+
+func (self *client) getVersion() (string, error) {
+	req := calls.NonStreaming(calls.GetVersion())
+	result, err := self.fetchAndDecode(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get mesos version: %v", err)
+	}
+	version := result.GetVersion
+
+	if version == nil {
+		return "", fmt.Errorf("failed to get mesos version")
+	}
+	return version.VersionInfo.Version, nil
 }
 
 func (self *client) getContainers() (mContainers, error) {


### PR DESCRIPTION
We see a lot of logs in k/k CI as follows:
"Factory "mesos" was unable to handle container "/system.slice/home-kubernetes-containerized_mounter.mount"

Example, please see:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/69003/pull-kubernetes-node-e2e/105485/artifacts/tmp-node-e2e-9f0e4e26-cos-stable-63-10032-71-0/kubelet.log

It would be better if we do some sanity check for mesos running before
we try to use it.

Change-Id: I5f6ebcd44fdd4f8d724b85857edf1600473ef1ab