### PR TITLE
Fix container `OnDemandHousekeeping` blocking on stop channel.

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -81,7 +81,7 @@ type containerData struct {
 	logUsage bool
 
 	// Tells the container to stop.
-	stop chan bool
+	stop chan struct{}
 
 	// Tells the container to immediately collect stats
 	onDemandChan chan chan struct{}
@@ -114,7 +114,7 @@ func (c *containerData) Stop() error {
 	if err != nil {
 		return err
 	}
-	c.stop <- true
+	close(c.stop)
 	return nil
 }
 
@@ -383,7 +383,7 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
 		allowDynamicHousekeeping: allowDynamicHousekeeping,
 		logUsage:                 logUsage,
 		loadAvg:                  -1.0, // negative value indicates uninitialized.
-		stop:                     make(chan bool, 1),
+		stop:                     make(chan struct{}),
 		collectorManager:         collectorManager,
 		onDemandChan:             make(chan chan struct{}, 100),
 		clock:                    clock,


### PR DESCRIPTION
The `stop` channel used in `container.go` is selected in both public method `OnDemandHousekeeping` and as a base case in `housekeepingTick`. A deadlock condition can occur when the user calls `OnDemandHousekeeping` with a `maxAge` more recent than the last stats update time after the container has already been stopped and the `stop` channel already drained in `housekeepingTick`.

I've been able to reproduce this issue consistently by ramping up a number of docker containers and stopping them in groups.

I've added unit test to demonstrate the fix. Without the stop channel changes this test times out due to blocking call.