### PR TITLE
Build go-bindata in a tmpdir

### DIFF
--- a/build/assets.sh
+++ b/build/assets.sh
@@ -28,7 +28,10 @@ TEMPLATES_PACKAGE="pages"
 
 FORCE="${FORCE:-}" # Force assets to be rebuilt if FORCE=true
 
+# Install while in a temp dir to avoid polluting go.mod/go.sum
+pushd "${TMPDIR:-/tmp}" > /dev/null
 go get -u github.com/kevinburke/go-bindata/...
+popd > /dev/null
 
 build_asset () {
   local package=$1


### PR DESCRIPTION
Builds go-bindata in a tmp dir to avoid mutating the go.mod/go.sum file of this module

Split out of #2437 for separate review/merge

cc @dashpole