### PR TITLE
Fix security issues: bump alpine to 3.10

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils zfs && \


### PR DESCRIPTION
During coreos/clair scan of image, we can see lot's of security issues:
```
clair-scanner --ip=192.168.1.199 google/cadvisor:canary

2019/07/29 22:12:50 [INFO] ▶ Start clair-scanner
2019/07/29 22:13:08 [INFO] ▶ Server listening on port 9279
2019/07/29 22:13:08 [INFO] ▶ Analyzing ef9a4ff474958b9a2d5cd094a0eec98592409204e99009e4fd11a5cf130dcdda
2019/07/29 22:13:10 [INFO] ▶ Analyzing dd9025d43c3a02c77de9e4b02021a46443456141bcdcf7fbed4b33537526911e
2019/07/29 22:13:11 [INFO] ▶ Analyzing 1f63c10165d40d556a4cf7c7896cb5305d9079a525449948dfa5083fd7046b3d
2019/07/29 22:13:11 [INFO] ▶ Analyzing 512d7b4edea1c6567deb10a997ad697ffb8d1c504c41471803df21fd4ea91f3f
2019/07/29 22:13:14 [INFO] ▶ Analyzing 87862a09725060dba575ef899b3ec6e82d1673c2c51534f7556a4cad2649c327
2019/07/29 22:13:18 [INFO] ▶ Analyzing 5c328e2ced925fdec54c231eecc785a8a18c10568af8b9cfde6231ee205a87c9
2019/07/29 22:13:25 [INFO] ▶ Analyzing 83e73a40baa3325dcefcf90c7371879e60082a6d9724d2429922187fad200f25
2019/07/29 22:13:25 [INFO] ▶ Analyzing fffe37e03e9ddf026997e4a0abd8ed17e4d9e551175f94a163ca8d6f434952e2
2019/07/29 22:13:26 [INFO] ▶ Analyzing 5df167d8afae63caf694cbc367fd2cd5ada0206f4b2d8d93b12385bc615b064e
2019/07/29 22:13:27 [INFO] ▶ Analyzing 1787b6ada9f5c764bd0c7322782fc6024d96c06df2e8c1ebd3788110ecbddbb9
2019/07/29 22:13:32 [WARN] ▶ Image [google/cadvisor:canary] contains 158 total vulnerabilities
2019/07/29 22:13:32 [ERRO] ▶ Image [google/cadvisor:canary] contains 158 unapproved vulnerabilities
```

<details><summary>Security report</summary>

