### PR TITLE
Exporting container_memory_kernel from memory.kmem.usage_in_bytes

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -549,6 +549,7 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	ret.Memory.Usage = s.MemoryStats.Usage.Usage
 	ret.Memory.MaxUsage = s.MemoryStats.Usage.MaxUsage
 	ret.Memory.Failcnt = s.MemoryStats.Usage.Failcnt
+	ret.Memory.Kernel = s.MemoryStats.KernelUsage.Usage
 
 	if s.MemoryStats.UseHierarchy {
 		ret.Memory.Cache = s.MemoryStats.Stats["total_cache"]

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -352,6 +352,10 @@ type MemoryStats struct {
 	// Units: Bytes.
 	MaxUsage uint64 `json:"max_usage"`
 
+	// Size of kernel memory allocated in bytes.
+	// Units: Bytes.
+	Kernel uint64 `json:"kernel"`
+
 	// Number of bytes of page cache memory.
 	// Units: Bytes.
 	Cache uint64 `json:"cache"`

--- a/info/v1/test/datagen.go
+++ b/info/v1/test/datagen.go
@@ -47,6 +47,7 @@ func GenerateRandomStats(numStats, numCores int, duration time.Duration) []*info
 		stats.Memory.Cache = uint64(rand.Int63n(4096))
 		stats.Memory.RSS = uint64(rand.Int63n(4096))
 		stats.Memory.MappedFile = uint64(rand.Int63n(4096))
+		stats.Memory.Kernel = uint64(rand.Int63n(4096))
 		ret[i] = stats
 	}
 	return ret

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -337,6 +337,14 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				getValues: func(s *info.ContainerStats) metricValues {
 					return metricValues{{value: float64(s.Memory.RSS), timestamp: s.Timestamp}}
 				},
+			},
+			{
+				name:      "container_memory_kernel",
+				help:      "Size of kernel memory allocated in bytes.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Kernel), timestamp: s.Timestamp}}
+				},
 			}, {
 				name:      "container_memory_mapped_file",
 				help:      "Size of memory mapped files in bytes.",

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -132,6 +132,7 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 						Cache:      14,
 						RSS:        15,
 						MappedFile: 16,
+						Kernel:     17,
 						Swap:       8192,
 					},
 					Network: info.NetworkStats{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -124,6 +124,9 @@ container_memory_failures_total{container_env_foo_env="prod",container_label_foo
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",failure_type="pgfault",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",zone_name="hello"} 12 1395066363000
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",failure_type="pgmajfault",id="testcontainer",image="test",name="testcontaineralias",scope="container",zone_name="hello"} 11 1395066363000
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",failure_type="pgmajfault",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",zone_name="hello"} 13 1395066363000
+# HELP container_memory_kernel Size of kernel memory allocated in bytes.
+# TYPE container_memory_kernel gauge
+container_memory_kernel{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 17 1395066363000
 # HELP container_memory_mapped_file Size of memory mapped files in bytes.
 # TYPE container_memory_mapped_file gauge
 container_memory_mapped_file{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 16 1395066363000


### PR DESCRIPTION
In response to #2138 

Through prometheus testing the following relationship seems to be present:

`container_memory_usage_bytes` == `container_memory_rss` + `container_memory_cache` + `container_memory_kernel` 

