### PR TITLE
Update assets to fix e2e tests

### DIFF
--- a/pages/static/assets.go
+++ b/pages/static/assets.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pages/templates.go
+++ b/pages/templates.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
See https://github.com/google/cadvisor/pull/2364#issuecomment-571345370 for an example of the failure.  This is the classic new year's bump of UI assets...  Everything has to say 2020!