### PR TITLE
runtime option for housekeeping jitter

### DIFF
--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -79,6 +79,7 @@ Per-container housekeeping is run once on each container cAdvisor tracks. This t
 --global_housekeeping_interval=1m0s: Interval between global housekeepings
 --housekeeping_interval=1s: Interval between container housekeepings
 --max_housekeeping_interval=1m0s: Largest interval to allow between container housekeepings (default 1m0s)
+--housekeeping_jitter_factor=1.0: Housekeeping interval jitter factor. Full interval equals interval + factor * random(interval) (default 1)
 ```
 
 ## HTTP


### PR DESCRIPTION
Jitter itself is a good thing, but it can cause some non obvious side effects in case of prometheus.

For example I want to collect metrics every 30 seconds. I have a bunch of containers so I'm using cadvisor to collect metrics from them with housekeeping_interval = 30 seconds and I have prometheus exporter to collect data from cadvisors and some other subsysterms (and it collects every 30 seconds too).

Such setup couses a chain of issues. First off all, real interval isn't a 30 seconds, it's 30-60 seconds and this part isn't documented. As a result cadvisor has less measurments than prometheus exporter. Looks... not terrible but it can cause signiffican fluctuations in exported cpu usage metric for example.

Cadvisor exports cpu seconds as a counter, like 10, 20, 30 and so on. But if prometheus exporter is getting two equal values in a row (cadvisor is a bit slower in our case, since interval is 30-60 seconds) it thinks that cpu usage is 0, because nothing were changed for the last 30 seconds.

So I'm forsed to set housekeeping interval to 15 seconds to make sure that metrics are collecte at least once. I personally would prefer to be able to shrink jitter factor if needed.