### PR TITLE
fs: get inodes and disk usage via pure go

### DIFF
--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -51,7 +51,6 @@ type realFsHandler struct {
 }
 
 const (
-	timeout          = 2 * time.Minute
 	maxBackoffFactor = 20
 )
 
@@ -74,17 +73,16 @@ func NewFsHandler(period time.Duration, rootfs, extraDir string, fsInfo fs.FsInf
 
 func (fh *realFsHandler) update() error {
 	var (
-		baseUsage, extraDirUsage, inodeUsage    uint64
-		rootDiskErr, rootInodeErr, extraDiskErr error
+		rootUsage, extraUsage fs.UsageInfo
+		rootErr, extraErr     error
 	)
 	// TODO(vishh): Add support for external mounts.
 	if fh.rootfs != "" {
-		baseUsage, rootDiskErr = fh.fsInfo.GetDirDiskUsage(fh.rootfs, timeout)
-		inodeUsage, rootInodeErr = fh.fsInfo.GetDirInodeUsage(fh.rootfs, timeout)
+		rootUsage, rootErr = fh.fsInfo.GetDirUsage(fh.rootfs)
 	}
 
 	if fh.extraDir != "" {
-		extraDirUsage, extraDiskErr = fh.fsInfo.GetDirDiskUsage(fh.extraDir, timeout)
+		extraUsage, extraErr = fh.fsInfo.GetDirUsage(fh.extraDir)
 	}
 
 	// Wait to handle errors until after all operartions are run.
@@ -92,18 +90,17 @@ func (fh *realFsHandler) update() error {
 	fh.Lock()
 	defer fh.Unlock()
 	fh.lastUpdate = time.Now()
-	if rootInodeErr == nil && fh.rootfs != "" {
-		fh.usage.InodeUsage = inodeUsage
+	if fh.rootfs != "" && rootErr == nil {
+		fh.usage.InodeUsage = rootUsage.Inodes
+		fh.usage.TotalUsageBytes = rootUsage.Bytes + extraUsage.Bytes
 	}
-	if rootDiskErr == nil && fh.rootfs != "" {
-		fh.usage.TotalUsageBytes = baseUsage + extraDirUsage
+	if fh.extraDir != "" && extraErr == nil {
+		fh.usage.BaseUsageBytes = rootUsage.Bytes
 	}
-	if extraDiskErr == nil && fh.extraDir != "" {
-		fh.usage.BaseUsageBytes = baseUsage
-	}
+
 	// Combine errors into a single error to return
-	if rootDiskErr != nil || rootInodeErr != nil || extraDiskErr != nil {
-		return fmt.Errorf("rootDiskErr: %v, rootInodeErr: %v, extraDiskErr: %v", rootDiskErr, rootInodeErr, extraDiskErr)
+	if rootErr != nil || extraErr != nil {
+		return fmt.Errorf("rootDiskErr: %v, extraDiskErr: %v", rootErr, extraErr)
 	}
 	return nil
 }
@@ -132,7 +129,7 @@ func (fh *realFsHandler) trackUsage() {
 				// if the long duration is persistent either because of slow
 				// disk or lots of containers.
 				longOp = longOp + time.Second
-				klog.V(2).Infof("du and find on following dirs took %v: %v; will not log again for this container unless duration exceeds %v", duration, []string{fh.rootfs, fh.extraDir}, longOp)
+				klog.V(2).Infof("fs: disk usage and inodes count on following dirs took %v: %v; will not log again for this container unless duration exceeds %v", duration, []string{fh.rootfs, fh.extraDir}, longOp)
 			}
 		}
 	}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/pkg/mount"
 	"github.com/stretchr/testify/assert"
@@ -101,9 +100,9 @@ func TestDirDiskUsage(t *testing.T) {
 	fi, err := f.Stat()
 	as.NoError(err)
 	expectedSize := uint64(fi.Size())
-	size, err := fsInfo.GetDirDiskUsage(dir, time.Minute)
+	usage, err := fsInfo.GetDirUsage(dir)
 	as.NoError(err)
-	as.True(expectedSize <= size, "expected dir size to be at-least %d; got size: %d", expectedSize, size)
+	as.True(expectedSize <= usage.Bytes, "expected dir size to be at-least %d; got size: %d", expectedSize, usage.Bytes)
 }
 
 func TestDirInodeUsage(t *testing.T) {
@@ -118,10 +117,10 @@ func TestDirInodeUsage(t *testing.T) {
 		_, err := ioutil.TempFile(dir, "")
 		require.NoError(t, err)
 	}
-	inodes, err := fsInfo.GetDirInodeUsage(dir, time.Minute)
+	usage, err := fsInfo.GetDirUsage(dir)
 	as.NoError(err)
 	// We sould get numFiles+1 inodes, since we get 1 inode for each file, plus 1 for the directory
-	as.True(uint64(numFiles+1) == inodes, "expected inodes in dir to be %d; got inodes: %d", numFiles+1, inodes)
+	as.True(uint64(numFiles+1) == usage.Inodes, "expected inodes in dir to be %d; got inodes: %d", numFiles+1, usage.Inodes)
 }
 
 var dmStatusTests = []struct {

--- a/fs/types.go
+++ b/fs/types.go
@@ -16,7 +16,6 @@ package fs
 
 import (
 	"errors"
-	"time"
 )
 
 type DeviceInfo struct {
@@ -62,6 +61,11 @@ type DiskStats struct {
 	WeightedIoTime  uint64
 }
 
+type UsageInfo struct {
+	Bytes  uint64
+	Inodes uint64
+}
+
 // ErrNoSuchDevice is the error indicating the requested device does not exist.
 var ErrNoSuchDevice = errors.New("cadvisor: no such device")
 
@@ -72,11 +76,8 @@ type FsInfo interface {
 	// Returns capacity and free space, in bytes, of the set of mounts passed.
 	GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error)
 
-	// Returns number of bytes occupied by 'dir'.
-	GetDirDiskUsage(dir string, timeout time.Duration) (uint64, error)
-
-	// Returns number of inodes used by 'dir'.
-	GetDirInodeUsage(dir string, timeout time.Duration) (uint64, error)
+	// GetDirUsage returns a usage information for 'dir'.
+	GetDirUsage(dir string) (UsageInfo, error)
 
 	// GetDeviceInfoByFsUUID returns the information of the device with the
 	// specified filesystem uuid. If no such device exists, this function will


### PR DESCRIPTION
Hello there,
I would like to return to the PR have been making almost two years ago. (this one https://github.com/google/cadvisor/pull/1576). @euank proposed to get rid of `find` command. I took as a basis his PR and also got rid of `du` command. Now we collect both disk space and inode stats at the same time.

Why it matters for us: both `du` and `find` overwhelme our audit log.

Also, I have benchmarked `du` command and pure go implementation and got the following results:
```
Benchmark_duDiskUsage-8             1000           1597743 ns/op           22551 B/op        165 allocs/op
Benchmark_osStatDiskUsage-8        20000             56153 ns/op           53624 B/op         88 allocs/op
```
As we can see, pure go implementation is ~20x faster.