### PR TITLE
Only add non-empty labels to metrics

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1153,8 +1153,10 @@ func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric)
 		labels := make([]string, 0, len(rawLabels))
 		containerLabels := c.containerLabelsFunc(cont)
 		for l := range rawLabels {
-			labels = append(labels, sanitizeLabelName(l))
-			values = append(values, containerLabels[l])
+			if v, ok := containerLabels[l]; ok && len(v) > 0 {
+				labels = append(labels, sanitizeLabelName(l))
+				values = append(values, v)
+			}
 		}
 
 		// Container spec


### PR DESCRIPTION
Instead of adding all labels to all exposed metrics, only add labels to a metric if the label also has a value. This reduces the memory footprint used by cadvisor at no additional downside, as empty label is the same as not providing the label in the first place.
This reduces the data exposed on the `/metrics` endpoint by several megabytes (depending on the amount of pods) because it doesn't include a lot of labels with empty value for each metric. 

This change is done in an effort to run cadvisor in production Kubernetes clusters without incurring too much of an overhead in terms of resources used for cluster monitoring.

The effect of this can be seen in the following graphs showing CPU and Memory usage for cadvisor pods running in one of our clusters. The impact is not incredible big, but visible:

![image](https://user-images.githubusercontent.com/128566/50644556-75960d80-0f71-11e9-957c-0f253bdd1067.png)

(switch to run with this patch was done around 15:48 on the graph).