### PR TITLE
Fixes #2232

### DIFF
--- a/utils/cloudinfo/aws/aws.go
+++ b/utils/cloudinfo/aws/aws.go
@@ -16,7 +16,6 @@ package cloudinfo
 
 import (
 	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,9 +27,10 @@ import (
 )
 
 const (
-	productVerFileName = "/sys/class/dmi/id/product_version"
-	biosVerFileName    = "/sys/class/dmi/id/bios_vendor"
-	amazon             = "amazon"
+	productVerFileName       = "/sys/class/dmi/id/product_version"
+	biosVerFileName          = "/sys/class/dmi/id/bios_vendor"
+	systemdOSReleaseFileName = "/etc/os-release"
+	amazon                   = "amazon"
 )
 
 func init() {
@@ -42,23 +42,18 @@ type provider struct{}
 var _ cloudinfo.CloudProvider = provider{}
 
 func (provider) IsActiveProvider() bool {
-	var dataProduct []byte
-	var dataBios []byte
-	if _, err := os.Stat(productVerFileName); err == nil {
-		dataProduct, err = ioutil.ReadFile(productVerFileName)
-		if err != nil {
-			return false
-		}
+	return fileContainsAmazonIdentifier(productVerFileName) ||
+		fileContainsAmazonIdentifier(biosVerFileName) ||
+		fileContainsAmazonIdentifier(systemdOSReleaseFileName)
+}
+
+func fileContainsAmazonIdentifier(filename string) bool {
+	fileContent, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return false
 	}
 
-	if _, err := os.Stat(biosVerFileName); err == nil {
-		dataBios, err = ioutil.ReadFile(biosVerFileName)
-		if err != nil {
-			return false
-		}
-	}
-
-	return strings.Contains(string(dataProduct), amazon) || strings.Contains(strings.ToLower(string(dataBios)), amazon)
+	return strings.Contains(string(fileContent), amazon)
 }
 
 func getAwsMetadata(name string) string {


### PR DESCRIPTION
Hey all :smiley: !

This commit fixes #2232 where cadvisor was not able to detect the cloud provider when it's running on a custom AMI derived from Amazon Linux 2.

It does so by checking /etc/os-release. However, from what I've read, /etc/os-release is pretty much a systemd thing. Although Amazon Linux 2 comes with systemd, cadvisor cannot assume the existence of systemd in other AMIs / OSes, therefore we would only be checking for /etc/os-release if all other methods fail us.

I have also made a small refactoring so the resulting diff is a little bigger than I wanted it to be for such a small PR, so sorry about that :( 