### PR TITLE
fix spelling errors

### DIFF
--- a/cache/memory/memory.go
+++ b/cache/memory/memory.go
@@ -29,7 +29,7 @@ import (
 // ErrDataNotFound is the error resulting if failed to find a container in memory cache.
 var ErrDataNotFound = errors.New("unable to find data in memory cache")
 
-// TODO(vmarmol): See about refactoring this class, we have an unecessary redirection of containerCache and InMemoryCache.
+// TODO(vmarmol): See about refactoring this class, we have an unnecessary redirection of containerCache and InMemoryCache.
 // containerCache is used to store per-container information
 type containerCache struct {
 	ref         info.ContainerReference

--- a/container/common/inotify_watcher.go
+++ b/container/common/inotify_watcher.go
@@ -78,7 +78,7 @@ func (iw *InotifyWatcher) RemoveWatch(containerName, dir string) (bool, error) {
 	iw.lock.Lock()
 	defer iw.lock.Unlock()
 
-	// If we don't have a watch registed for this, just return.
+	// If we don't have a watch registered for this, just return.
 	cgroupsWatched, ok := iw.containersWatched[containerName]
 	if !ok {
 		return false, nil

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -228,7 +228,7 @@ func newDockerContainerHandler(
 		handler.labels["restartcount"] = strconv.Itoa(ctnr.RestartCount)
 	}
 
-	// Obtain the IP address for the contianer.
+	// Obtain the IP address for the container.
 	// If the NetworkMode starts with 'container:' then we need to use the IP address of the container specified.
 	// This happens in cases such as kubernetes where the containers doesn't have an IP address itself and we need to use the pod's address
 	ipAddress := ctnr.NetworkSettings.IPAddress

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -114,7 +114,7 @@ func NewFsInfo(context Context) (FsInfo, error) {
 
 	fsUUIDToDeviceName, err := getFsUUIDToDeviceNameMap()
 	if err != nil {
-		// UUID is not always avaiable across different OS distributions.
+		// UUID is not always available across different OS distributions.
 		// Do not fail if there is an error.
 		glog.Warningf("Failed to get disk UUID mapping, getting disk info by uuid will not work: %v", err)
 	}

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -102,11 +102,11 @@ type ContainerInfoRequest struct {
 	NumStats int `json:"num_stats,omitempty"`
 
 	// Start time for which to query information.
-	// If ommitted, the beginning of time is assumed.
+	// If omitted, the beginning of time is assumed.
 	Start time.Time `json:"start,omitempty"`
 
 	// End time for which to query information.
-	// If ommitted, current time is assumed.
+	// If omitted, current time is assumed.
 	End time.Time `json:"end,omitempty"`
 }
 

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -38,7 +38,7 @@ type CpuSpec struct {
 	Mask string `json:"mask,omitempty"`
 	// CPUQuota Default is disabled
 	Quota uint64 `json:"quota,omitempty"`
-	// Period is the CPU reference time in ns e.g the quota is compared aginst this.
+	// Period is the CPU reference time in ns e.g the quota is compared against this.
 	Period uint64 `json:"period,omitempty"`
 }
 


### PR DESCRIPTION
```
modified:   cache/memory/memory.go
modified:   container/common/inotify_watcher.go
modified:   fs/fs.go
modified:   info/v1/container.go
modified:   info/v2/container.go
```

:smiley: 