### PR TITLE
refactor AllMetrics to support external reference

### DIFF
--- a/cadvisor.go
+++ b/cadvisor.go
@@ -260,27 +260,5 @@ func createCollectorHttpClient(collectorCert, collectorKey string) http.Client {
 }
 
 func toIncludedMetrics(ignoreMetrics container.MetricSet) container.MetricSet {
-	set := container.MetricSet{}
-	allMetrics := []container.MetricKind{
-		container.CpuUsageMetrics,
-		container.ProcessSchedulerMetrics,
-		container.PerCpuUsageMetrics,
-		container.MemoryUsageMetrics,
-		container.CpuLoadMetrics,
-		container.DiskIOMetrics,
-		container.DiskUsageMetrics,
-		container.NetworkUsageMetrics,
-		container.NetworkTcpUsageMetrics,
-		container.NetworkAdvancedTcpUsageMetrics,
-		container.NetworkUdpUsageMetrics,
-		container.AcceleratorUsageMetrics,
-		container.AppMetrics,
-		container.ProcessMetrics,
-	}
-	for _, metric := range allMetrics {
-		if !ignoreMetrics.Has(metric) {
-			set[metric] = struct{}{}
-		}
-	}
-	return set
+	return container.AllMetrics.Difference(ignoreMetrics)
 }

--- a/cadvisor_test.go
+++ b/cadvisor_test.go
@@ -59,3 +59,39 @@ func TestIgnoreMetrics(t *testing.T) {
 		}
 	}
 }
+
+func TestToIncludedMetrics(t *testing.T) {
+	ignores := []container.MetricSet{
+		{
+			container.CpuUsageMetrics: struct{}{},
+		},
+		{
+		},
+		container.AllMetrics,
+	}
+
+	expected := []container.MetricSet{
+		{
+			container.ProcessSchedulerMetrics:        struct{}{},
+			container.PerCpuUsageMetrics:             struct{}{},
+			container.MemoryUsageMetrics:             struct{}{},
+			container.CpuLoadMetrics:                 struct{}{},
+			container.DiskIOMetrics:                  struct{}{},
+			container.AcceleratorUsageMetrics:        struct{}{},
+			container.DiskUsageMetrics:               struct{}{},
+			container.NetworkUsageMetrics:            struct{}{},
+			container.NetworkTcpUsageMetrics:         struct{}{},
+			container.NetworkAdvancedTcpUsageMetrics: struct{}{},
+			container.NetworkUdpUsageMetrics:         struct{}{},
+			container.ProcessMetrics:                 struct{}{},
+			container.AppMetrics:                     struct{}{},
+		},
+		container.AllMetrics,
+		{},
+	}
+
+	for idx, ignore := range ignores {
+		actual := toIncludedMetrics(ignore)
+		assert.Equal(t, actual, expected[idx])
+	}
+}

--- a/container/factory.go
+++ b/container/factory.go
@@ -59,6 +59,24 @@ const (
 	ProcessMetrics                 MetricKind = "process"
 )
 
+// AllMetrics represents all kinds of metrics that cAdvisor supported.
+var AllMetrics = MetricSet{
+	CpuUsageMetrics:                struct{}{},
+	ProcessSchedulerMetrics:        struct{}{},
+	PerCpuUsageMetrics:             struct{}{},
+	MemoryUsageMetrics:             struct{}{},
+	CpuLoadMetrics:                 struct{}{},
+	DiskIOMetrics:                  struct{}{},
+	AcceleratorUsageMetrics:        struct{}{},
+	DiskUsageMetrics:               struct{}{},
+	NetworkUsageMetrics:            struct{}{},
+	NetworkTcpUsageMetrics:         struct{}{},
+	NetworkAdvancedTcpUsageMetrics: struct{}{},
+	NetworkUdpUsageMetrics:         struct{}{},
+	ProcessMetrics:                 struct{}{},
+	AppMetrics:                     struct{}{},
+}
+
 func (mk MetricKind) String() string {
 	return string(mk)
 }
@@ -72,6 +90,16 @@ func (ms MetricSet) Has(mk MetricKind) bool {
 
 func (ms MetricSet) Add(mk MetricKind) {
 	ms[mk] = struct{}{}
+}
+
+func (ms MetricSet) Difference(ms1 MetricSet) MetricSet {
+	result := MetricSet{}
+	for kind := range ms {
+		if !ms1.Has(kind) {
+			result.Add(kind)
+		}
+	}
+	return result
 }
 
 // All registered auth provider plugins.

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -48,23 +48,6 @@ func (p testSubcontainersInfoProvider) GetMachineInfo() (*info.MachineInfo, erro
 	}, nil
 }
 
-var allMetrics = container.MetricSet{
-	container.CpuUsageMetrics:                struct{}{},
-	container.ProcessSchedulerMetrics:        struct{}{},
-	container.PerCpuUsageMetrics:             struct{}{},
-	container.MemoryUsageMetrics:             struct{}{},
-	container.CpuLoadMetrics:                 struct{}{},
-	container.DiskIOMetrics:                  struct{}{},
-	container.AcceleratorUsageMetrics:        struct{}{},
-	container.DiskUsageMetrics:               struct{}{},
-	container.NetworkUsageMetrics:            struct{}{},
-	container.NetworkTcpUsageMetrics:         struct{}{},
-	container.NetworkAdvancedTcpUsageMetrics: struct{}{},
-	container.NetworkUdpUsageMetrics:         struct{}{},
-	container.ProcessMetrics:                 struct{}{},
-	container.AppMetrics:                     struct{}{},
-}
-
 func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.ContainerInfoRequest) ([]*info.ContainerInfo, error) {
 	return []*info.ContainerInfo{
 		{
@@ -426,7 +409,7 @@ func TestPrometheusCollector(t *testing.T) {
 		s := DefaultContainerLabels(container)
 		s["zone.name"] = "hello"
 		return s
-	}, allMetrics)
+	}, container.AllMetrics)
 	prometheus.MustRegister(c)
 	defer prometheus.Unregister(c)
 
@@ -496,7 +479,7 @@ func TestPrometheusCollector_scrapeFailure(t *testing.T) {
 		s := DefaultContainerLabels(container)
 		s["zone.name"] = "hello"
 		return s
-	}, allMetrics)
+	}, container.AllMetrics)
 	prometheus.MustRegister(c)
 	defer prometheus.Unregister(c)
 


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubernetes/pull/88841

To support configurable metricSet in `kubelet`, we should add a `AllMetrics` to relieve hard code pain.

And  `AllMetrics` has been used for some other where like `cadvisor.go` and `prometheus_test.go` in cadvisor, we can unified it.