### PR TITLE
Moving Nvidia interfaces

### DIFF
--- a/accelerators/nvidia.go
+++ b/accelerators/nvidia.go
@@ -16,7 +16,6 @@ package accelerators
 import (
 	"bufio"
 	"fmt"
-	"github.com/google/cadvisor/stats"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -26,6 +25,7 @@ import (
 	"time"
 
 	info "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/stats"
 
 	"github.com/mindprince/gonvml"
 	"k8s.io/klog"

--- a/accelerators/nvidia_test.go
+++ b/accelerators/nvidia_test.go
@@ -72,13 +72,13 @@ func TestGetCollector(t *testing.T) {
 	}
 	parseDevicesCgroup = mockParser
 	originalInitializeNVML := initializeNVML
-	initializeNVML = func(_ *NvidiaManager) {}
+	initializeNVML = func(_ *nvidiaManager) {}
 	defer func() {
 		parseDevicesCgroup = originalParser
 		initializeNVML = originalInitializeNVML
 	}()
 
-	nm := &NvidiaManager{}
+	nm := &nvidiaManager{}
 
 	// When devicesPresent is false, empty collector should be returned.
 	ac, err := nm.GetCollector("does-not-matter")

--- a/accelerators/nvidia_test.go
+++ b/accelerators/nvidia_test.go
@@ -84,27 +84,27 @@ func TestGetCollector(t *testing.T) {
 	ac, err := nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok := ac.(*NvidiaCollector)
+	nc, ok := ac.(*nvidiaCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.Devices))
+	assert.Equal(t, 0, len(nc.devices))
 
 	// When nvmlInitialized is false, empty collector should be returned.
 	nm.devicesPresent = true
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*NvidiaCollector)
+	nc, ok = ac.(*nvidiaCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.Devices))
+	assert.Equal(t, 0, len(nc.devices))
 
 	// When nvidiaDevices is empty, empty collector should be returned.
 	nm.nvmlInitialized = true
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*NvidiaCollector)
+	nc, ok = ac.(*nvidiaCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.Devices))
+	assert.Equal(t, 0, len(nc.devices))
 
 	// nvidiaDevices contains devices but they are different than what
 	// is returned by parseDevicesCgroup. We should get an error.
@@ -112,9 +112,9 @@ func TestGetCollector(t *testing.T) {
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.NotNil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*NvidiaCollector)
+	nc, ok = ac.(*nvidiaCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.Devices))
+	assert.Equal(t, 0, len(nc.devices))
 
 	// nvidiaDevices contains devices returned by parseDevicesCgroup.
 	// No error should be returned and collectors devices array should be
