### PR TITLE
Add white list cgroup path list

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -141,7 +141,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, []string{"/"})
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, []string{"/"}, nil)
 	if err != nil {
 		klog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -142,7 +142,7 @@ type Manager interface {
 }
 
 // New takes a memory storage and returns a new manager.
-func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, includedMetricsSet container.MetricSet, collectorHttpClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string) (Manager, error) {
+func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, includedMetricsSet container.MetricSet, collectorHttpClient *http.Client, rawContainerCgroupPathPrefixWhiteList, rawContainerCgroupPathWhiteList []string) (Manager, error) {
 	if memoryCache == nil {
 		return nil, fmt.Errorf("manager requires memory storage")
 	}
@@ -219,6 +219,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 		collectorHttpClient:                   collectorHttpClient,
 		nvidiaManager:                         &accelerators.NvidiaManager{},
 		rawContainerCgroupPathPrefixWhiteList: rawContainerCgroupPathPrefixWhiteList,
+		rawContainerCgroupPathList:            rawContainerCgroupPathWhiteList,
 	}
 
 	machineInfo, err := machine.Info(sysfs, fsInfo, inHostNamespace)
@@ -292,6 +293,8 @@ type manager struct {
 	nvidiaManager            accelerators.AcceleratorManager
 	// List of raw container cgroup path prefix whitelist.
 	rawContainerCgroupPathPrefixWhiteList []string
+	// List of raw container cgroup path whitelist.
+	rawContainerCgroupPathList []string
 }
 
 // Start the container manager.
@@ -332,7 +335,7 @@ func (self *manager) Start() error {
 		klog.V(5).Infof("Registration of the systemd container factory failed: %v", err)
 	}
 
-	err = raw.Register(self, self.fsInfo, self.includedMetrics, self.rawContainerCgroupPathPrefixWhiteList)
+	err = raw.Register(self, self.fsInfo, self.includedMetrics, self.rawContainerCgroupPathPrefixWhiteList, self.rawContainerCgroupPathList)
 	if err != nil {
 		klog.Errorf("Registration of the raw container factory failed: %v", err)
 	}


### PR DESCRIPTION
We only have a path prefix args previously, so we can't collect specific paths and blacklist the others under a prefix.

ref: https://github.com/kubernetes/kubernetes/issues/71367