### PR TITLE
Make the containerd factory configurable

### DIFF
--- a/container/containerd/factory.go
+++ b/container/containerd/factory.go
@@ -31,7 +31,8 @@ import (
 	"github.com/google/cadvisor/manager/watcher"
 )
 
-var ArgContainerdEndpoint = flag.String("containerd", "unix:///var/run/containerd.sock", "containerd endpoint")
+var ArgContainerdEndpoint = flag.String("containerd", "/run/containerd/containerd.sock", "containerd endpoint")
+var ArgContainerdNamespace = flag.String("containerd-namespace", "k8s.io", "containerd namespace")
 
 // The namespace under which containerd aliases are unique.
 const k8sContainerdNamespace = "containerd"
@@ -56,7 +57,7 @@ func (self *containerdFactory) String() string {
 }
 
 func (self *containerdFactory) NewContainerHandler(name string, inHostNamespace bool) (handler container.ContainerHandler, err error) {
-	client, err := Client()
+	client, err := Client(*ArgContainerdEndpoint, *ArgContainerdNamespace)
 	if err != nil {
 		return
 	}
@@ -118,7 +119,7 @@ func (self *containerdFactory) DebugInfo() map[string][]string {
 
 // Register root container before running this function!
 func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet) error {
-	client, err := Client()
+	client, err := Client(*ArgContainerdEndpoint, *ArgContainerdNamespace)
 	if err != nil {
 		return fmt.Errorf("unable to create containerd client: %v", err)
 	}


### PR DESCRIPTION
1. Change the default value of command line flag `--containerd` to '/run/containerd/containerd.sock'.
2. Add a command line flag `--containerd-namespace` defaulting to 'k8s.io'.
3. Create containerd client with values from `--containerd` and `--containerd-namespace`.