### PR TITLE
Provide free inodes and disk space with container filesystem stats

### DIFF
--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -257,6 +257,8 @@ func (self *crioContainerHandler) getFsStats(stats *info.ContainerStats) error {
 	fsStat.BaseUsage = usage.BaseUsageBytes
 	fsStat.Usage = usage.TotalUsageBytes
 	fsStat.Inodes = usage.InodeUsage
+	fsStat.Available = usage.FreeBytes
+	fsStat.InodesFree = usage.InodesFree
 
 	stats.Filesystem = append(stats.Filesystem, fsStat)
 

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -410,6 +410,8 @@ func (self *dockerContainerHandler) getFsStats(stats *info.ContainerStats) error
 	fsStat.BaseUsage = usage.BaseUsageBytes
 	fsStat.Usage = usage.TotalUsageBytes
 	fsStat.Inodes = usage.InodeUsage
+	fsStat.Available = usage.FreeBytes
+	fsStat.InodesFree = usage.InodesFree
 
 	stats.Filesystem = append(stats.Filesystem, fsStat)
 

--- a/container/rkt/handler.go
+++ b/container/rkt/handler.go
@@ -215,6 +215,8 @@ func (handler *rktContainerHandler) getFsStats(stats *info.ContainerStats) error
 	fsStat.BaseUsage = usage.BaseUsageBytes
 	fsStat.Usage = usage.TotalUsageBytes
 	fsStat.Inodes = usage.InodeUsage
+	fsStat.Available = usage.FreeBytes
+	fsStat.InodesFree = usage.InodesFree
 
 	stats.Filesystem = append(stats.Filesystem, fsStat)
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -648,6 +648,12 @@ func getVfsStats(path string) (total uint64, free uint64, avail uint64, inodes u
 	return total, free, avail, inodes, inodesFree, nil
 }
 
+func (self *RealFsInfo) GetVfsStats(dir string) (total uint64, free uint64, avail uint64, inodes uint64, inodesFree uint64, err error) {
+	claimToken()
+	defer releaseToken()
+	return getVfsStats(dir)
+}
+
 // Devicemapper thin provisioning is detailed at
 // https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
 func dockerDMDevice(driverStatus map[string]string, dmsetup devicemapper.DmsetupClient) (string, uint, uint, uint, error) {

--- a/fs/types.go
+++ b/fs/types.go
@@ -79,6 +79,11 @@ type FsInfo interface {
 	// GetDirUsage returns a usage information for 'dir'.
 	GetDirUsage(dir string) (UsageInfo, error)
 
+	// Returns the total number of bytes, number of free bytes, number of available
+	// bytes, number of inodes in use, and nmber of inodes free in the
+	// filesystem containing 'dir'.
+	GetVfsStats(dir string) (uint64, uint64, uint64, uint64, uint64, error)
+
 	// GetDeviceInfoByFsUUID returns the information of the device with the
 	// specified filesystem uuid. If no such device exists, this function will
 	// return the ErrNoSuchDevice error.


### PR DESCRIPTION
cadvisor currently does not provide free bytes and inodes for container volumes; this information is useful for e. g. eviction decisions based on inode pressure in Kubernetes/OpenShift.