### PR TITLE
Do not disable disk and network metrics

### DIFF
--- a/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
+++ b/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
@@ -2,8 +2,6 @@
 # This set of arguments mirrors what the kubelet currently uses for cAdvisor, 
 # enables only cpu, memory, diskIO, disk and network metrics, and shows only
 # container metrics.
-#
-# https://github.com/google/cadvisor/blob/master/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
 apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
 kind: DaemonSet
 metadata:
@@ -14,9 +12,9 @@ spec:
       containers:
       - name: cadvisor
         args:
-          - --housekeeping_interval=10s                   # kubernetes default args
+          - --housekeeping_interval=10s                    # kubernetes default args
           - --max_housekeeping_interval=15s
           - --event_storage_event_limit=default=0
           - --event_storage_age_limit=default=0
-          - --disable_metrics=percpu,tcp,udp              # enable only diskIO, cpu, memory, network, disk
-          - --docker_only                                 # only show stats for docker containers
+          - --disable_metrics=percpu,process,sched,tcp,udp # enable only diskIO, cpu, memory, network, disk
+          - --docker_only                                  # only show stats for docker containers

--- a/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
+++ b/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
@@ -1,6 +1,9 @@
 # This patch is an example of setting arguments for the cAdvisor container.
 # This set of arguments mirrors what the kubelet currently uses for cAdvisor, 
-# enables only cpu, memory, and diskIO metrics, and shows only container metrics.
+# enables only cpu, memory, diskIO, disk and network metrics, and shows only
+# container metrics.
+#
+# https://github.com/google/cadvisor/blob/master/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
 apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
 kind: DaemonSet
 metadata:
@@ -15,5 +18,5 @@ spec:
           - --max_housekeeping_interval=15s
           - --event_storage_event_limit=default=0
           - --event_storage_age_limit=default=0
-          - --disable_metrics=percpu,disk,network,tcp,udp # enable only diskIO, cpu, memory
+          - --disable_metrics=percpu,tcp,udp              # enable only diskIO, cpu, memory, network, disk
           - --docker_only                                 # only show stats for docker containers


### PR DESCRIPTION
These are actually present in cadvisor metrics that are served via
kubelet (version v1.13.5). This change will bring stand-alone cadvisor
daemonset closer with the one shipped with the kubelet