### PR TITLE
Issue fix: get wrong machine info on Arm64 guest

### DIFF
--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -220,9 +220,12 @@ func GetNodesInfo(sysFs sysfs.SysFs) ([]info.Node, int, error) {
 		}
 
 		allLogicalCoresCount += len(cpuDirs)
+
+		// On some Linux platforms(such as Arm64 guest kernel), cache info may not exist.
+		// So, we should ignore error here.
 		err = addCacheInfo(sysFs, &node)
 		if err != nil {
-			return nil, 0, err
+			klog.Warningf("Found node without cache information, nodeDir: %s", nodeDir)
 		}
 
 		node.Memory, err = getNodeMemInfo(sysFs, nodeDir)
@@ -269,9 +272,11 @@ func getCPUTopology(sysFs sysfs.SysFs) ([]info.Node, int, error) {
 		}
 		node.Cores = cores
 
+		// On some Linux platforms(such as Arm64 guest kernel), cache info may not exist.
+		// So, we should ignore error here.
 		err = addCacheInfo(sysFs, &node)
 		if err != nil {
-			return nil, 0, err
+			klog.Warningf("Found cpu without cache information, cpuPath: %s", cpus)
 		}
 		nodes = append(nodes, node)
 	}


### PR DESCRIPTION
The latest kubernetes deployment on Arm64 VM-s(official ubuntu18.04) always fails.
Because k8s always get num_cores=0 from cAdvisor on Arm64 VM-s.

The reason is that, there is no cache info on Arm64 VM-s.
So the process of getMachineInfo was blocked by the step of getCacheInfo
on Arm64 guest.

And the good news is, we can get cache info on Arm64 hosts.

When this patch was merged, I will deliver a patch to update the version
of cAdvisor in kubernetes as soon as possible.

Signed-off-by: bblu <bin.lu@arm.com>