### PR TITLE
Fix typos related to NVMinfo struct and GetMachineMemoryByType function

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -223,10 +223,10 @@ type MemoryInfo struct {
 
 type NVMInfo struct {
 	// The total NVM capacity in bytes for memory mode.
-	MemoryModeCapcity uint64 `json:"memory_mode_capcity"`
+	MemoryModeCapacity uint64 `json:"memory_mode_capacity"`
 
 	//The total NVM capacity in bytes for app direct mode.
-	AppDirectModeCapcity uint64 `json:"app direct_mode_capcity"`
+	AppDirectModeCapacity uint64 `json:"app direct_mode_capacity"`
 
 	// Average power budget in watts for NVM devices configured in BIOS.
 	AvgPowerBudget uint `json:"avg_power_budget"`

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -139,7 +139,7 @@ func GetMachineMemoryCapacity() (uint64, error) {
 	return memoryCapacity, err
 }
 
-// GetMachineMemoryByType returns information about memory capcity and number of DIMMs.
+// GetMachineMemoryByType returns information about memory capacity and number of DIMMs.
 // Information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/)
 // introduced in kernel 3.6. Documentation can be found at
 // https://www.kernel.org/doc/Documentation/admin-guide/ras.rst.

--- a/machine/machine_libipmctl.go
+++ b/machine/machine_libipmctl.go
@@ -85,7 +85,7 @@ func GetNVMInfo() (info.NVMInfo, error) {
 	defer C.nvm_uninit()
 
 	var err error
-	nvmInfo.MemoryModeCapcity, nvmInfo.AppDirectModeCapcity, err = getNVMCapacities()
+	nvmInfo.MemoryModeCapacity, nvmInfo.AppDirectModeCapacity, err = getNVMCapacities()
 	if err != nil {
 		return info.NVMInfo{}, fmt.Errorf("Unable to get NVM capacities, err: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Katarzyna Kujawa <katarzyna.kujawa@intel.com>