### PR TITLE
Extending machine API by NVM memory mode capacity

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -223,7 +223,10 @@ type MemoryInfo struct {
 
 type NVMInfo struct {
 	// The total NVM capacity in bytes for memory mode.
-	MemoryModeCapcity uint `json:"memory_mode_capcity"`
+	MemoryModeCapcity uint64 `json:"memory_mode_capcity"`
+
+	//The total NVM capacity in bytes for app direct mode.
+	AppDirectModeCapcity uint64 `json:"app direct_mode_capcity"`
 
 	// Average power budget for NVM devices configured in BIOS.
 	AvgPowerBudget uint `json:"avg_power_budget"`

--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -222,6 +222,9 @@ type MemoryInfo struct {
 }
 
 type NVMInfo struct {
+	// The total NVM capacity in bytes for memory mode.
+	MemoryModeCapcity uint `json:"memory_mode_capcity"`
+
 	// Average power budget for NVM devices configured in BIOS.
 	AvgPowerBudget uint `json:"avg_power_budget"`
 }

--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -228,7 +228,7 @@ type NVMInfo struct {
 	//The total NVM capacity in bytes for app direct mode.
 	AppDirectModeCapcity uint64 `json:"app direct_mode_capcity"`
 
-	// Average power budget for NVM devices configured in BIOS.
+	// Average power budget in watts for NVM devices configured in BIOS.
 	AvgPowerBudget uint `json:"avg_power_budget"`
 }
 

--- a/machine/info.go
+++ b/machine/info.go
@@ -77,7 +77,7 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 		return nil, err
 	}
 
-	nvmPowerBudget, err := GetNVMAvgPowerBudget()
+	nvmInfo, err := GetNVMInfo()
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 		CpuFrequency:     clockSpeed,
 		MemoryCapacity:   memoryCapacity,
 		MemoryByType:     memoryByType,
-		NVMInfo:          info.NVMInfo{AvgPowerBudget: nvmPowerBudget},
+		NVMInfo:          nvmInfo,
 		HugePages:        hugePagesInfo,
 		DiskMap:          diskMap,
 		NetworkDevices:   netDevices,

--- a/machine/machine_libipmctl.go
+++ b/machine/machine_libipmctl.go
@@ -22,25 +22,19 @@ import "C"
 import (
 	"fmt"
 
+	info "github.com/google/cadvisor/info/v1"
+
 	"k8s.io/klog"
 )
 
-// GetNVMAvgPowerBudget retrieves configured power budget
+// getNVMAvgPowerBudget retrieves configured power budget
 // (in watts) for NVM devices. When libipmct is not available
 // zero is returned.
-func GetNVMAvgPowerBudget() (uint, error) {
-	// Initialize libipmctl library.
-	err := C.nvm_init()
-	if err != C.NVM_SUCCESS {
-		klog.Warningf("libipmctl initialization failed with status %d", err)
-		return uint(0), fmt.Errorf("libipmctl initialization failed with status %d", err)
-	}
-	defer C.nvm_uninit()
-
+func getNVMAvgPowerBudget() (uint, error) {
 	// Get number of devices on the platform
 	// see: https://github.com/intel/ipmctl/blob/v01.00.00.3497/src/os/nvm_api/nvm_management.h#L1478
 	var count C.uint
-	err = C.nvm_get_number_of_devices(&count)
+	err := C.nvm_get_number_of_devices(&count)
 	if err != C.NVM_SUCCESS {
 		klog.Warningf("Unable to get number of NVM devices. Status code: %d", err)
 		return uint(0), fmt.Errorf("Unable to get number of NVM devices. Status code: %d", err)
@@ -66,4 +60,40 @@ func GetNVMAvgPowerBudget() (uint, error) {
 	}
 
 	return uint(device.avg_power_budget / 1000), nil
+}
+
+// getNVMMemoryModeCapcity retrieves the total NVM capacity in bytes for memory mode
+func getNVMMemoryModeCapcity() (uint, error) {
+	var caps C.struct_device_capacities
+	err := C.nvm_get_nvm_capacities(&caps)
+	if err != C.NVM_SUCCESS {
+		klog.Warningf("Unable to get NVM capacity. Status code: %d", err)
+		return uint(0), fmt.Errorf("Unable to get NVM capacity. Status code: %d", err)
+	}
+	return uint(caps.memory_capacity), nil
+}
+
+// GetNVMInfo returns information specific for non-volatile memory modules:
+// average power budget and total memory mode capacity
+func GetNVMInfo() (info.NVMInfo, error) {
+	nvmInfo := info.NVMInfo{}
+	// Initialize libipmctl library.
+	cErr := C.nvm_init()
+	if cErr != C.NVM_SUCCESS {
+		klog.Warningf("libipmctl initialization failed with status %d", cErr)
+		return info.NVMInfo{}, fmt.Errorf("libipmctl initialization failed with status %d", cErr)
+	}
+	defer C.nvm_uninit()
+
+	var err error
+	nvmInfo.MemoryModeCapcity, err = getNVMMemoryModeCapcity()
+	if err != nil {
+		return info.NVMInfo{}, fmt.Errorf("Unable to get NVM capacity in bytes for memory mode, err: %s", err)
+	}
+
+	nvmInfo.AvgPowerBudget, err = getNVMAvgPowerBudget()
+	if err != nil {
+		return info.NVMInfo{}, fmt.Errorf("Unable to get NVM average power budget, err: %s", err)
+	}
+	return nvmInfo, nil
 }

--- a/machine/machine_no_libipmctl.go
+++ b/machine/machine_no_libipmctl.go
@@ -16,9 +16,11 @@
 
 package machine
 
-// GetNVMAvgPowerBudget retrieves configured power budget
-// (in watts) for NVM devices. When libipmct is not available
+import info "github.com/google/cadvisor/info/v1"
+
+// GetNVMInfo returns information specific for non-volatile memory modules:
+// average power budget and total memory mode capacity. When libipmct is not available
 // zero is returned.
-func GetNVMAvgPowerBudget() (uint, error) {
-	return uint(0), nil
+func GetNVMInfo() (info.NVMInfo, error) {
+	return info.NVMInfo{}, nil
 }

--- a/machine/machine_no_libipmctl.go
+++ b/machine/machine_no_libipmctl.go
@@ -18,9 +18,8 @@ package machine
 
 import info "github.com/google/cadvisor/info/v1"
 
-// GetNVMInfo returns information specific for non-volatile memory modules:
-// average power budget and total memory mode capacity. When libipmct is not available
-// zero is returned.
+// GetNVMInfo returns information specific for non-volatile memory modules.
+// When libipmct is not available zero value is returned.
 func GetNVMInfo() (info.NVMInfo, error) {
 	return info.NVMInfo{}, nil
 }


### PR DESCRIPTION
Signed-off-by: Katarzyna Kujawa <katarzyna.kujawa@intel.com>

NVM memory mode capacity is visible on API in following form:
```
 "nvm": {
    "memory_mode_capcity": 429496729600,
    "avg_power_budget": 15
  }, 
``` 

related to #2388