### PR TITLE
Chk scanner err

### DIFF
--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -262,16 +262,21 @@ func (self *crioContainerHandler) getFsStats(stats *info.ContainerStats) error {
 		limit  uint64
 		fsType string
 	)
+	deviceFound := false
 
 	// crio does not impose any filesystem limits for containers. So use capacity as limit.
 	for _, fs := range mi.Filesystems {
 		if fs.Device == device {
 			limit = fs.Capacity
 			fsType = fs.Type
+			deviceFound = true
 			break
 		}
 	}
 
+	if !deviceFound {
+		return fmt.Errorf("unable to determine fs type for device: %v", device)
+	}
 	fsStat := info.FsStats{Device: device, Type: fsType, Limit: limit}
 	usage := self.fsHandler.Usage()
 	fsStat.BaseUsage = usage.BaseUsageBytes

--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -477,6 +477,9 @@ func scanAdvancedTcpStats(advancedStats *info.TcpAdvancedStat, advancedTcpStatsF
 			}
 		}
 	}
+	if scanner.Err() != nil {
+		return scanner.Err()
+	}
 
 	b, err := json.Marshal(advancedTcpStats)
 	if err != nil {
@@ -488,7 +491,7 @@ func scanAdvancedTcpStats(advancedStats *info.TcpAdvancedStat, advancedTcpStatsF
 		return err
 	}
 
-	return scanner.Err()
+	return nil
 
 }
 


### PR DESCRIPTION
In scanAdvancedTcpStats, after scanning is done, we call json.Marshal followed by returning scanner.Err() .
If scanning has had error, it should be returned prior to calling json.Marshal .