### PR TITLE
Always collect disk stats for rootfs.

### DIFF
--- a/container/common/container_hints_test.go
+++ b/container/common/container_hints_test.go
@@ -27,7 +27,7 @@ func TestGetContainerHintsFromFile(t *testing.T) {
 
 	if cHints.AllHosts[0].NetworkInterface.VethHost != "veth24031eth1" &&
 		cHints.AllHosts[0].NetworkInterface.VethChild != "eth1" {
-		t.Errorf("Cannot find network interface in %s", cHints)
+		t.Errorf("Cannot find network interface in %+v", cHints)
 	}
 
 	correctMountDirs := [...]string{
@@ -44,7 +44,7 @@ func TestGetContainerHintsFromFile(t *testing.T) {
 
 	for i, mountDir := range cHints.AllHosts[0].Mounts {
 		if correctMountDirs[i] != mountDir.HostDir {
-			t.Errorf("Cannot find mount %s in %s", mountDir.HostDir, cHints)
+			t.Errorf("Cannot find mount %s in %+v", mountDir.HostDir, cHints)
 		}
 	}
 }

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -188,16 +188,15 @@ func fsToFsStats(fs *fs.Fs) info.FsStats {
 
 func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 	var filesystems []fs.Fs
-
-	if self.includedMetrics.Has(container.DiskUsageMetrics) || self.includedMetrics.Has(container.DiskIOMetrics) {
-		var err error
-		// Get Filesystem information only for the root cgroup.
-		if isRootCgroup(self.name) {
-			filesystems, err = self.fsInfo.GetGlobalFsInfo()
-			if err != nil {
-				return err
-			}
-		} else if len(self.externalMounts) > 0 {
+	var err error
+	// Get Filesystem information only for the root cgroup.
+	if isRootCgroup(self.name) {
+		filesystems, err = self.fsInfo.GetGlobalFsInfo()
+		if err != nil {
+			return err
+		}
+	} else if self.includedMetrics.Has(container.DiskUsageMetrics) || self.includedMetrics.Has(container.DiskIOMetrics) {
+		if len(self.externalMounts) > 0 {
 			var mountSet map[string]struct{}
 			mountSet = make(map[string]struct{})
 			for _, mount := range self.externalMounts {
@@ -210,14 +209,14 @@ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 		}
 	}
 
-	if self.includedMetrics.Has(container.DiskUsageMetrics) {
+	if isRootCgroup(self.name) || self.includedMetrics.Has(container.DiskUsageMetrics) {
 		for i := range filesystems {
 			fs := filesystems[i]
 			stats.Filesystem = append(stats.Filesystem, fsToFsStats(&fs))
 		}
 	}
 
-	if self.includedMetrics.Has(container.DiskIOMetrics) {
+	if isRootCgroup(self.name) || self.includedMetrics.Has(container.DiskIOMetrics) {
 		common.AssignDeviceNamesToDiskStats(&fsNamer{fs: filesystems, factory: self.machineInfoFactory}, &stats.DiskIo)
 
 	}


### PR DESCRIPTION
Always collect disk stats for root.

Kubelet needs it for all runtimes.

@dashpole Can you help me double check whether this is sufficient for CRI runtimes?

Based on my understanding and testing, this seems sufficient.

Signed-off-by: Lantao Liu <lantaol@google.com>