### PR TITLE
add rate metrics to prometheus api 

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -954,7 +954,7 @@ func BaseContainerLabels(container *info.ContainerInfo) map[string]string {
 }
 
 func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric) {
-	containers, err := c.infoProvider.SubcontainersInfo("/", &info.ContainerInfoRequest{NumStats: 1})
+	containers, err := c.infoProvider.SubcontainersInfo("/", &info.ContainerInfoRequest{NumStats: 2})
 	if err != nil {
 		c.errors.Set(1)
 		glog.Warningf("Couldn't get containers: %s", err)


### PR DESCRIPTION
prometheus use cadvisor to aggregate cpu_uage_rate with the metric `container_cpu_usage_seconds_total`(cumulative cpu time consumed in seconds) but cadvisor don't provide timestamp. So the cpu usage rate will  be not accuracy because of the deviation of the calculation of time range especially when data collection delayed.Here is a demo to show the impact.   
![07f9cf92-e2fa-44d7-97ae-b37a446f8055](https://user-images.githubusercontent.com/3116693/46208826-8de90180-c35e-11e8-823c-4a1e43ebb04c.png)
![411bebf8-d29e-407c-aa77-6127630ad0f9](https://user-images.githubusercontent.com/3116693/46208841-9c371d80-c35e-11e8-8813-9a6c2a466a10.png)
The first image is using  the metric `container_cpu_usage_seconds_total` and the second image is using the new metric `container_cpu_user_usage_rate`. 