### PR TITLE
Cache process metrics

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -557,6 +557,14 @@ type AcceleratorStats struct {
 	DutyCycle uint64 `json:"duty_cycle"`
 }
 
+type ProcessStats struct {
+	// Number of processes
+	ProcessCount uint64 `json:"process_count"`
+
+	// Number of open file descriptors
+	FdCount uint64 `json:"fd_count"`
+}
+
 type ContainerStats struct {
 	// The time of this stat point.
 	Timestamp time.Time    `json:"timestamp"`
@@ -573,6 +581,9 @@ type ContainerStats struct {
 
 	// Metrics for Accelerators. Each Accelerator corresponds to one element in the array.
 	Accelerators []AcceleratorStats `json:"accelerators,omitempty"`
+
+	// ProcessStats for Containers
+	Processes ProcessStats `json:"processes,omitempty"`
 
 	// Custom metrics from all collectors
 	CustomMetrics map[string][]MetricVal `json:"custom_metrics,omitempty"`

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -252,6 +252,10 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 							DutyCycle:   6,
 						},
 					},
+					Processes: info.ProcessStats{
+						ProcessCount: 1,
+						FdCount:      5,
+					},
 					TaskStats: info.LoadStats{
 						NrSleeping:        50,
 						NrRunning:         51,


### PR DESCRIPTION
Cache the process stats (ProcessCount, File Descriptor Count) of a container, so that the response time is improved.