### PR TITLE
Verify that fsType is found for device

### DIFF
--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -272,6 +272,9 @@ func (self *crioContainerHandler) getFsStats(stats *info.ContainerStats) error {
 		}
 	}
 
+	if fsType == "" {
+		return fmt.Errorf("unable to determine fs type for device: %v", device)
+	}
 	fsStat := info.FsStats{Device: device, Type: fsType, Limit: limit}
 	usage := self.fsHandler.Usage()
 	fsStat.BaseUsage = usage.BaseUsageBytes


### PR DESCRIPTION
In crioContainerHandler#getFsStats, we come out of the loop over mi.Filesystems when device is found.
However, in case the device is not found, we should return info.FsStats with limit of 0.

This PR adds check against the device not found case.