### PR TITLE
Added flag to manually set machine info refresh rate

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -67,6 +67,8 @@ var urlBasePrefix = flag.String("url_base_prefix", "", "prefix path that will be
 
 var rawCgroupPrefixWhiteList = flag.String("raw_cgroup_prefix_whitelist", "", "A comma-separated list of cgroup path prefix that needs to be collected even when -docker_only is specified")
 
+var machineInfoRefreshRate = flag.Int("text", 1000, "explanation")
+
 var (
 	// Metrics to be ignored.
 	// Tcp metrics are ignored by default.
@@ -147,7 +149,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList,","))
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList,","), machineInfoRefreshRate)
 	if err != nil {
 		klog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/cadvisor.go
+++ b/cadvisor.go
@@ -67,7 +67,7 @@ var urlBasePrefix = flag.String("url_base_prefix", "", "prefix path that will be
 
 var rawCgroupPrefixWhiteList = flag.String("raw_cgroup_prefix_whitelist", "", "A comma-separated list of cgroup path prefix that needs to be collected even when -docker_only is specified")
 
-var machineInfoRefreshRate = flag.Int("text", 1000, "explanation")
+var machineInfoRefreshRate = flag.Int("machine_info_refresh_rate", 1000, "The refresh rate of the machine information displayed on the webpage in milliseconds.")
 
 var (
 	// Metrics to be ignored.

--- a/cadvisor.go
+++ b/cadvisor.go
@@ -149,7 +149,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList,","), machineInfoRefreshRate)
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList,","), *machineInfoRefreshRate)
 	if err != nil {
 		klog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -143,7 +143,7 @@ type Manager interface {
 }
 
 // New takes a memory storage and returns a new manager.
-func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, includedMetricsSet container.MetricSet, collectorHttpClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string) (Manager, error) {
+func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, includedMetricsSet container.MetricSet, collectorHttpClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string, maschineInfoRefreshRate int) (Manager, error) {
 	if memoryCache == nil {
 		return nil, fmt.Errorf("manager requires memory storage")
 	}
@@ -221,6 +221,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 		collectorHttpClient:                   collectorHttpClient,
 		nvidiaManager:                         &accelerators.NvidiaManager{},
 		rawContainerCgroupPathPrefixWhiteList: rawContainerCgroupPathPrefixWhiteList,
+		maschineInfoRefreshRate:			   maschineInfoRefreshRate,
 	}
 
 	machineInfo, err := machine.Info(sysfs, fsInfo, inHostNamespace)
@@ -296,6 +297,7 @@ type manager struct {
 	nvidiaManager            accelerators.AcceleratorManager
 	// List of raw container cgroup path prefix whitelist.
 	rawContainerCgroupPathPrefixWhiteList []string
+	maschineInfoRefreshRate	 int
 }
 
 // Start the container manager.
@@ -1456,4 +1458,8 @@ func (f partialFailure) OrNil() error {
 		return nil
 	}
 	return f
+}
+
+func (m *manager) GetMaschineInfoRefreshRate() int {
+	return m.maschineInfoRefreshRate
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -140,10 +140,12 @@ type Manager interface {
 
 	// Returns debugging information. Map of lines per category.
 	DebugInfo() map[string][]string
+
+	GetMachineInfoRefreshRate() int
 }
 
 // New takes a memory storage and returns a new manager.
-func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, includedMetricsSet container.MetricSet, collectorHttpClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string, maschineInfoRefreshRate int) (Manager, error) {
+func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool, includedMetricsSet container.MetricSet, collectorHttpClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string, machineInfoRefreshRate int) (Manager, error) {
 	if memoryCache == nil {
 		return nil, fmt.Errorf("manager requires memory storage")
 	}
@@ -221,7 +223,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 		collectorHttpClient:                   collectorHttpClient,
 		nvidiaManager:                         &accelerators.NvidiaManager{},
 		rawContainerCgroupPathPrefixWhiteList: rawContainerCgroupPathPrefixWhiteList,
-		maschineInfoRefreshRate:			   maschineInfoRefreshRate,
+		machineInfoRefreshRate:			   	   machineInfoRefreshRate,
 	}
 
 	machineInfo, err := machine.Info(sysfs, fsInfo, inHostNamespace)
