### PR TITLE
Adding missing struct tags for JSON consistency

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -213,10 +213,10 @@ type MachineInfo struct {
 
 type MemoryInfo struct {
 	// The amount of memory (in bytes).
-	Capacity uint64
+	Capacity uint64 `json:"capacity"`
 
 	// Number of memory DIMMs.
-	DimmCount uint
+	DimmCount uint `json:"dimm_count"`
 }
 
 type VersionInfo struct {


### PR DESCRIPTION
I have realized that `info.MemoryInfo` that I added recently is missing (de)serialization tags.