### PR TITLE
Update the reference to Source attribute via safer Get API for mesos containers.

### DIFF
--- a/container/mesos/mesos_agent.go
+++ b/container/mesos/mesos_agent.go
@@ -138,7 +138,7 @@ func (s *state) FetchLabels(fwID string, exID string) (map[string]string, error)
 		return labels, fmt.Errorf("executor ID %q not found: %v", exID, err)
 	}
 
-	labels[source] = *exec.Source
+	labels[source] = exec.GetSource()
 
 	err = s.fetchLabelsFromTask(exID, labels)
 	if err != nil {


### PR DESCRIPTION
GetSource API for mesosContainers ensures to return a safer empty string on non-existence unlike the previous reference which would crash.