### PR TITLE
Add flag to white list container labels for prometheus metrics

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -61,7 +61,7 @@ var collectorCert = flag.String("collector_cert", "", "Collector's certificate, 
 var collectorKey = flag.String("collector_key", "", "Key for the collector's certificate")
 
 var storeContainerLabels = flag.Bool("store_container_labels", true, "convert container labels and environment variables into labels on prometheus metrics for each container. If flag set to false, then only metrics exported are container name, first alias, and image name")
-var whiteListedContainerLabels = flag.String("white_listed_container_labels", "", "comma separated list of container labels to be converted to labels on prometheus metrics for each container.")
+var whitelistedContainerLabels = flag.String("whitelisted_container_labels", "", "comma separated list of container labels to be converted to labels on prometheus metrics for each container. store_container_labels must be set to false for this to take effect.")
 
 var (
 	// Metrics to be ignored.
@@ -163,13 +163,11 @@ func main() {
 	}
 
 	containerLabelFunc := metrics.DefaultContainerLabels
-
-	whiteListedLabels := strings.Split(*whiteListedContainerLabels, ",")
-	if len(whiteListedLabels) > 0 {
-		containerLabelFunc = metrics.WhiteListedContainerLabels(whiteListedLabels)
-	} else if !*storeContainerLabels {
-		containerLabelFunc = metrics.BaseContainerLabels
+	if !*storeContainerLabels {
+		whitelistedLabels := strings.Split(*whitelistedContainerLabels, ",")
+		containerLabelFunc = metrics.BaseContainerLabels(whitelistedLabels)
 	}
+
 	cadvisorhttp.RegisterPrometheusHandler(mux, containerManager, *prometheusEndpoint, containerLabelFunc, includedMetrics)
 
 	// Start the manager.

--- a/cadvisor.go
+++ b/cadvisor.go
@@ -61,6 +61,7 @@ var collectorCert = flag.String("collector_cert", "", "Collector's certificate, 
 var collectorKey = flag.String("collector_key", "", "Key for the collector's certificate")
 
 var storeContainerLabels = flag.Bool("store_container_labels", true, "convert container labels and environment variables into labels on prometheus metrics for each container. If flag set to false, then only metrics exported are container name, first alias, and image name")
+var whiteListedContainerLabels = flag.String("white_listed_container_labels", "", "comma separated list of container labels to be converted to labels on prometheus metrics for each container.")
 
 var (
 	// Metrics to be ignored.
@@ -162,7 +163,11 @@ func main() {
 	}
 
 	containerLabelFunc := metrics.DefaultContainerLabels
-	if !*storeContainerLabels {
+
+	whiteListedLabels := strings.Split(*whiteListedContainerLabels, ",")
+	if len(whiteListedLabels) > 0 {
+		containerLabelFunc = metrics.WhiteListedContainerLabels(whiteListedLabels)
+	} else if !*storeContainerLabels {
 		containerLabelFunc = metrics.BaseContainerLabels
 	}
 	cadvisorhttp.RegisterPrometheusHandler(mux, containerManager, *prometheusEndpoint, containerLabelFunc, includedMetrics)

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -902,32 +902,6 @@ const (
 	LabelImage = "image"
 )
 
-// WhiteListedContainerLabels returns a ContainerLabelsFunc that exports the
-// container name, first alias, image name as well as white listed label
-// values.
-func WhiteListedContainerLabels(whiteList []string) func(container *info.ContainerInfo) map[string]string {
-	whiteListMap := make(map[string]struct{}, len(whiteList))
-	for _, k := range whiteList {
-		whiteListMap[k] = struct{}{}
-	}
-
-	return func(container *info.ContainerInfo) map[string]string {
-		set := map[string]string{LabelID: container.Name}
-		if len(container.Aliases) > 0 {
-			set[LabelName] = container.Aliases[0]
-		}
-		if image := container.Spec.Image; len(image) > 0 {
-			set[LabelImage] = image
-		}
-		for k, v := range container.Spec.Labels {
-			if _, ok := whiteListMap[k]; ok {
-				set[ContainerLabelPrefix+k] = v
-			}
-		}
-		return set
-	}
-}
-
 // DefaultContainerLabels implements ContainerLabelsFunc. It exports the
 // container name, first alias, image name as well as all its env and label
 // values.
@@ -948,17 +922,29 @@ func DefaultContainerLabels(container *info.ContainerInfo) map[string]string {
 	return set
 }
 
-// BaseContainerLabels implements ContainerLabelsFunc. It only exports the
-// container name, first alias, and image name.
-func BaseContainerLabels(container *info.ContainerInfo) map[string]string {
-	set := map[string]string{LabelID: container.Name}
-	if len(container.Aliases) > 0 {
-		set[LabelName] = container.Aliases[0]
+// BaseContainerLabels returns a ContainerLabelsFunc that exports the container
+// name, first alias, image name as well as white listed label values.
+func BaseContainerLabels(whiteList []string) func(container *info.ContainerInfo) map[string]string {
+	whiteListMap := make(map[string]struct{}, len(whiteList))
+	for _, k := range whiteList {
+		whiteListMap[k] = struct{}{}
 	}
-	if image := container.Spec.Image; len(image) > 0 {
-		set[LabelImage] = image
+
+	return func(container *info.ContainerInfo) map[string]string {
+		set := map[string]string{LabelID: container.Name}
+		if len(container.Aliases) > 0 {
+			set[LabelName] = container.Aliases[0]
+		}
+		if image := container.Spec.Image; len(image) > 0 {
+			set[LabelImage] = image
+		}
+		for k, v := range container.Spec.Labels {
+			if _, ok := whiteListMap[k]; ok {
+				set[ContainerLabelPrefix+k] = v
+			}
+		}
+		return set
 	}
-	return set
 }
 
 func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric) {


### PR DESCRIPTION
This adds a flag `white_listed_container_labels` which allows specifying
a comma separated list of container labels that are allowed to be
attached to prometheus metrics. This helps limit the label space of
each data point and limits the memory used by cadvisor compared to just
add all labels from all containers which is the default.

This is somewhat similar to the `store_container_labels` flag but a bit
more flexible because it allows white listing some common labels e.g.
`io.kubernetes.pod.name`, `io.kubernetes.pod.namespace` etc.

Without this white listing in place we saw the memory footprint of
cadvisor explode in our production environment because users add a lot
of data in pod labels, data which is not useful for metrics but may be
useful for the individual applications.