### PR TITLE
container: crio: Return more informative error

### DIFF
--- a/container/crio/client.go
+++ b/container/crio/client.go
@@ -122,6 +122,13 @@ func (c *crioClientImpl) ContainerInfo(id string) (*ContainerInfo, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	// golang's http.Do doesn't return an error if non 200 response code is returned
+	// handle this case here, rather than failing to decode the body
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error finding container %s: Status %d returned error %s", id, resp.StatusCode, resp.Body)
+	}
+
 	cInfo := ContainerInfo{}
 	if err := json.NewDecoder(resp.Body).Decode(&cInfo); err != nil {
 		return nil, err


### PR DESCRIPTION
Before, making a ContainerInfo request returned an uninformative message about failing to decode json.
Fix this by catching response codes that aren't 200, and return a more informative message.

Signed-off-by: Peter Hunt <pehunt@redhat.com>