### PR TITLE
Assign quota if the parsing doesn't encounter error

### DIFF
--- a/container/common/helpers.go
+++ b/container/common/helpers.go
@@ -109,8 +109,9 @@ func GetSpec(cgroupPaths map[string]string, machineInfoFactory info.MachineInfoF
 				val, err := strconv.ParseUint(quota, 10, 64)
 				if err != nil {
 					klog.Errorf("GetSpec: Failed to parse CPUQuota from %q: %s", path.Join(cpuRoot, "cpu.cfs_quota_us"), err)
+				} else {
+					spec.Cpu.Quota = val
 				}
-				spec.Cpu.Quota = val
 			}
 		}
 	}


### PR DESCRIPTION
In GetSpec, we shouldn't assign val to spec.Cpu.Quota if the parsing fails.