### PR TITLE
Allow storage drivers to read the spec details as well.

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -631,9 +631,18 @@ func (c *containerData) updateStats() error {
 		}
 		return err
 	}
+	spec, err := c.handler.GetSpec()
+	if err != nil {
+		// Ignore errors if the container is dead.
+		if !c.handler.Exists() {
+			return nil
+		}
+		return err
+	}
 
 	cInfo := info.ContainerInfo{
 		ContainerReference: ref,
+		Spec:               spec,
 	}
 
 	err = c.memoryCache.AddStats(&cInfo, stats)


### PR DESCRIPTION
Per quick discussion in slack[0] here is the patch to pass the spec information long to the storage driver. I am not really certain if this is passing the cached copy as requested but it follows the existing patterns for other information going into the struct.

[0] - https://kubernetes.slack.com/archives/C0BP8PW9G/p1560178234038700