### PR TITLE
Respect --docker-only flag

### DIFF
--- a/container/raw/factory.go
+++ b/container/raw/factory.go
@@ -65,15 +65,19 @@ func (self *rawFactory) NewContainerHandler(name string, inHostNamespace bool) (
 
 // The raw factory can handle any container. If --docker_only is set to false, non-docker containers are ignored.
 func (self *rawFactory) CanHandleAndAccept(name string) (bool, bool, error) {
-	accept := name == "/" || !*dockerOnly
+	if name == "/" {
+		return true, true, nil
+	}
+	if *dockerOnly {
+		return true, false, nil
+	}
 
 	for _, prefix := range self.rawPrefixWhiteList {
 		if strings.HasPrefix(name, prefix) {
-			accept = true
-			break
+			return true, true, nil
 		}
 	}
-	return true, accept, nil
+	return true, false, nil
 }
 
 func (self *rawFactory) DebugInfo() map[string][]string {


### PR DESCRIPTION
When the rawPrefixWhitelist was added, it was incorrectly able to override the docker_only flag.  This fixes it by clearly indicating the order of priority of what determines if a raw cgroup is monitored.  The order is:

Always collect the "/" cgroup
Never collect if --docker_only is specified.
Collect if the cgroup is within one of the whitelisted cgroup prefixes
Dont collect otherwise

cc @viberan

This should be cherry-picked back 1 release