### PR TITLE
Add missing error handler in machine info

### DIFF
--- a/machine/info.go
+++ b/machine/info.go
@@ -100,6 +100,9 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 	}
 
 	cpuinfo, err := ioutil.ReadFile(filepath.Join(rootFs, "/proc/cpuinfo"))
+	if err != nil {
+		return nil, err
+	}
 	clockSpeed, err := GetClockSpeed(cpuinfo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add error handler after reading `cpuinfo`.