### PR TITLE
Update gofmt with go1.13

### DIFF
--- a/storage/elasticsearch/elasticsearch.go
+++ b/storage/elasticsearch/elasticsearch.go
@@ -69,7 +69,7 @@ func new() (storage.StorageDriver, error) {
 
 func (self *elasticStorage) containerStatsAndDefaultValues(
 	cInfo *info.ContainerInfo, stats *info.ContainerStats) *detailSpec {
-	timestamp := stats.Timestamp.UnixNano() / 1E3
+	timestamp := stats.Timestamp.UnixNano() / 1e3
 	var containerName string
 	if len(cInfo.ContainerReference.Aliases) > 0 {
 		containerName = cInfo.ContainerReference.Aliases[0]

--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -66,7 +66,7 @@ func (self *redisStorage) defaultReadyToFlush() bool {
 
 // We must add some default params (for example: MachineName,ContainerName...)because containerStats do not include them
 func (self *redisStorage) containerStatsAndDefaultValues(cInfo *info.ContainerInfo, stats *info.ContainerStats) *detailSpec {
-	timestamp := stats.Timestamp.UnixNano() / 1E3
+	timestamp := stats.Timestamp.UnixNano() / 1e3
 	var containerName string
 	if len(cInfo.ContainerReference.Aliases) > 0 {
 		containerName = cInfo.ContainerReference.Aliases[0]


### PR DESCRIPTION
The e2e tests are currently failing with:

```
I1107 01:53:45.099] >> checking go formatting
I1107 01:53:45.634] The following files are not properly formatted:
I1107 01:53:45.634] storage/elasticsearch/elasticsearch.go storage/redis/redis.go storage/redis/redis.go storage/elasticsearch/elasticsearch.go
```


https://k8s-testgrid.appspot.com/sig-node-cadvisor#cadvisor-e2e