### PR TITLE
Check extraErr before accessing extraUsage.Bytes

### DIFF
--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -90,7 +90,7 @@ func (fh *realFsHandler) update() error {
 	fh.Lock()
 	defer fh.Unlock()
 	fh.lastUpdate = time.Now()
-	if fh.rootfs != "" && rootErr == nil {
+	if fh.rootfs != "" && rootErr == nil && extraErr == nil {
 		fh.usage.InodeUsage = rootUsage.Inodes
 		fh.usage.TotalUsageBytes = rootUsage.Bytes + extraUsage.Bytes
 	}

--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -90,12 +90,13 @@ func (fh *realFsHandler) update() error {
 	fh.Lock()
 	defer fh.Unlock()
 	fh.lastUpdate = time.Now()
-	if fh.rootfs != "" && rootErr == nil && extraErr == nil {
+	if fh.rootfs != "" && rootErr == nil {
 		fh.usage.InodeUsage = rootUsage.Inodes
-		fh.usage.TotalUsageBytes = rootUsage.Bytes + extraUsage.Bytes
+		fh.usage.BaseUsageBytes = rootUsage.Bytes
+		fh.usage.TotalUsageBytes = rootUsage.Bytes
 	}
 	if fh.extraDir != "" && extraErr == nil {
-		fh.usage.BaseUsageBytes = rootUsage.Bytes
+		fh.usage.TotalUsageBytes += extraUsage.Bytes
 	}
 
 	// Combine errors into a single error to return


### PR DESCRIPTION
In realFsHandler#update, extraUsage.Bytes is accessed without checking extraErr.

This PR adds check before referencing extraUsage.Bytes