### PR TITLE
Remove CloudProvider SDK dependencies

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -29,12 +30,14 @@ import (
 	"github.com/google/cadvisor/container"
 	cadvisorhttp "github.com/google/cadvisor/http"
 	"github.com/google/cadvisor/manager"
+	"github.com/google/cadvisor/metrics"
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/google/cadvisor/version"
 
-	"crypto/tls"
-
-	"github.com/google/cadvisor/metrics"
+	// Register CloudProviders
+	_ "github.com/google/cadvisor/utils/cloudinfo/aws"
+	_ "github.com/google/cadvisor/utils/cloudinfo/azure"
+	_ "github.com/google/cadvisor/utils/cloudinfo/gce"
 
 	"k8s.io/klog"
 )
@@ -147,7 +150,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList,","))
+	containerManager, err := manager.New(memoryStorage, sysFs, *maxHousekeepingInterval, *allowDynamicHousekeeping, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList, ","))
 	if err != nil {
 		klog.Fatalf("Failed to create a Container Manager: %s", err)
 	}

--- a/utils/cloudinfo/azure/azure.go
+++ b/utils/cloudinfo/azure/azure.go
@@ -15,32 +15,42 @@
 package cloudinfo
 
 import (
-	info "github.com/google/cadvisor/info/v1"
 	"io/ioutil"
 	"strings"
+
+	info "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/utils/cloudinfo"
 )
 
 const (
-	SysVendorFileName    = "/sys/class/dmi/id/sys_vendor"
-	BiosUUIDFileName     = "/sys/class/dmi/id/product_uuid"
-	MicrosoftCorporation = "Microsoft Corporation"
+	sysVendorFileName    = "/sys/class/dmi/id/sys_vendor"
+	biosUUIDFileName     = "/sys/class/dmi/id/product_uuid"
+	microsoftCorporation = "Microsoft Corporation"
 )
 
-func onAzure() bool {
-	data, err := ioutil.ReadFile(SysVendorFileName)
+func init() {
+	cloudinfo.RegisterCloudProvider(info.Azure, &provider{})
+}
+
+type provider struct{}
+
+var _ cloudinfo.CloudProvider = provider{}
+
+func (provider) IsActiveProvider() bool {
+	data, err := ioutil.ReadFile(sysVendorFileName)
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(data), MicrosoftCorporation)
+	return strings.Contains(string(data), microsoftCorporation)
 }
 
 // TODO: Implement method.
-func getAzureInstanceType() info.InstanceType {
+func (provider) GetInstanceType() info.InstanceType {
 	return info.UnknownInstance
 }
 
-func getAzureInstanceID() info.InstanceID {
-	data, err := ioutil.ReadFile(BiosUUIDFileName)
+func (provider) GetInstanceID() info.InstanceID {
+	data, err := ioutil.ReadFile(biosUUIDFileName)
 	if err != nil {
 		return info.UnNamedInstance
 	}


### PR DESCRIPTION
Change CloudInfo to use a registration pattern, making the dependencies on the cloud provider SDKs optional. The CloudProviders are registered in the main cadvisor binary, so for non-library usages there are no changes.

For Kubernetes, I verified that the info provided by CloudInfo is unused by removing it and confirming everything still builds: https://github.com/tallclair/kubernetes/commit/9274b43f7c2a270b464e8ff5a7a5034d4618d562 (the only reference in Kubernetes was in the cadvisor fake)