### PR TITLE
Db password fromfile

### DIFF
--- a/storage/common_flags.go
+++ b/storage/common_flags.go
@@ -21,6 +21,7 @@ import (
 
 var ArgDbUsername = flag.String("storage_driver_user", "root", "database username")
 var ArgDbPassword = flag.String("storage_driver_password", "root", "database password")
+var ArgDbPasswordFile = flag.String("storage_driver_password_file", "", "database password from file")
 var ArgDbHost = flag.String("storage_driver_host", "localhost:8086", "database host:port")
 var ArgDbName = flag.String("storage_driver_db", "cadvisor", "database name")
 var ArgDbTable = flag.String("storage_driver_table", "stats", "table name")

--- a/storage/common_flags.go
+++ b/storage/common_flags.go
@@ -21,7 +21,7 @@ import (
 
 var ArgDbUsername = flag.String("storage_driver_user", "root", "database username")
 var ArgDbPassword = flag.String("storage_driver_password", "root", "database password")
-var ArgDbPasswordFile = flag.String("storage_driver_password_file", "", "database password from file")
+var ArgDbPasswordFile = flag.String("storage_driver_password_file", "", "read database password from file (overrides -storage_driver_password)")
 var ArgDbHost = flag.String("storage_driver_host", "localhost:8086", "database host:port")
 var ArgDbName = flag.String("storage_driver_db", "cadvisor", "database name")
 var ArgDbTable = flag.String("storage_driver_table", "stats", "table name")

--- a/storage/influxdb/influxdb.go
+++ b/storage/influxdb/influxdb.go
@@ -17,8 +17,10 @@ package influxdb
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -76,11 +78,33 @@ const (
 	serFsUsage string = "fs_usage"
 )
 
+// read a db password from a file 
+func readPassword(passwordFile string) (string, error) {
+
+	passwordFileData, err := ioutil.ReadFile(passwordFile)
+	if err != nil {
+		return "", err
+	}
+
+	password := string(passwordFileData)
+	password = strings.TrimSuffix(password, "\n")
+
+	return password, nil
+}
+
 func new() (storage.StorageDriver, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
 	}
+	
+	if *storage.ArgDbPasswordFile != "" {
+		*storage.ArgDbPassword, err = readPassword(*storage.ArgDbPasswordFile)
+		if err != nil {
+			return nil, err
+		}
+	}	
+	
 	return newStorage(
 		hostname,
 		*storage.ArgDbTable,


### PR DESCRIPTION
A simple patch to allow the reading of a db password from a file as opposed to having to type the password on the command line when starting cadvisor.  This can be useful with e.g. docker secrets where you can specify "-storage_driver_password_file=/run/secrets/cadvisor_influxdb_password".

InfluxDB looks to be the only storage engine with authentication so it's only valid for that at the moment but would be trivial to extend to other storage engines if they gain authentication functionality e.g. #1570 

This should address #1633 

Tested with Docker 19.03.5 against InfluxDB 1.7.9