### PR TITLE
Update CRI-O storage driver support

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -283,7 +283,7 @@ func (self *RealFsInfo) addCrioImagesLabel(context Context, mounts []*mount.Info
 		crioImagePaths := map[string]struct{}{
 			"/": {},
 		}
-		for _, dir := range []string{"overlay", "overlay2"} {
+		for _, dir := range []string{"devicemapper", "btrfs", "aufs", "overlay", "zfs"} {
 			crioImagePaths[path.Join(crioPath, dir+"-images")] = struct{}{}
 		}
 		for crioPath != "/" && crioPath != "." {


### PR DESCRIPTION
Some storage drivers seems to be missing which are now supported by
CRI-O. Beside that, we removed the non-existing overlay2 driver.