### PR TITLE
fix timestamp error for container_last_seen

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -139,7 +139,10 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Last time a container was seen by the exporter",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
-					return metricValues{{value: float64(time.Now().Unix())}}
+					return metricValues{{
+						value:     float64(time.Now().Unix()),
+						timestamp: time.Now(),
+					}}
 				},
 			},
 		},

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -111,7 +111,7 @@ container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label
 container_fs_writes_total{container_env_foo_env="prod",container_label_foo_label="bar",device="sda2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 43 1395066363000
 # HELP container_last_seen Last time a container was seen by the exporter
 # TYPE container_last_seen gauge
-container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.426203694e+09 1395066363000
+container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.395066363e+09 1395066363000
 # HELP container_memory_cache Number of bytes of page cache memory.
 # TYPE container_memory_cache gauge
 container_memory_cache{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 14 1395066363000


### PR DESCRIPTION
Since PR  https://github.com/google/cadvisor/pull/2124, prometheus can not scrape cAdvisor /metrics now.

Issue https://github.com/google/cadvisor/issues/2133 report the bug. 

I don't know this PR is an appropriate way to fix that bug. 