### PR TITLE
Add example kustomization which gives cAdvisor access to NVML

### DIFF
--- a/deploy/kubernetes/overlays/examples/gpu-privilages.yaml
+++ b/deploy/kubernetes/overlays/examples/gpu-privilages.yaml
@@ -1,0 +1,29 @@
+# This patch adds the required hostpath mounts and privilages to initialize NVML, as well as to access devices.
+# This patch meets the requirements described in the accellerator docs: 
+# https://github.com/google/cadvisor/blob/master/docs/running.md#hardware-accelerator-monitoring
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+spec:
+  template:
+    spec:
+      containers:
+      - name: cadvisor
+        volumeMounts:
+        - name: dev
+          mountPath: /dev
+        - name: libnvidia
+          mountPath: /bin/nvidia/lib64/
+        securityContext:
+          privileged: true  # TODO use more granular permissions (e.g. linux capabilities) to allow cAdvisor to use NVML
+        env:
+        - name: LD_LIBRARY_PATH
+          value: "/bin/nvidia/lib64/"
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: libnvidia
+          hostPath:
+            path: /home/kubernetes/bin/nvidia/lib64/  # Insert your path to libnvidia here

--- a/deploy/kubernetes/overlays/examples/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples/kustomization.yaml
@@ -4,3 +4,4 @@ patches:
 - stackdriver-sidecar.yaml
 - critical-priority.yaml
 - cadvisor-args.yaml
+- gpu-privilages.yaml


### PR DESCRIPTION
I have gotten a bunch of questions about how to use containerized cAdvisor to monitor GPUs.  This should give _something_ for me to point at, even if it isn't perfect.

cc @mindprince 
/assign @tallclair 