### PR TITLE
Monitor docker restart container events and update pid for the container process.

### DIFF
--- a/container/docker/event.go
+++ b/container/docker/event.go
@@ -1,0 +1,109 @@
+package docker
+
+import (
+	"context"
+	"sync"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	dclient "github.com/docker/docker/client"
+	containerlibcontainer "github.com/google/cadvisor/container/libcontainer"
+	"k8s.io/klog"
+)
+
+const eventRestart = "restart"
+
+type eventHandler struct {
+	client           *dclient.Client
+	containerHandler *containerlibcontainer.Handler
+	eventMutex       sync.Mutex
+	filter           filters.Args
+	id               string
+	// Tells the eventHandler to stop.
+	stopChan chan struct{}
+}
+
+type worker struct {
+	message events.Message
+}
+
+func newDockerEventHandler(dockerClient *dclient.Client, id string, containerHandler *containerlibcontainer.Handler) (*eventHandler, error) {
+	filter := filters.NewArgs()
+	filter.Add("type", events.ContainerEventType)
+	filter.Add("event", eventRestart)
+	filter.Add("container", id)
+
+	return &eventHandler{
+		client:           dockerClient,
+		containerHandler: containerHandler,
+		filter:           filter,
+		id:               id,
+		stopChan:         make(chan struct{}, 1),
+	}, nil
+}
+
+func (eh *eventHandler) routeEvents(ctx context.Context) (bool, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	messages, errs := dockerClient.Events(ctx, types.EventsOptions{
+		Filters: eh.filter,
+	})
+	for {
+		select {
+		case event := <-messages:
+			message := worker{
+				message: event,
+			}
+			message.processEvent(event, eh)
+		case err := <-errs:
+			return true, err
+		case <-eh.stopChan:
+			return false, nil
+		}
+
+	}
+}
+
+func (w worker) processEvent(event events.Message, eh *eventHandler) {
+	if event.Action == eventRestart {
+		eh.eventMutex.Lock()
+		defer eh.eventMutex.Unlock()
+
+		klog.V(6).Infof("event received for %s: %s", eh.id, event.Action)
+		ctnr, err := eh.client.ContainerInspect(context.Background(), eh.id)
+		if err != nil {
+			klog.V(6).Infof("error while retrieving container info %s", err)
+			return
+		}
+
+		eh.containerHandler.UpdatePid(ctnr.State.Pid)
+	}
+}
+
+func (eh *eventHandler) EventMutex() *sync.Mutex {
+	return &eh.eventMutex
+}
+
+func (eh *eventHandler) Start() {
+	klog.V(6).Infof("started event monitoring on container %s", eh.id)
+
+	go func() {
+		for {
+			restart, err := eh.routeEvents(context.Background())
+			if err != nil {
+				klog.V(6).Infof("error in event channel %v", err)
+			}
+
+			if !restart {
+				break
+			}
+		}
+	}()
+}
+
+func (eh *eventHandler) Stop() {
+	klog.V(6).Infof("stopped event monitoring on container %s", eh.id)
+	close(eh.stopChan)
+}

--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -140,6 +140,13 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 	return stats, nil
 }
 
+func (h *Handler) UpdatePid(pid int) {
+	if pid != h.pid {
+		klog.V(6).Infof("updating %d pid to %d pid", h.pid, pid)
+		h.pid = pid
+	}
+}
+
 func processStatsFromProcs(rootFs string, cgroupPath string) (info.ProcessStats, error) {
 	var fdCount uint64
 	filePath := path.Join(cgroupPath, "cgroup.procs")


### PR DESCRIPTION
Network stats correctly work after containers are restarted: issue #1522
I've been running this for a couple of weeks now and haven't seen any issues affecting performance. 
Pid of containers is updated.

Note:
- This solution resets the cumulative values in network stats so the documentation will need updating to show this. 
- I can't seem to synchronise `GetStats()` to when the containers are restarted. Therefore, as soon as a container is restarted (with `docker restart ...`), the error `Unable to get network stats from pid 34215` might appear once before the pid is updated. This as a knock-on effect on the front-end. 
- The front-end will receive a single empty network stat (from the issue mention above) causing a error on rendering the graph. This will fix itself when the time stamp of that specific empty stat is outside the time range of the graph. This can be solved by not returning empty stats on the API but i have't looked into it.