### PR TITLE
Check whether Mesos task labels are available

### DIFF
--- a/container/mesos/mesos_agent.go
+++ b/container/mesos/mesos_agent.go
@@ -113,8 +113,10 @@ func (s *state) fetchLabelsFromTask(exID string, labels map[string]string) error
 		}
 	}
 
-	for _, l := range t.Labels.Labels {
-		labels[l.Key] = *l.Value
+	if t.Labels != nil {
+		for _, l := range t.Labels.Labels {
+			labels[l.Key] = *l.Value
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This patch fixes the panic issue when `mesos.Task` does not have a Labels reference:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xded5e4]

goroutine 1 [running]:
github.com/google/cadvisor/container/mesos.(*state).fetchLabelsFromTask(0xc000a0b378, 0xc000988270, 0x30, 0xc000980ae0, 0xc00087c1b8, 0x0)
        /home/lanchang/go/src/github.com/google/cadvisor/container/mesos/mesos_agent.go:116 +0xf4
github.com/google/cadvisor/container/mesos.(*state).FetchLabels(0xc000a0b378, 0xc000988240, 0x29, 0xc000988270, 0x30, 0x4, 0x4, 0xc000a0b388)
        /home/lanchang/go/src/github.com/google/cadvisor/container/mesos/mesos_agent.go:141 +0x3dd
github.com/google/cadvisor/container/mesos.(*client).getLabels(0xc00000e2b8, 0xc00097e4c0, 0x24, 0xc00097e4c0, 0x0)
        /home/lanchang/go/src/github.com/google/cadvisor/container/mesos/client.go:181 +0x175
github.com/google/cadvisor/container/mesos.(*client).ContainerInfo(0xc00000e2b8, 0xc0007c710d, 0x24, 0x24, 0x40c888, 0x10)
        /home/lanchang/go/src/github.com/google/cadvisor/container/mesos/client.go:89 +0x73
github.com/google/cadvisor/container/mesos.(*mesosFactory).CanHandleAndAccept(0xc000142780, 0xc0007c7100, 0x31, 0xc000a0b530, 0x2, 0x2)
        /home/lanchang/go/src/github.com/google/cadvisor/container/mesos/factory.go:110 +0x8a
github.com/google/cadvisor/container.NewContainerHandler(0xc0007c7100, 0x31, 0x0, 0x1e55101, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/lanchang/go/src/github.com/google/cadvisor/container/factory.go:107 +0x124
github.com/google/cadvisor/manager.(*manager).createContainerLocked(0xc0005101e0, 0xc0007c7100, 0x31, 0x0, 0x0, 0x0)
        /home/lanchang/go/src/github.com/google/cadvisor/manager/manager.go:965 +0xd6
github.com/google/cadvisor/manager.(*manager).createContainer(0xc0005101e0, 0xc0007c7100, 0x31, 0x0, 0x0, 0x0)
        /home/lanchang/go/src/github.com/google/cadvisor/manager/manager.go:952 +0x94
github.com/google/cadvisor/manager.(*manager).detectSubcontainers(0xc0005101e0, 0x11b9325, 0x1, 0x0, 0x0)
        /home/lanchang/go/src/github.com/google/cadvisor/manager/manager.go:1145 +0x199
github.com/google/cadvisor/manager.(*manager).Start(0xc0005101e0, 0xc0005bd170, 0x133f180)
        /home/lanchang/go/src/github.com/google/cadvisor/manager/manager.go:366 +0x50e
main.main()
        /home/lanchang/go/src/cadvisor/cadvisor.go:173 +0x4b6
```