### PR TITLE
support export envs with prefix

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -60,7 +60,7 @@ const rootDirRetryPeriod time.Duration = 1000 * time.Millisecond
 // --cgroup-parent have another prefix than 'docker'
 var dockerCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
 
-var dockerEnvWhitelist = flag.String("docker_env_metadata_whitelist", "", "a comma-separated list of environment variable keys that needs to be collected for docker containers")
+var dockerEnvWhitelist = flag.String("docker_env_metadata_whitelist", "", "a comma-separated list of environment variable keys matched with specified prefix that needs to be collected for docker containers")
 
 var (
 	// Basepath to all container specific information that libcontainer stores.

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -51,7 +51,6 @@ const (
 )
 
 type dockerContainerHandler struct {
-
 	// machineInfoFactory provides info.MachineInfo
 	machineInfoFactory info.MachineInfoFactory
 
@@ -253,11 +252,16 @@ func newDockerContainerHandler(
 
 	// split env vars to get metadata map.
 	for _, exposedEnv := range metadataEnvs {
+		if exposedEnv == "" {
+			// no envs provided, len(metadataEnvs) == 1, metadataEnvs[0] == ""
+			continue
+		}
+
 		for _, envVar := range ctnr.Config.Env {
 			if envVar != "" {
 				splits := strings.SplitN(envVar, "=", 2)
-				if len(splits) == 2 && splits[0] == exposedEnv {
-					handler.envs[strings.ToLower(exposedEnv)] = splits[1]
+				if len(splits) == 2 && strings.HasPrefix(splits[0], exposedEnv) {
+					handler.envs[strings.ToLower(splits[0])] = splits[1]
 				}
 			}
 		}


### PR DESCRIPTION
This is a feature that cadvisor can export envs with kinds of prefix pattern.

 It can be set by flag `--docker-env-metadata-whitelist` in `kubelet`, and with this feature, users can access pods' envs exposed to collect more metrics.

For example, if user want to expose some metrics collected by `prometheus` sdk, or metrics about runtime like java `jmx` and so on, they can set `--docker-env-metadata-whitelist` and acquire metrics detail by kubelet API with `Subcontainers` option enabled.

Eventually, I wanna to set envs exposed to be `Upper` cased(Lower cased now).