### PR TITLE
docs: update running flag for current process metrics

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -18,9 +18,11 @@ sudo docker run \
 
 cAdvisor is now running (in the background) on `http://localhost:8080/`. The setup includes directories with Docker state cAdvisor needs to observe.
 
-**Note**: If docker daemon is running with [user namespace enabled](https://docs.docker.com/engine/reference/commandline/dockerd/#starting-the-daemon-with-user-namespaces-enabled),
-You need to add `--userns=host` option in order for cAdvisor to monitor Docker containers,
+**Note**: 
+- If docker daemon is running with [user namespace enabled](https://docs.docker.com/engine/reference/commandline/dockerd/#starting-the-daemon-with-user-namespaces-enabled),
+you need to add `--userns=host` option in order for cAdvisor to monitor Docker containers,
 otherwise cAdvisor can not connect to docker daemon.
+- If cadvisor scrapes `process metrics` by set flag `--disable_metrics`, you need to add `--pid=host` and `--privileged` for `docker run` to get `/proc/pid/fd` path in host.
 
 ## Latest Canary
 

--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -116,7 +116,7 @@ cAdvisor stores the latest historical data in memory. How long of a history it s
 --application_metrics_count_limit=100: Max number of application metrics to store (per container) (default 100)
 --collector_cert="": Collector's certificate, exposed to endpoints for certificate based authentication.
 --collector_key="": Key for the collector's certificate
---disable_metrics=tcp, udp: comma-separated list of metrics to be disabled. Options are 'disk', 'network', 'tcp', 'udp'. Note: tcp and udp are disabled by default due to high CPU usage. (default tcp,udp)
+--disable_metrics=tcp,udp,sched,process: comma-separated list of metrics to be disabled. Options are 'disk', 'network', 'tcp', 'udp', 'sched', 'process'. Note: tcp and udp are disabled by default due to high CPU usage. (default tcp,udp,sched,process)
 --prometheus_endpoint="/metrics": Endpoint to expose Prometheus metrics on (default "/metrics")
 ```
 


### PR DESCRIPTION
**What changed**
1. Add `Note` when cadvisor running in docker want to scrape process metrics. 
2. Update `--disable_metrics` information.

related issues [2258](https://github.com/google/cadvisor/issues/2258) [2250](https://github.com/google/cadvisor/issues/2250) [2251](https://github.com/google/cadvisor/issues/2251)