### PR TITLE
Change log level to warning instead of error when cgroups file read f…

### DIFF
--- a/container/common/helpers.go
+++ b/container/common/helpers.go
@@ -134,7 +134,7 @@ func readString(dirpath string, file string) string {
 	if err != nil {
 		// Ignore non-existent files
 		if !os.IsNotExist(err) {
-			klog.Errorf("readString: Failed to read %q: %s", cgroupFile, err)
+			klog.Warningf("readString: Failed to read %q: %s", cgroupFile, err)
 		}
 		return ""
 	}


### PR DESCRIPTION
…ailed.

Because cgroups file may not exist at the timing of the read, it's better not to use error level.