```
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| STATUS     | CVE SEVERITY                | PACKAGE NAME    | PACKAGE VERSION | CVE DESCRIPTION                                                  |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | High CVE-2019-13272         | linux           | 4.19.37-5       | In the Linux kernel before 5.1.17, ptrace_link in                |
|            |                             |                 |                 | kernel/ptrace.c mishandles the recording of the                  |
|            |                             |                 |                 | credentials of a process that wants to create a ptrace           |
|            |                             |                 |                 | relationship, which allows local users to obtain                 |
|            |                             |                 |                 | root access by leveraging certain scenarios with a               |
|            |                             |                 |                 | parent-child process relationship, where a parent                |
|            |                             |                 |                 | drops privileges and calls execve (potentially allowing          |
|            |                             |                 |                 | control by an attacker). One contributing factor                 |
|            |                             |                 |                 | is an object lifetime issue (which can also cause                |
|            |                             |                 |                 | a panic). Another contributing factor is incorrect               |
|            |                             |                 |                 | marking of a ptrace relationship as privileged, which            |
|            |                             |                 |                 | is exploitable through (for example) Polkit's pkexec             |
|            |                             |                 |                 | helper with PTRACE_TRACEME. NOTE: SELinux deny_ptrace            |
|            |                             |                 |                 | might be a usable workaround in some environments.               |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-13272       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | High CVE-2013-7445          | linux           | 4.19.37-5       | The Direct Rendering Manager (DRM) subsystem in                  |
|            |                             |                 |                 | the Linux kernel through 4.x mishandles requests                 |
|            |                             |                 |                 | for Graphics Execution Manager (GEM) objects,                    |
|            |                             |                 |                 | which allows context-dependent attackers to cause                |
|            |                             |                 |                 | a denial of service (memory consumption) via                     |
|            |                             |                 |                 | an application that processes graphics data, as                  |
|            |                             |                 |                 | demonstrated by JavaScript code that creates many                |
|            |                             |                 |                 | CANVAS elements for rendering by Chrome or Firefox.              |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2013-7445        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | High CVE-2018-20836         | linux           | 4.19.37-5       | An issue was discovered in the Linux kernel before 4.20.         |
|            |                             |                 |                 | There is a race condition in smp_task_timedout() and             |
|            |                             |                 |                 | smp_task_done() in drivers/scsi/libsas/sas_expander.c,           |
|            |                             |                 |                 | leading to a use-after-free.                                     |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-20836       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | High CVE-2019-1999          | linux           | 4.19.37-5       | In binder_alloc_free_page of binder_alloc.c,                     |
|            |                             |                 |                 | there is a possible double free due to improper                  |
|            |                             |                 |                 | locking. This could lead to local escalation                     |
|            |                             |                 |                 | of privilege in the kernel with no additional                    |
|            |                             |                 |                 | execution privileges needed. User interaction is                 |
|            |                             |                 |                 | not needed for exploitation. Product: Android.                   |
|            |                             |                 |                 | Versions: Android kernel. Android ID: A-120025196.               |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-1999        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-10638       | linux           | 4.19.37-5       | In the Linux kernel before 5.1.7, a device can be tracked        |
|            |                             |                 |                 | by an attacker using the IP ID values the kernel produces        |
|            |                             |                 |                 | for connection-less protocols (e.g., UDP and ICMP). When         |
|            |                             |                 |                 | such traffic is sent to multiple destination IP addresses,       |
|            |                             |                 |                 | it is possible to obtain hash collisions (of indices             |
|            |                             |                 |                 | to the counter array) and thereby obtain the hashing             |
|            |                             |                 |                 | key (via enumeration). An attack may be conducted by             |
|            |                             |                 |                 | hosting a crafted web page that uses WebRTC or gQUIC to          |
|            |                             |                 |                 | force UDP traffic to attacker-controlled IP addresses.           |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-10638       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2018-12928       | linux           | 4.19.37-5       | In the Linux kernel 4.15.0, a NULL pointer dereference           |
|            |                             |                 |                 | was discovered in hfs_ext_read_extent in hfs.ko. This            |
|            |                             |                 |                 | can occur during a mount of a crafted hfs filesystem.            |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-12928       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2018-12886       | gcc-8           | 8.3.0-6         | stack_protect_prologue in cfgexpand.c and                        |
|            |                             |                 |                 | stack_protect_epilogue in function.c in GNU Compiler             |
|            |                             |                 |                 | Collection (GCC) 4.1 through 8 (under certain                    |
|            |                             |                 |                 | circumstances) generate instruction sequences when               |
|            |                             |                 |                 | targeting ARM targets that spill the address of                  |
|            |                             |                 |                 | the stack protector guard, which allows an attacker              |
|            |                             |                 |                 | to bypass the protection of -fstack-protector,                   |
|            |                             |                 |                 | -fstack-protector-all, -fstack-protector-strong, and             |
|            |                             |                 |                 | -fstack-protector-explicit against stack overflow by             |
|            |                             |                 |                 | controlling what the stack canary is compared against.           |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-12886       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-12904       | libgcrypt20     | 1.8.4-5         | In Libgcrypt 1.8.4, the C implementation                         |
|            |                             |                 |                 | of AES is vulnerable to a flush-and-reload                       |
|            |                             |                 |                 | side-channel attack because physical addresses                   |
|            |                             |                 |                 | are available to other processes. (The C                         |
|            |                             |                 |                 | implementation is used on platforms where an                     |
|            |                             |                 |                 | assembly-language implementation is unavailable.)                |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-12904       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13012       | glib2.0         | 2.58.3-2        | The keyfile settings backend in GNOME GLib (aka                  |
|            |                             |                 |                 | glib2.0) before 2.59.1 creates directories using                 |
|            |                             |                 |                 | g_file_make_directory_with_parents (kfsb->dir,                   |
|            |                             |                 |                 | NULL, NULL) and files using g_file_replace_contents              |
|            |                             |                 |                 | (kfsb->file, contents, length, NULL, FALSE,                      |
|            |                             |                 |                 | G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, NULL).            |
|            |                             |                 |                 | Consequently, it does not properly restrict directory            |
|            |                             |                 |                 | (and file) permissions. Instead, for directories,                |
|            |                             |                 |                 | 0777 permissions are used; for files, default file               |
|            |                             |                 |                 | permissions are used. This is similar to CVE-2019-12450.         |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-13012       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-3843        | systemd         | 241-5           | It was discovered that a systemd service that uses               |
|            |                             |                 |                 | DynamicUser property can create a SUID/SGID binary               |
|            |                             |                 |                 | that would be allowed to run as the transient service            |
|            |                             |                 |                 | UID/GID even after the service is terminated. A local            |
|            |                             |                 |                 | attacker may use this flaw to access resources that              |
|            |                             |                 |                 | will be owned by a potentially different service                 |
|            |                             |                 |                 | in the future, when the UID/GID will be recycled.                |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-3843        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-3844        | systemd         | 241-5           | It was discovered that a systemd service that                    |
|            |                             |                 |                 | uses DynamicUser property can get new privileges                 |
|            |                             |                 |                 | through the execution of SUID binaries, which                    |
|            |                             |                 |                 | would allow to create binaries owned by the service              |
|            |                             |                 |                 | transient group with the setgid bit set. A local                 |
|            |                             |                 |                 | attacker may use this flaw to access resources that              |
|            |                             |                 |                 | will be owned by a potentially different service                 |
|            |                             |                 |                 | in the future, when the GID will be recycled.                    |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-3844        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-3900        | linux           | 4.19.37-5       | An infinite loop issue was found in the vhost_net kernel         |
|            |                             |                 |                 | module in Linux Kernel up to and including v5.1-rc6,             |
|            |                             |                 |                 | while handling incoming packets in handle_rx().                  |
|            |                             |                 |                 | It could occur if one end sends packets faster                   |
|            |                             |                 |                 | than the other end can process them. A guest user,               |
|            |                             |                 |                 | maybe remote one, could use this flaw to stall the               |
|            |                             |                 |                 | vhost_net kernel thread, resulting in a DoS scenario.            |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-3900        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2018-20839       | systemd         | 241-5           | systemd 242 changes the VT1 mode upon a logout,                  |
|            |                             |                 |                 | which allows attackers to read cleartext                         |
|            |                             |                 |                 | passwords in certain circumstances, such as                      |
|            |                             |                 |                 | watching a shutdown, or using Ctrl-Alt-F1 and                    |
|            |                             |                 |                 | Ctrl-Alt-F2. This occurs because the KDGKBMODE                   |
|            |                             |                 |                 | (aka current keyboard mode) check is mishandled.                 |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-20839       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13115       | libssh2         | 1.8.0-2.1       | In libssh2 before 1.9.0,                                         |
|            |                             |                 |                 | kex_method_diffie_hellman_group_exchange_sha256_key_exchange     |
|            |                             |                 |                 | in kex.c has an integer overflow that could lead to an           |
|            |                             |                 |                 | out-of-bounds read in the way packets are read from the          |
|            |                             |                 |                 | server. A remote attacker who compromises a SSH server           |
|            |                             |                 |                 | may be able to disclose sensitive information or cause           |
|            |                             |                 |                 | a denial of service condition on the client system when          |
|            |                             |                 |                 | a user connects to the server. This is related to an             |
|            |                             |                 |                 | _libssh2_check_length mistake, and is different from the         |
|            |                             |                 |                 | various issues fixed in 1.8.1, such as CVE-2019-3855.            |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-13115       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-9947        | python2.7       | 2.7.16-2        | An issue was discovered in urllib2 in Python 2.x                 |
|            |                             |                 |                 | through 2.7.16 and urllib in Python 3.x through 3.7.3.           |
|            |                             |                 |                 | CRLF injection is possible if the attacker controls a            |
|            |                             |                 |                 | url parameter, as demonstrated by the first argument             |
|            |                             |                 |                 | to urllib.request.urlopen with \r\n (specifically in             |
|            |                             |                 |                 | the path component of a URL that lacks a ? character)            |
|            |                             |                 |                 | followed by an HTTP header or a Redis command. This              |
|            |                             |                 |                 | is similar to the CVE-2019-9740 query string issue.              |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-9947        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2016-10723       | linux           | 4.19.37-5       | ** DISPUTED ** An issue was discovered in the Linux kernel       |
|            |                             |                 |                 | through 4.17.2. Since the page allocator does not yield          |
|            |                             |                 |                 | CPU resources to the owner of the oom_lock mutex, a local        |
|            |                             |                 |                 | unprivileged user can trivially lock up the system forever       |
|            |                             |                 |                 | by wasting CPU resources from the page allocator (e.g., via      |
|            |                             |                 |                 | concurrent page fault events) when the global OOM killer         |
|            |                             |                 |                 | is invoked. NOTE: the software maintainer has not accepted       |
|            |                             |                 |                 | certain proposed patches, in part because of a viewpoint         |
|            |                             |                 |                 | that "the underlying problem is non-trivial to handle."          |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2016-10723       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2018-20852       | python2.7       | 2.7.16-2        | http.cookiejar.DefaultPolicy.domain_return_ok in                 |
|            |                             |                 |                 | Lib/http/cookiejar.py in Python before 3.7.3 does not            |
|            |                             |                 |                 | correctly validate the domain: it can be tricked into            |
|            |                             |                 |                 | sending existing cookies to the wrong server. An attacker        |
|            |                             |                 |                 | may abuse this flaw by using a server with a hostname            |
|            |                             |                 |                 | that has another valid hostname as a suffix (e.g.,               |
|            |                             |                 |                 | pythonicexample.com to steal cookies for example.com).           |
|            |                             |                 |                 | When a program uses http.cookiejar.DefaultPolicy and             |
|            |                             |                 |                 | tries to do an HTTP connection to an attacker-controlled         |
|            |                             |                 |                 | server, existing cookies can be leaked to the attacker.          |
|            |                             |                 |                 | This affects 2.x through 2.7.16, 3.x before 3.4.10, 3.5.x        |
|            |                             |                 |                 | before 3.5.7, 3.6.x before 3.6.9, and 3.7.x before 3.7.3.        |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-20852       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-9740        | python2.7       | 2.7.16-2        | An issue was discovered in urllib2 in Python 2.x                 |
|            |                             |                 |                 | through 2.7.16 and urllib in Python 3.x through                  |
|            |                             |                 |                 | 3.7.3. CRLF injection is possible if the attacker                |
|            |                             |                 |                 | controls a url parameter, as demonstrated by the                 |
|            |                             |                 |                 | first argument to urllib.request.urlopen with \r\n               |
|            |                             |                 |                 | (specifically in the query string after a ? character)           |
|            |                             |                 |                 | followed by an HTTP header or a Redis command.                   |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-9740        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-10160       | python2.7       | 2.7.16-2        | A security regression of CVE-2019-9636 was discovered in         |
|            |                             |                 |                 | python since commit d537ab0ff9767ef024f26246899728f0116b1ec3     |
|            |                             |                 |                 | affecting versions 2.7, 3.5, 3.6, 3.7 and from v3.8.0a4          |
|            |                             |                 |                 | through v3.8.0b1, which still allows an attacker to exploit      |
|            |                             |                 |                 | CVE-2019-9636 by abusing the user and password parts of          |
|            |                             |                 |                 | a URL. When an application parses user-supplied URLs to          |
|            |                             |                 |                 | store cookies, authentication credentials, or other kind         |
|            |                             |                 |                 | of information, it is possible for an attacker to provide        |
|            |                             |                 |                 | specially crafted URLs to make the application locate            |
|            |                             |                 |                 | host-related information (e.g. cookies, authentication           |
|            |                             |                 |                 | data) and send them to a different host than where it            |
|            |                             |                 |                 | should, unlike if the URLs had been correctly parsed. The        |
|            |                             |                 |                 | result of an attack may vary based on the application.           |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-10160       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2018-3693        | linux           | 4.19.37-5       | Systems with microprocessors utilizing speculative execution     |
|            |                             |                 |                 | and branch prediction may allow unauthorized disclosure          |
|            |                             |                 |                 | of information to an attacker with local user access via         |
|            |                             |                 |                 | a speculative buffer overflow and side-channel analysis.         |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-3693        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-12984       | linux           | 4.19.37-5       | A NULL pointer dereference vulnerability in the function         |
|            |                             |                 |                 | nfc_genl_deactivate_target() in net/nfc/netlink.c                |
|            |                             |                 |                 | in the Linux kernel before 5.1.13 can be triggered               |
|            |                             |                 |                 | by a malicious user-mode program that omits certain              |
|            |                             |                 |                 | NFC attributes, leading to denial of service.                    |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-12984       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2011-3389        | gnutls28        | 3.6.7-4         | The SSL protocol, as used in certain configurations              |
|            |                             |                 |                 | in Microsoft Windows and Microsoft Internet Explorer,            |
|            |                             |                 |                 | Mozilla Firefox, Google Chrome, Opera, and other                 |
|            |                             |                 |                 | products, encrypts data by using CBC mode with chained           |
|            |                             |                 |                 | initialization vectors, which allows man-in-the-middle           |
|            |                             |                 |                 | attackers to obtain plaintext HTTP headers via a blockwise       |
|            |                             |                 |                 | chosen-boundary attack (BCBA) on an HTTPS session, in            |
|            |                             |                 |                 | conjunction with JavaScript code that uses (1) the HTML5         |
|            |                             |                 |                 | WebSocket API, (2) the Java URLConnection API, or (3)            |
|            |                             |                 |                 | the Silverlight WebClient API, aka a "BEAST" attack.             |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2011-3389        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13631       | linux           | 4.19.37-5       | In parse_hid_report_descriptor in                                |
|            |                             |                 |                 | drivers/input/tablet/gtco.c in the Linux kernel                  |
|            |                             |                 |                 | through 5.2.1, a malicious USB device can send                   |
|            |                             |                 |                 | an HID report that triggers an out-of-bounds                     |
|            |                             |                 |                 | write during generation of debugging messages.                   |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-13631       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-13233       | linux           | 4.19.37-5       | In arch/x86/lib/insn-eval.c in the Linux kernel before           |
|            |                             |                 |                 | 5.1.9, there is a use-after-free for access to an LDT            |
|            |                             |                 |                 | entry because of a race condition between modify_ldt()           |
|            |                             |                 |                 | and a #BR exception for an MPX bounds violation.                 |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-13233       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2019-12817       | linux           | 4.19.37-5       | arch/powerpc/mm/mmu_context_book3s64.c in the Linux              |
|            |                             |                 |                 | kernel before 5.1.15 for powerpc has a bug where unrelated       |
|            |                             |                 |                 | processes may be able to read/write to one another's             |
|            |                             |                 |                 | virtual memory under certain conditions via an mmap above        |
|            |                             |                 |                 | 512 TB. Only a subset of powerpc systems are affected.           |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-12817       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Medium CVE-2018-17977       | linux           | 4.19.37-5       | The Linux kernel 4.14.67 mishandles certain interaction          |
|            |                             |                 |                 | among XFRM Netlink messages, IPPROTO_AH packets,                 |
|            |                             |                 |                 | and IPPROTO_IP packets, which allows local users to              |
|            |                             |                 |                 | cause a denial of service (memory consumption and                |
|            |                             |                 |                 | system hang) by leveraging root access to execute                |
|            |                             |                 |                 | crafted applications, as demonstrated on CentOS 7.               |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-17977       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2016-2781           | coreutils       | 8.30-3          | chroot in GNU coreutils, when used with --userspec,              |
|            |                             |                 |                 | allows local users to escape to the parent session               |
|            |                             |                 |                 | via a crafted TIOCSTI ioctl call, which pushes                   |
|            |                             |                 |                 | characters to the terminal's input buffer.                       |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2016-2781        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2016-10228          | glibc           | 2.28-10         | The iconv program in the GNU C Library (aka glibc or             |
|            |                             |                 |                 | libc6) 2.25 and earlier, when invoked with the -c option,        |
|            |                             |                 |                 | enters an infinite loop when processing invalid multi-byte       |
|            |                             |                 |                 | input sequences, leading to a denial of service.                 |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2016-10228       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2017-0630           | linux           | 4.19.37-5       | An information disclosure vulnerability in the kernel            |
|            |                             |                 |                 | trace subsystem could enable a local malicious application       |
|            |                             |                 |                 | to access data outside of its permission levels. This            |
|            |                             |                 |                 | issue is rated as Moderate because it first requires             |
|            |                             |                 |                 | compromising a privileged process. Product: Android.             |
|            |                             |                 |                 | Versions: Kernel-3.10, Kernel-3.18. Android ID: A-34277115.      |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2017-0630        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2018-7169           | shadow          | 1:4.5-1.1       | An issue was discovered in shadow 4.5. newgidmap (in             |
|            |                             |                 |                 | shadow-utils) is setuid and allows an unprivileged user          |
|            |                             |                 |                 | to be placed in a user namespace where setgroups(2) is           |
|            |                             |                 |                 | permitted. This allows an attacker to remove themselves          |
|            |                             |                 |                 | from a supplementary group, which may allow access to            |
|            |                             |                 |                 | certain filesystem paths if the administrator has used           |
|            |                             |                 |                 | "group blacklisting" (e.g., chmod g-rwx) to restrict access      |
|            |                             |                 |                 | to paths. This flaw effectively reverts a security feature       |
|            |                             |                 |                 | in the kernel (in particular, the /proc/self/setgroups           |
|            |                             |                 |                 | knob) to prevent this sort of privilege escalation.              |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-7169        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2019-3874           | linux           | 4.19.37-5       | The SCTP socket buffer used by a userspace application is        |
|            |                             |                 |                 | not accounted by the cgroups subsystem. An attacker can          |
|            |                             |                 |                 | use this flaw to cause a denial of service attack. Kernel        |
|            |                             |                 |                 | 3.10.x and 4.18.x branches are believed to be vulnerable.        |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-3874        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2018-15919          | openssh         | 1:7.9p1-10      | Remotely observable behaviour in auth-gss2.c in OpenSSH          |
|            |                             |                 |                 | through 7.8 could be used by remote attackers to detect          |
|            |                             |                 |                 | existence of users on a target system when GSS2 is in            |
|            |                             |                 |                 | use. NOTE: the discoverer states 'We understand that             |
|            |                             |                 |                 | the OpenSSH developers do not want to treat such a               |
|            |                             |                 |                 | username enumeration (or "oracle") as a vulnerability.'          |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2018-15919       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2019-13057          | openldap        | 2.4.47+dfsg-3   | An issue was discovered in the server in OpenLDAP before         |
|            |                             |                 |                 | 2.4.48. When the server administrator delegates rootDN           |
|            |                             |                 |                 | (database admin) privileges for certain databases but            |
|            |                             |                 |                 | wants to maintain isolation (e.g., for multi-tenant              |
|            |                             |                 |                 | deployments), slapd does not properly stop a rootDN from         |
|            |                             |                 |                 | requesting authorization as an identity from another             |
|            |                             |                 |                 | database during a SASL bind or with a proxyAuthz (RFC            |
|            |                             |                 |                 | 4370) control. (It is not a common configuration to              |
|            |                             |                 |                 | deploy a system where the server administrator and a             |
|            |                             |                 |                 | DB administrator enjoy different levels of trust.)               |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-13057       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2019-13565          | openldap        | 2.4.47+dfsg-3   | An issue was discovered in OpenLDAP 2.x before 2.4.48.           |
|            |                             |                 |                 | When using SASL authentication and session encryption,           |
|            |                             |                 |                 | and relying on the SASL security layers in slapd access          |
|            |                             |                 |                 | controls, it is possible to obtain access that would             |
|            |                             |                 |                 | otherwise be denied via a simple bind for any identity           |
|            |                             |                 |                 | covered in those ACLs. After the first SASL bind is              |
|            |                             |                 |                 | completed, the sasl_ssf value is retained for all new            |
|            |                             |                 |                 | non-SASL connections. Depending on the ACL configuration,        |
|            |                             |                 |                 | this can affect different types of operations (searches,         |
|            |                             |                 |                 | modifications, etc.). In other words, a successful               |
|            |                             |                 |                 | authorization step completed by one user affects                 |
|            |                             |                 |                 | the authorization requirement for a different user.              |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2019-13565       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Low CVE-2016-8660           | linux           | 4.19.37-5       | The XFS subsystem in the Linux kernel through 4.8.2              |
|            |                             |                 |                 | allows local users to cause a denial of service (fdatasync       |
|            |                             |                 |                 | failure and system hang) by using the vfs syscall                |
|            |                             |                 |                 | group in the trinity program, related to a "page lock            |
|            |                             |                 |                 | order bug in the XFS seek hole/data implementation."             |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2016-8660        |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
| Unapproved | Negligible CVE-2017-11164   | pcre3           | 2:8.39-12       | In PCRE 8.41, the OP_KETRMAX feature in the match function       |
|            |                             |                 |                 | in pcre_exec.c allows stack exhaustion (uncontrolled             |
|            |                             |                 |                 | recursion) when processing a crafted regular expression.         |
|            |                             |                 |                 | https://security-tracker.debian.org/tracker/CVE-2017-11164       |
+------------+-----------------------------+-----------------+-----------------+------------------------------------------------------------------+
```
</details>