@@ -297,7 +299,7 @@ type manager struct {
 	nvidiaManager            accelerators.AcceleratorManager
 	// List of raw container cgroup path prefix whitelist.
 	rawContainerCgroupPathPrefixWhiteList []string
-	maschineInfoRefreshRate	 int
+	machineInfoRefreshRate	 int
 }
 
 // Start the container manager.
@@ -1460,6 +1462,6 @@ func (f partialFailure) OrNil() error {
 	return f
 }
 
-func (m *manager) GetMaschineInfoRefreshRate() int {
-	return m.maschineInfoRefreshRate
+func (m *manager) GetMachineInfoRefreshRate() int {
+	return m.machineInfoRefreshRate
 }

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -367,7 +367,7 @@ func TestDockerContainersInfo(t *testing.T) {
 }
 
 func TestNewNilManager(t *testing.T) {
-	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient, []string{"/"})
+	_, err := New(nil, nil, 60*time.Second, true, container.MetricSet{}, http.DefaultClient, []string{"/"}, 1000)
 	if err == nil {
 		t.Fatalf("Expected nil manager to return error")
 	}

--- a/pages/assets/html/containers.html
+++ b/pages/assets/html/containers.html
@@ -263,7 +263,7 @@
       {{end}}
     </div>
     <script type="text/javascript">
-      startPage({{.ContainerName}}, {{.CpuAvailable}}, {{.MemoryAvailable}}, {{.Root}}, {{.IsRoot}});
+      startPage({{.ContainerName}}, {{.CpuAvailable}}, {{.MemoryAvailable}}, {{.Root}}, {{.IsRoot}}, {{.MaschineInfoRefreshRate}});
       drawImages({{.DockerImages}});
     </script>
   </body>

--- a/pages/assets/html/containers.html
+++ b/pages/assets/html/containers.html
@@ -263,7 +263,7 @@
       {{end}}
     </div>
     <script type="text/javascript">
-      startPage({{.ContainerName}}, {{.CpuAvailable}}, {{.MemoryAvailable}}, {{.Root}}, {{.IsRoot}}, {{.MaschineInfoRefreshRate}});
+      startPage({{.ContainerName}}, {{.CpuAvailable}}, {{.MemoryAvailable}}, {{.Root}}, {{.IsRoot}}, {{.MachineInfoRefreshRate}});
       drawImages({{.DockerImages}});
     </script>
   </body>

--- a/pages/assets/js/containers.js
+++ b/pages/assets/js/containers.js
@@ -1069,7 +1069,7 @@ function drawCustomMetrics(elementId, containerInfo, metricsInfo) {
 }
 
 // Executed when the page finishes loading.
-function startPage(containerName, hasCpu, hasMemory, rootDir, isRoot, maschineInfoRefreshRate) {
+function startPage(containerName, hasCpu, hasMemory, rootDir, isRoot, machineInfoRefreshRate) {
   // Don't fetch data if we don't have any resource.
   if (!hasCpu && !hasMemory) {
     return;
@@ -1098,6 +1098,6 @@ function startPage(containerName, hasCpu, hasMemory, rootDir, isRoot, maschineIn
   // Get machine info, then get the stats every 1s.
   getMachineInfo(rootDir, function(machineInfo) {
     window.cadvisor.machineInfo = machineInfo;
-    setInterval(function() { refreshStats(); }, maschineInfoRefreshRate);
+    setInterval(function() { refreshStats(); }, machineInfoRefreshRate);
   });
 }

--- a/pages/assets/js/containers.js
+++ b/pages/assets/js/containers.js
@@ -1069,7 +1069,7 @@ function drawCustomMetrics(elementId, containerInfo, metricsInfo) {
 }
 
 // Executed when the page finishes loading.
-function startPage(containerName, hasCpu, hasMemory, rootDir, isRoot) {
+function startPage(containerName, hasCpu, hasMemory, rootDir, isRoot, maschineInfoRefreshRate) {
   // Don't fetch data if we don't have any resource.
   if (!hasCpu && !hasMemory) {
     return;
@@ -1098,6 +1098,6 @@ function startPage(containerName, hasCpu, hasMemory, rootDir, isRoot) {
   // Get machine info, then get the stats every 1s.
   getMachineInfo(rootDir, function(machineInfo) {
     window.cadvisor.machineInfo = machineInfo;
-    setInterval(function() { refreshStats(); }, 1000);
+    setInterval(function() { refreshStats(); }, maschineInfoRefreshRate);
   });
 }

--- a/pages/containers.go
+++ b/pages/containers.go
@@ -236,6 +236,8 @@ func serveContainersPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 		CustomMetricsAvailable: cont.Spec.HasCustomMetrics,
 		SubcontainersAvailable: len(subcontainerLinks) > 0,
 		Root:                   rootDir,
+		MaschineInfoRefreshRate: m.GetMaschineInfoRefreshRate(),
+
 	}
 	err = pageTemplate.Execute(w, data)
 	if err != nil {

--- a/pages/containers.go
+++ b/pages/containers.go
@@ -236,7 +236,7 @@ func serveContainersPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 		CustomMetricsAvailable: cont.Spec.HasCustomMetrics,
 		SubcontainersAvailable: len(subcontainerLinks) > 0,
 		Root:                   rootDir,
-		MaschineInfoRefreshRate: m.GetMaschineInfoRefreshRate(),
+		MachineInfoRefreshRate: m.GetMachineInfoRefreshRate(),
 
 	}
 	err = pageTemplate.Execute(w, data)

--- a/pages/docker.go
+++ b/pages/docker.go
@@ -135,6 +135,8 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 			http.Error(w, fmt.Sprintf("failed to get machine info: %v", err), http.StatusInternalServerError)
 			return
 		}
+		machineInfoRefreshRate = m.GetMachineInfoRefreshRate()
+
 		data = &pageData{
 			DisplayName:            displayName,
 			ContainerName:          escapeContainerName(cont.Name),
@@ -149,6 +151,8 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 			FsAvailable:            cont.Spec.HasFilesystem,
 			CustomMetricsAvailable: cont.Spec.HasCustomMetrics,
 			Root:                   rootDir,
+			MachineInfoRefreshRate: machineInfoRefreshRate,
+
 		}
 	}
 

--- a/pages/docker.go
+++ b/pages/docker.go
@@ -135,7 +135,6 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 			http.Error(w, fmt.Sprintf("failed to get machine info: %v", err), http.StatusInternalServerError)
 			return
 		}
-		machineInfoRefreshRate = m.GetMachineInfoRefreshRate()
 
 		data = &pageData{
 			DisplayName:            displayName,
@@ -151,8 +150,7 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 			FsAvailable:            cont.Spec.HasFilesystem,
 			CustomMetricsAvailable: cont.Spec.HasCustomMetrics,
 			Root:                   rootDir,
-			MachineInfoRefreshRate: machineInfoRefreshRate,
-
+			MachineInfoRefreshRate: m.GetMachineInfoRefreshRate(),
 		}
 	}
 

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -64,7 +64,7 @@ type pageData struct {
 	DockerStatus           []keyVal
 	DockerDriverStatus     []keyVal
 	DockerImages           []info.DockerImage
-	MaschineInfoRefreshRate int
+	MachineInfoRefreshRate int
 }
 
 func init() {

--- a/pages/pages.go
+++ b/pages/pages.go
@@ -64,6 +64,7 @@ type pageData struct {
 	DockerStatus           []keyVal
 	DockerDriverStatus     []keyVal
 	DockerImages           []info.DockerImage
+	MaschineInfoRefreshRate int
 }
 
 func init() {


### PR DESCRIPTION
Solves #2141. 

Hi,
I found ticket #2141 and wanted to create a more generic solution than provided in #2172. 

Currently the machine info displayed on the web page gets updated every 1000ms. I implemented a new flag which replaces the old hard coded value. The flag has the default value 1000 in order to not change the default behavior. However the flag can be used to set a customized refresh rate (in ms). The flag is named machine_info_refresh_rate. 

On my system it passes all test. 