### PR TITLE
Add support for emitting file descriptor limits for containers.

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -564,6 +564,12 @@ type AcceleratorStats struct {
 	DutyCycle uint64 `json:"duty_cycle"`
 }
 
+type UlimitSpec struct {
+	Name      string `json:"name"`
+	SoftLimit int64  `json:"soft_limit"`
+	HardLimit int64  `json:"hard_limit"`
+}
+
 type ProcessStats struct {
 	// Number of processes
 	ProcessCount uint64 `json:"process_count"`
@@ -579,6 +585,9 @@ type ProcessStats struct {
 
 	// Maxium number of threads allowed in container
 	ThreadsMax uint64 `json:"threads_max,omitempty"`
+
+	// Ulimits for the top-level container process
+	Ulimits []UlimitSpec `json:"ulimits,omitempty"`
 }
 
 type ContainerStats struct {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1079,6 +1079,23 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 					}
 				},
 			},
+			{
+				name:        "container_ulimits_soft",
+				help:        "Soft ulimit values for the container root process. Unlimited if -1, except priority and nice",
+				valueType:   prometheus.GaugeValue,
+				extraLabels: []string{"ulimit"},
+				getValues: func(s *info.ContainerStats) metricValues {
+					values := make(metricValues, 0, len(s.Processes.Ulimits))
+					for _, ulimit := range s.Processes.Ulimits {
+						values = append(values, metricValue{
+							value:     float64(ulimit.SoftLimit),
+							labels:    []string{ulimit.Name},
+							timestamp: s.Timestamp,
+						})
+					}
+					return values
+				},
+			},
 		}...)
 
 	}

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -260,6 +260,13 @@ func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.Container
 						SocketCount:    3,
 						ThreadsCurrent: 5,
 						ThreadsMax:     100,
+						Ulimits: []info.UlimitSpec{
+							{
+								Name:      "max_open_files",
+								SoftLimit: 16384,
+								HardLimit: 16384,
+							},
+						},
 					},
 					TaskStats: info.LoadStats{
 						NrSleeping:        50,

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -238,6 +238,9 @@ container_threads{container_env_foo_env="prod",container_label_foo_label="bar",i
 # HELP container_threads_max Maximum number of threads allowed inside the container, infinity if value is zero
 # TYPE container_threads_max gauge
 container_threads_max{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 100 1395066363000
+# HELP container_ulimits_soft Soft ulimit values for the container root process. Unlimited if -1, except priority and nice
+# TYPE container_ulimits_soft gauge
+container_ulimits_soft{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",ulimit="max_open_files",zone_name="hello"} 16384 1395066363000
 # HELP machine_cpu_cores Number of CPU cores on the machine.
 # TYPE machine_cpu_cores gauge
 machine_cpu_cores 4


### PR DESCRIPTION
This change is intended to address issue #2311.

It adds a ContainerSpec field for Ulimits and populates it for docker containers from the HostConfig. I only emitted the fd soft limit since that's the one we need right now. In theory we could emit all ulimits that are populated (and generate metric names from the resource names), but it seemed better to avoid emitting unnecessary metrics.

The fd soft limit is emitted as container_spec_file_descriptor_limit_soft, which is longer than I would like, but seems to be consistent with the naming convention.

An alternative approach that might be more "container agnostic" involves looking up all the processes in the cgroup, and emitting the ulimits for the "parent/init/session" process for the cgroup. However, it might be more "fragile".