### PR TITLE
Use go1.10 for canary builds

### DIFF
--- a/deploy/canary/Dockerfile
+++ b/deploy/canary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.10
 MAINTAINER vmarmol@google.com
 
 RUN apt-get update && apt-get install -y git dmsetup && apt-get clean

--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -6,7 +6,7 @@
 
 cAdvisor is written in the [Go](http://golang.org) programming language. If you haven't set up a Go development environment, please follow [these instructions](http://golang.org/doc/code.html) to install go tool and set up GOPATH. Note that the version of Go in package repositories of some operating systems is outdated, so please [download](https://golang.org/dl/) the latest version.
 
-**Note**: cAdvisor requires Go 1.7 to build.
+**Note**: cAdvisor requires Go 1.10 to build.
 
 After setting up Go, you should be able to `go get` cAdvisor as expected (we use `-d` to only download):
 


### PR DESCRIPTION
The canary builds run with the latest go version, which has been failing since it was updated to 1.11:
https://k8s-testgrid.appspot.com/sig-node-cadvisor#cadvisor-push

Rather than making cadvisor work with 1.11, this changes the canary version to 1.10 (the same development version as k/k).  We can change it back to the `latest` tag after we move to 1.11, assuming 1.11 and 1.12 are compatible.