@@ -124,9 +124,9 @@ func TestGetCollector(t *testing.T) {
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*NvidiaCollector)
+	nc, ok = ac.(*nvidiaCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 2, len(nc.Devices))
+	assert.Equal(t, 2, len(nc.devices))
 }
 
 func TestParseDevicesCgroup(t *testing.T) {

--- a/manager/container.go
+++ b/manager/container.go
@@ -17,7 +17,6 @@ package manager
 import (
 	"flag"
 	"fmt"
-	"github.com/google/cadvisor/stats"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -35,6 +34,7 @@ import (
 	"github.com/google/cadvisor/container"
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/stats"
 	"github.com/google/cadvisor/summary"
 	"github.com/google/cadvisor/utils/cpuload"
 

--- a/manager/container.go
+++ b/manager/container.go
@@ -17,6 +17,7 @@ package manager
 import (
 	"flag"
 	"fmt"
+	"github.com/google/cadvisor/stats"
 	"io/ioutil"
 	"math"
 	"math/rand"
@@ -29,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/cadvisor/accelerators"
 	"github.com/google/cadvisor/cache/memory"
 	"github.com/google/cadvisor/collector"
 	"github.com/google/cadvisor/container"
@@ -90,7 +90,7 @@ type containerData struct {
 	collectorManager collector.CollectorManager
 
 	// nvidiaCollector updates stats for Nvidia GPUs attached to the container.
-	nvidiaCollector accelerators.AcceleratorCollector
+	nvidiaCollector stats.Collector
 }
 
 // jitter returns a time.Duration between duration and duration + maxFactor * duration,

--- a/manager/container_test.go
+++ b/manager/container_test.go
@@ -217,7 +217,7 @@ func TestUpdateNvidiaStats(t *testing.T) {
 	stats := info.ContainerStats{}
 
 	// When there are no devices, we should not get an error and stats should not change.
-	cd.nvidiaCollector = &accelerators.NvidiaCollector{}
+	cd.nvidiaCollector = accelerators.NewNvidiaCollector([]gonvml.Device{})
 	err := cd.nvidiaCollector.UpdateStats(&stats)
 	assert.Nil(t, err)
 	assert.Equal(t, info.ContainerStats{}, stats)
@@ -225,7 +225,7 @@ func TestUpdateNvidiaStats(t *testing.T) {
 	// This is an impossible situation (there are devices but nvml is not initialized).
 	// Here I am testing that the CGo gonvml library doesn't panic when passed bad
 	// input and instead returns an error.
-	cd.nvidiaCollector = &accelerators.NvidiaCollector{Devices: []gonvml.Device{{}, {}}}
+	cd.nvidiaCollector = accelerators.NewNvidiaCollector([]gonvml.Device{{}, {}})
 	err = cd.nvidiaCollector.UpdateStats(&stats)
 	assert.NotNil(t, err)
 	assert.Equal(t, info.ContainerStats{}, stats)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -18,6 +18,7 @@ package manager
 import (
 	"flag"
 	"fmt"
+	"github.com/google/cadvisor/stats"
 	"net/http"
 	"os"
 	"path"
@@ -181,7 +182,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
 		containerWatchers:                     []watcher.ContainerWatcher{},
 		eventsChannel:                         eventsChannel,
 		collectorHttpClient:                   collectorHttpClient,
-		nvidiaManager:                         &accelerators.NvidiaManager{},
+		nvidiaManager:                         accelerators.NewNvidiaManager(),
 		rawContainerCgroupPathPrefixWhiteList: rawContainerCgroupPathPrefixWhiteList,
 	}
 
@@ -230,7 +231,7 @@ type manager struct {
 	containerWatchers        []watcher.ContainerWatcher
 	eventsChannel            chan watcher.ContainerEvent
 	collectorHttpClient      *http.Client
-	nvidiaManager            accelerators.AcceleratorManager
+	nvidiaManager            stats.Manager
 	// List of raw container cgroup path prefix whitelist.
 	rawContainerCgroupPathPrefixWhiteList []string
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -18,7 +18,6 @@ package manager
 import (
 	"flag"
 	"fmt"
-	"github.com/google/cadvisor/stats"
 	"net/http"
 	"os"
 	"path"
@@ -38,6 +37,7 @@ import (
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/machine"
+	"github.com/google/cadvisor/stats"
 	"github.com/google/cadvisor/utils/oomparser"
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/google/cadvisor/version"

--- a/stats/types.go
+++ b/stats/types.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,22 +11,25 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package accelerators
+
+// Handling statistics that are fully controlled in cAdvisor
+package stats
 
 import info "github.com/google/cadvisor/info/v1"
 
-// This is supposed to store global state about an accelerator metrics collector.
-// cadvisor manager will call Setup() when it starts and Destroy() when it stops.
-// For each container detected by the cadvisor manager, it will call
+// This is supposed to store global state about an cAdvisor metrics collector.
+// cAdvisor manager will call Setup() when it starts and Destroy() when it stops.
+// For each container detected by the cAdvisor manager, it will call
 // GetCollector() with the devices cgroup path for that container.
 // GetCollector() is supposed to return an object that can update
 // accelerator stats for that container.
-type AcceleratorManager interface {
+type Manager interface {
 	Setup()
 	Destroy()
-	GetCollector(deviceCgroup string) (AcceleratorCollector, error)
+	GetCollector(deviceCgroup string) (Collector, error)
 }
 
-type AcceleratorCollector interface {
+// Collector can update ContainerStats by adding more metrics.
+type Collector interface {
 	UpdateStats(*info.ContainerStats) error
 }


### PR DESCRIPTION
Moving Nvidia interfaces to stats package so that they can be used outside of the accelerators package. This is related to #2419 and will be used there eventually.