### PR TITLE
added --uri_base_prefix option (#2018)

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -62,6 +62,8 @@ var collectorKey = flag.String("collector_key", "", "Key for the collector's cer
 
 var storeContainerLabels = flag.Bool("store_container_labels", true, "convert container labels and environment variables into labels on prometheus metrics for each container. If flag set to false, then only metrics exported are container name, first alias, and image name")
 
+var urlBasePrefix = flag.String("url_base_prefix", "", "prefix path that will be prepended to all paths to support some reverse proxies")
+
 var (
 	// Metrics to be ignored.
 	// Tcp metrics are ignored by default.
@@ -156,7 +158,7 @@ func main() {
 	}
 
 	// Register all HTTP handlers.
-	err = cadvisorhttp.RegisterHandlers(mux, containerManager, *httpAuthFile, *httpAuthRealm, *httpDigestFile, *httpDigestRealm)
+	err = cadvisorhttp.RegisterHandlers(mux, containerManager, *httpAuthFile, *httpAuthRealm, *httpDigestFile, *httpDigestRealm, *urlBasePrefix)
 	if err != nil {
 		klog.Fatalf("Failed to register HTTP handlers: %v", err)
 	}
@@ -177,8 +179,11 @@ func main() {
 
 	klog.V(1).Infof("Starting cAdvisor version: %s-%s on port %d", version.Info["version"], version.Info["revision"], *argPort)
 
+	rootMux := http.NewServeMux()
+	rootMux.Handle(*urlBasePrefix+"/", http.StripPrefix(*urlBasePrefix, mux))
+
 	addr := fmt.Sprintf("%s:%d", *argIp, *argPort)
-	klog.Fatal(http.ListenAndServe(addr, mux))
+	klog.Fatal(http.ListenAndServe(addr, rootMux))
 }
 
 func setMaxProcs() {

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -100,7 +100,7 @@ func dockerHandler(containerManager manager.Manager) auth.AuthenticatedHandlerFu
 }
 
 // Register http handlers
-func RegisterHandlersDigest(mux httpmux.Mux, containerManager manager.Manager, authenticator *auth.DigestAuth) error {
+func RegisterHandlersDigest(mux httpmux.Mux, containerManager manager.Manager, authenticator *auth.DigestAuth, urlBasePrefix string) error {
 	// Register the handler for the containers page.
 	if authenticator != nil {
 		mux.HandleFunc(ContainersPage, authenticator.Wrap(containerHandler(containerManager)))
@@ -109,10 +109,20 @@ func RegisterHandlersDigest(mux httpmux.Mux, containerManager manager.Manager, a
 		mux.HandleFunc(ContainersPage, containerHandlerNoAuth(containerManager))
 		mux.HandleFunc(DockerPage, dockerHandlerNoAuth(containerManager))
 	}
+
+	if ContainersPage[len(ContainersPage)-1] == '/' {
+		redirectHandler := http.RedirectHandler(urlBasePrefix+ContainersPage, http.StatusMovedPermanently)
+		mux.Handle(ContainersPage[0:len(ContainersPage)-1], redirectHandler)
+	}
+	if DockerPage[len(DockerPage)-1] == '/' {
+		redirectHandler := http.RedirectHandler(urlBasePrefix+DockerPage, http.StatusMovedPermanently)
+		mux.Handle(DockerPage[0:len(DockerPage)-1], redirectHandler)
+	}
+
 	return nil
 }
 
-func RegisterHandlersBasic(mux httpmux.Mux, containerManager manager.Manager, authenticator *auth.BasicAuth) error {
+func RegisterHandlersBasic(mux httpmux.Mux, containerManager manager.Manager, authenticator *auth.BasicAuth, urlBasePrefix string) error {
 	// Register the handler for the containers and docker age.
 	if authenticator != nil {
 		mux.HandleFunc(ContainersPage, authenticator.Wrap(containerHandler(containerManager)))
@@ -121,6 +131,16 @@ func RegisterHandlersBasic(mux httpmux.Mux, containerManager manager.Manager, au
 		mux.HandleFunc(ContainersPage, containerHandlerNoAuth(containerManager))
 		mux.HandleFunc(DockerPage, dockerHandlerNoAuth(containerManager))
 	}
+
+	if ContainersPage[len(ContainersPage)-1] == '/' {
+		redirectHandler := http.RedirectHandler(urlBasePrefix+ContainersPage, http.StatusMovedPermanently)
+		mux.Handle(ContainersPage[0:len(ContainersPage)-1], redirectHandler)
+	}
+	if DockerPage[len(DockerPage)-1] == '/' {
+		redirectHandler := http.RedirectHandler(urlBasePrefix+DockerPage, http.StatusMovedPermanently)
+		mux.Handle(DockerPage[0:len(DockerPage)-1], redirectHandler)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Some reverse proxies do not support overriding 'Location' header
in 3xx responses. This commit adds a --uri_base_prefix option
that adds a prefix to all URLs of cAdvisor so that
redirects go to the correct places.