### PR TITLE
Fix printed output for prow script

### DIFF
--- a/build/prow_e2e.sh
+++ b/build/prow_e2e.sh
@@ -31,7 +31,7 @@ FORCE=true build/assets.sh
 if [[ ! -z "$(git diff --name-only pages)" ]]; then
   echo "Found changes to UI assets:"
   git diff --name-only pages
-  echo "Run: `make assets FORCE=true`"
+  echo "Run: 'make assets FORCE=true'"
   exit 1
 fi
 


### PR DESCRIPTION
We the makes it print 'make assets FORCE=true', rather than run it (which just exits 1 since it fails).

Related: #2291

/assign @mJace