### PR TITLE
Avoid logging unnecessary errors from systemd handler

### DIFF
--- a/container/systemd/factory.go
+++ b/container/systemd/factory.go
@@ -42,7 +42,8 @@ func (f *systemdFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	if strings.HasSuffix(name, ".mount") {
 		return true, false, nil
 	}
-	return false, false, fmt.Errorf("%s not handled by systemd handler", name)
+	klog.V(5).Infof("%s not handled by systemd handler", name)
+	return false, false, nil
 }
 
 func (f *systemdFactory) DebugInfo() map[string][]string {


### PR DESCRIPTION
Just turn the message into a log that folks can see if they turn up the
logging level.

Fixes #2440

Signed-off-by: Davanum Srinivas <davanum@gmail.com>