### PR TITLE
Fix deprecated image reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo docker run \
   --publish=8080:8080 \
   --detach=true \
   --name=cadvisor \
-  google/cadvisor:latest
+  gcr.io/google-containers/cadvisor:latest
 ```
 
 cAdvisor is now running (in the background) on `http://localhost:8080`. The setup includes directories with Docker state cAdvisor needs to observe.


### PR DESCRIPTION
Dockerhub repository has a deprecation notice.

Signed-off-by: Roman Mazur <roman@balena.io>