### PR TITLE
set memory limitation for cadvisor 

### DIFF
--- a/deploy/kubernetes/base/daemonset.yaml
+++ b/deploy/kubernetes/base/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
             memory: 200Mi
             cpu: 150m
           limits:
+            memory: 2000Mi
             cpu: 300m
         volumeMounts:
         - name: rootfs


### PR DESCRIPTION
see issue #2264 
this patch adds default memory limitation for Cadvisor in K8s so k8s will restart it. 