### PR TITLE
Skip TestTopology on non-amd64

### DIFF
--- a/machine/topology_test.go
+++ b/machine/topology_test.go
@@ -82,6 +82,9 @@ func TestTopology(t *testing.T) {
 }
 
 func TestTopologyWithSimpleCpuinfo(t *testing.T) {
+	if isSystemZ() {
+		t.Skip("systemZ has no topology info")
+	}
 	sysFs := &fakesysfs.FakeSysFs{}
 	c := sysfs.CacheInfo{
 		Size:  32 * 1024,
@@ -118,6 +121,9 @@ func TestTopologyWithSimpleCpuinfo(t *testing.T) {
 }
 
 func TestTopologyEmptyCpuinfo(t *testing.T) {
+	if isSystemZ() {
+		t.Skip("systemZ has no topology info")
+	}
 	_, _, err := GetTopology(&fakesysfs.FakeSysFs{}, "")
 	if err == nil {
 		t.Errorf("Expected empty cpuinfo to fail.")

--- a/machine/topology_test.go
+++ b/machine/topology_test.go
@@ -17,6 +17,7 @@ package machine
 import (
 	"io/ioutil"
 	"reflect"
+	"runtime"
 	"testing"
 
 	info "github.com/google/cadvisor/info/v1"
@@ -25,6 +26,9 @@ import (
 )
 
 func TestTopology(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("cpuinfo testdata is for amd64")
+	}
 	testfile := "./testdata/cpuinfo"
 	testcpuinfo, err := ioutil.ReadFile(testfile)
 	if err != nil {


### PR DESCRIPTION
It fails on s390x and aarch64, since GetTopology
function is platform specified.