### PR TITLE
Add socketCount for container process stat

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -571,6 +571,9 @@ type ProcessStats struct {
 	// Number of open file descriptors
 	FdCount uint64 `json:"fd_count"`
 
+	// Number of sockets
+	SocketCount uint64 `json:"socket_count"`
+
 	// Number of threads currently in container
 	ThreadsCurrent uint64 `json:"threads_current,omitempty"`
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1046,6 +1046,14 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				},
 			},
 			{
+				name:      "container_sockets",
+				help:      "Number of open sockets for the container.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Processes.SocketCount), timestamp: s.Timestamp}}
+				},
+			},
+			{
 				name:      "container_threads_max",
 				help:      "Maximum number of threads allowed inside the container, infinity if value is zero",
 				valueType: prometheus.GaugeValue,

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -257,6 +257,7 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 					Processes: info.ProcessStats{
 						ProcessCount:   1,
 						FdCount:        5,
+						SocketCount:    3,
 						ThreadsCurrent: 5,
 						ThreadsMax:     100,
 					},

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -210,6 +210,9 @@ container_processes{container_env_foo_env="prod",container_label_foo_label="bar"
 # HELP container_scrape_error 1 if there was an error while getting container metrics, 0 otherwise
 # TYPE container_scrape_error gauge
 container_scrape_error 0
+# HELP container_sockets Number of open sockets for the container.
+# TYPE container_sockets gauge
+container_sockets{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3 1395066363000
 # HELP container_spec_cpu_period CPU period of the container.
 # TYPE container_spec_cpu_period gauge
 container_spec_cpu_period{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 100000


### PR DESCRIPTION
**What**
Add metrics `container_threads` and `container_sockets` for container。
As follows:
```
	Processes: info.ProcessStats{
		ProcessCount: 1,
		ThreadCount:  10,
		FdCount:      5,
		SocketCount:  3,
	},
```