### PR TITLE
Remove unused interface method

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/cadvisor/container"
 	info "github.com/google/cadvisor/info/v1"
-	"github.com/google/cadvisor/info/v2"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog"
@@ -36,8 +35,6 @@ type infoProvider interface {
 	GetVersionInfo() (*info.VersionInfo, error)
 	// GetMachineInfo provides information about the machine.
 	GetMachineInfo() (*info.MachineInfo, error)
-	// GetProcessList provides information about each container's processes
-	GetProcessList(containerName string, options v2.RequestOptions) ([]v2.ProcessInfo, error)
 }
 
 // metricValue describes a single metric value for a given set of label values

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/google/cadvisor/container"
 	info "github.com/google/cadvisor/info/v1"
-	"github.com/google/cadvisor/info/v2"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -47,26 +46,6 @@ func (p testSubcontainersInfoProvider) GetMachineInfo() (*info.MachineInfo, erro
 	return &info.MachineInfo{
 		NumCores:       4,
 		MemoryCapacity: 1024,
-	}, nil
-}
-
-func (p testSubcontainersInfoProvider) GetProcessList(containerName string, options v2.RequestOptions) ([]v2.ProcessInfo, error) {
-	return []v2.ProcessInfo{
-		{
-			User:          "user1",
-			Pid:           1,
-			Ppid:          2,
-			StartTime:     "OCT2018",
-			PercentCpu:    0.0,
-			PercentMemory: 0.0,
-			RSS:           3,
-			VirtualSize:   4,
-			Status:        "S",
-			RunningTime:   "00:00:00",
-			Cmd:           "cmd1",
-			CgroupPath:    "path",
-			FdCount:       5,
-		},
 	}, nil
 }
 
@@ -329,13 +308,6 @@ func (p *erroringSubcontainersInfoProvider) GetMachineInfo() (*info.MachineInfo,
 		return nil, errors.New("Oops 2")
 	}
 	return p.successfulProvider.GetMachineInfo()
-}
-
-func (p *erroringSubcontainersInfoProvider) GetProcessList(containerName string, options v2.RequestOptions) ([]v2.ProcessInfo, error) {
-	if p.shouldFail {
-		return nil, errors.New("Oops 2")
-	}
-	return p.successfulProvider.GetProcessList(containerName, options)
 }
 
 func (p *erroringSubcontainersInfoProvider) SubcontainersInfo(


### PR DESCRIPTION
The interface was added in https://github.com/google/cadvisor/pull/2069, but then we took a different approach in https://github.com/google/cadvisor/pull/2093.  This is causing issues for the cAdvisor godependency update: https://github.com/kubernetes/kubernetes/pull/70829.

cc @dims @sashankreddya 