### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: cadvisor
+version: '1.0'
+summary: Analyzes resource usage and performance characteristics of running containers
+description: |
+  Analyzes resource usage and performance characteristics of running containers.
+grade: stable
+confinement: classic
+parts:
+  cadvisor:
+    plugin: go
+    source: https://github.com/google/cadvisor.git
+    go-importpath: github.com/google/cadvisor
+    build-packages:
+      - build-essential
+apps:
+  cadvisor:
+    command: bin/cadvisor
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind


### PR DESCRIPTION
Hello folks,

I've created this PR to request support for building a snap package of cadvisor.

To give you a bit more context, snaps are cross-distro Linux software packages, supported on LTS and non-LTS Ubuntu from 14.04, as well as Debian, Manjaro, Fedora, OpenSUSE, Arch, and many others distributions. Making a snap of cadvisor will enable you to provide automatic updates on your schedule to your users via the snap store. The store is used by an audience of millions, so this could also give you extra exposure to your project.

If you accept this PR, you can use snapcraft locally, or perhaps a build/CI system such as travis or our free build system (build.snapcraft.io) to create snaps and upload to the Snap Store (snapcraft.io/store).

To test this PR locally, I used a stock Ubuntu 18.04 system, with the following steps:

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/cadvisor.git
cd cadvisor
git checkout add-snapcraft
snapcraft

This command will generate a <cadvisor-version>.snap file, something like cadvisor_1.0_amd64.snap.

This snap can be installed and tested locally with:

snap install cadvisor_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the app (snap) hasn’t gone through the snap store review process and is not signed.

Once installed, the cadvisor command can be executed, e.g.: snap run cadvisor

If landed, you will need to complete a couple more steps:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the cadvisor name in the store. 

snapcraft login
snapcraft register

- Upload a built snap to the store. The store supports multiple risk levels as “channels” with the 'edge' channel typically used to host the latest build from git master. Stable is where stable releases are pushed. Optionally, beta and candidate channels can also be used.

snapcraft push cadvisor_1.0_amd64.snap --release edge

- Test installing on a clean machine.

snap install cadvisor --edge

Once (and if) you are happy, you can push a stable release to the stable channel, update the store page, and promote the application online. We can help there, and we'd be glad to feature your application in our store. We can also help with any questions or issues you may have.

Thanks!