### PR TITLE
Fix stats in LXD with ZFS storage pool

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -404,20 +404,19 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
 				err error
 				fs  Fs
 			)
-			var fsType = partition.fsType
-			if fsType == ZFS.String() {
-				if _, devZfs := os.Stat("/dev/zfs"); os.IsNotExist(devZfs) {
-					fsType = "ZFS_no_dev"
-				}
-			}
-			switch fsType {
+			switch partition.fsType {
 			case DeviceMapper.String():
 				fs.Capacity, fs.Free, fs.Available, err = getDMStats(device, partition.blockSize)
 				klog.V(5).Infof("got devicemapper fs capacity stats: capacity: %v free: %v available: %v:", fs.Capacity, fs.Free, fs.Available)
 				fs.Type = DeviceMapper
 			case ZFS.String():
-				fs.Capacity, fs.Free, fs.Available, err = getZfstats(device)
-				fs.Type = ZFS
+				if _, devzfs := os.Stat("/dev/zfs"); os.IsExist(devzfs) {
+					fs.Capacity, fs.Free, fs.Available, err = getZfstats(device)
+					fs.Type = ZFS
+					break
+				}
+				// if /dev/zfs is not present default to VFS
+				fallthrough
 			default:
 				var inodes, inodesFree uint64
 				if utils.FileExists(partition.mountpoint) {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -404,7 +404,13 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
 				err error
 				fs  Fs
 			)
-			switch partition.fsType {
+			var fsType = partition.fsType
+			if fsType == ZFS.String() {
+				if _, devZfs := os.Stat("/dev/zfs"); os.IsNotExist(devZfs) {
+					fsType = "ZFS_no_dev"
+				}
+			}
+			switch fsType {
 			case DeviceMapper.String():
 				fs.Capacity, fs.Free, fs.Available, err = getDMStats(device, partition.blockSize)
 				klog.V(5).Infof("got devicemapper fs capacity stats: capacity: %v free: %v available: %v:", fs.Capacity, fs.Free, fs.Available)


### PR DESCRIPTION
When LXD containers are backed up by a ZFS storage pool they do not have the `/dev/zfs` device. Trying to get the file system stats from that device will fail (va the zfs utility).

With this PR, in the above setup (ZFS inside and LXD container), we default to getting the file system stats from VFS.

Here is the error you get when `/dev/zfs` is not present:
```
Feb 19 09:38:54 definite-cricket microk8s.daemon-kubelet[3118]: I0219 09:38:54.595436    3118 fs.go:425] Stat fs failed. Error: exit status 1: "/snap/microk8s/383/sbin/zfs zfs get -Hp all zfsdefault/containers/definite-cricket" => /dev/zfs and /proc/self/mounts are required.
```