### PR TITLE
Workaround for not being able to call nvm_init() after nvm_uninit()

### DIFF
--- a/machine/info.go
+++ b/machine/info.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/nvm"
 	"github.com/google/cadvisor/utils/cloudinfo"
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/google/cadvisor/utils/sysinfo"
@@ -77,7 +78,7 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 		return nil, err
 	}
 
-	nvmInfo, err := GetNVMInfo()
+	nvmInfo, err := nvm.GetInfo()
 	if err != nil {
 		return nil, err
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -37,6 +37,7 @@ import (
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/machine"
+	"github.com/google/cadvisor/nvm"
 	"github.com/google/cadvisor/stats"
 	"github.com/google/cadvisor/utils/oomparser"
 	"github.com/google/cadvisor/utils/sysfs"
@@ -311,6 +312,7 @@ func (self *manager) Stop() error {
 		}
 	}
 	self.quitChannels = make([]chan error, 0, 2)
+	nvm.FinalizeLibimpctl()
 	return nil
 }
 

--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -14,26 +14,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package machine
+package nvm
 
 // #cgo pkg-config: libipmctl
 // #include <nvm_management.h>
+// #include <stdlib.h>
 import "C"
 import (
 	"fmt"
-
 	info "github.com/google/cadvisor/info/v1"
+	"sync"
 
 	"k8s.io/klog"
 )
 
-// getNVMAvgPowerBudget retrieves configured power budget
+var (
+	isNVMLibInitialized = false
+	nvmLibMutex         = sync.Mutex{}
+)
+
+func init() {
+	nvmLibMutex.Lock()
+	defer nvmLibMutex.Unlock()
+	cErr := C.nvm_init()
+	if cErr != C.NVM_SUCCESS {
+		// Unfortunately klog does not seem to work here. I believe it's better to
+		// output information using fmt rather then let it disappear silently.
+		fmt.Printf("libipmctl initialization failed with status %d", cErr)
+	}
+	isNVMLibInitialized = true
+}
+
+// getAvgPowerBudget retrieves configured power budget
 // (in watts) for NVM devices. When libipmct is not available
 // zero is returned.
-func getNVMAvgPowerBudget() (uint, error) {
+func getAvgPowerBudget() (uint, error) {
 	// Get number of devices on the platform
 	// see: https://github.com/intel/ipmctl/blob/v01.00.00.3497/src/os/nvm_api/nvm_management.h#L1478
-	var count C.uint
+	count := C.uint(0)
 	err := C.nvm_get_number_of_devices(&count)
 	if err != C.NVM_SUCCESS {
 		klog.Warningf("Unable to get number of NVM devices. Status code: %d", err)
@@ -42,7 +60,7 @@ func getNVMAvgPowerBudget() (uint, error) {
 
 	// Load basic device information for all the devices
 	// to obtain UID of the first one.
-	var devices = make([]C.struct_device_discovery, count)
+	devices := make([]C.struct_device_discovery, count, count)
 	err = C.nvm_get_devices(&devices[0], C.uchar(count))
 	if err != C.NVM_SUCCESS {
 		klog.Warningf("Unable to get all NVM devices. Status code: %d", err)
@@ -51,7 +69,7 @@ func getNVMAvgPowerBudget() (uint, error) {
 
 	// Power budget is same for all the devices
 	// so we can rely on any of them.
-	var device C.struct_device_details
+	device := C.struct_device_details{}
 	err = C.nvm_get_device_details(&devices[0].uid[0], &device)
 	if err != C.NVM_SUCCESS {
 		uid := C.GoString(&devices[0].uid[0])
@@ -62,37 +80,57 @@ func getNVMAvgPowerBudget() (uint, error) {
 	return uint(device.avg_power_budget / 1000), nil
 }
 
-// getNVMCapacities retrieves the total NVM capacity in bytes for memory mode and app direct mode
-func getNVMCapacities() (uint64, uint64, error) {
-	var caps C.struct_device_capacities
+// getCapacities retrieves the total NVM capacity in bytes for memory mode and app direct mode
+func getCapacities() (uint64, uint64, error) {
+	caps := C.struct_device_capacities{}
+	//capsMemory := C.malloc(C.ulong(unsafe.Sizeof(C.struct_device_capacities{})))
+	//defer C.free(capsMemory)
+	//caps := (*C.struct_device_capacities)(capsMemory)
+	klog.V(1).Infof("WTF? %#v", caps)
 	err := C.nvm_get_nvm_capacities(&caps)
 	if err != C.NVM_SUCCESS {
 		klog.Warningf("Unable to get NVM capacity. Status code: %d", err)
 		return uint64(0), uint64(0), fmt.Errorf("Unable to get NVM capacity. Status code: %d", err)
 	}
+	klog.V(1).Infof("FULL? %#v", caps)
 	return uint64(caps.memory_capacity), uint64(caps.app_direct_capacity), nil
 }
 
-// GetNVMInfo returns information specific for non-volatile memory modules
-func GetNVMInfo() (info.NVMInfo, error) {
+// GetInfo returns information specific for non-volatile memory modules
+func GetInfo() (info.NVMInfo, error) {
+	nvmLibMutex.Lock()
+	defer nvmLibMutex.Unlock()
+
 	nvmInfo := info.NVMInfo{}
-	// Initialize libipmctl library.
-	cErr := C.nvm_init()
-	if cErr != C.NVM_SUCCESS {
-		klog.Warningf("libipmctl initialization failed with status %d", cErr)
-		return info.NVMInfo{}, fmt.Errorf("libipmctl initialization failed with status %d", cErr)
+	if !isNVMLibInitialized {
+		klog.V(1).Info("libimpctl has not been initialized. NVM information will not be available")
+		return nvmInfo, nil
 	}
-	defer C.nvm_uninit()
 
 	var err error
-	nvmInfo.MemoryModeCapacity, nvmInfo.AppDirectModeCapacity, err = getNVMCapacities()
+	nvmInfo.MemoryModeCapacity, nvmInfo.AppDirectModeCapacity, err = getCapacities()
 	if err != nil {
 		return info.NVMInfo{}, fmt.Errorf("Unable to get NVM capacities, err: %s", err)
 	}
 
-	nvmInfo.AvgPowerBudget, err = getNVMAvgPowerBudget()
+	nvmInfo.AvgPowerBudget, err = getAvgPowerBudget()
 	if err != nil {
 		return info.NVMInfo{}, fmt.Errorf("Unable to get NVM average power budget, err: %s", err)
 	}
 	return nvmInfo, nil
+}
+
+// FinalizeLibimpctl un-initializes libipmctl. See https://github.com/google/cadvisor/issues/2457.
+func FinalizeLibimpctl() {
+	nvmLibMutex.Lock()
+	defer nvmLibMutex.Unlock()
+
+	klog.V(1).Info("Attempting to un-initialize libipmctl")
+	if !isNVMLibInitialized {
+		klog.V(1).Info("libipmctl has not been initialized; not un-initializing.")
+		return
+	}
+
+	C.nvm_uninit()
+	isNVMLibInitialized = false
 }

--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -18,7 +18,6 @@ package nvm
 
 // #cgo pkg-config: libipmctl
 // #include <nvm_management.h>
-// #include <stdlib.h>
 import "C"
 import (
 	"fmt"
@@ -83,16 +82,11 @@ func getAvgPowerBudget() (uint, error) {
 // getCapacities retrieves the total NVM capacity in bytes for memory mode and app direct mode
 func getCapacities() (uint64, uint64, error) {
 	caps := C.struct_device_capacities{}
-	//capsMemory := C.malloc(C.ulong(unsafe.Sizeof(C.struct_device_capacities{})))
-	//defer C.free(capsMemory)
-	//caps := (*C.struct_device_capacities)(capsMemory)
-	klog.V(1).Infof("WTF? %#v", caps)
 	err := C.nvm_get_nvm_capacities(&caps)
 	if err != C.NVM_SUCCESS {
 		klog.Warningf("Unable to get NVM capacity. Status code: %d", err)
 		return uint64(0), uint64(0), fmt.Errorf("Unable to get NVM capacity. Status code: %d", err)
 	}
-	klog.V(1).Infof("FULL? %#v", caps)
 	return uint64(caps.memory_capacity), uint64(caps.app_direct_capacity), nil
 }
 

--- a/nvm/machine_no_libipmctl.go
+++ b/nvm/machine_no_libipmctl.go
@@ -14,12 +14,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package machine
+package nvm
 
-import info "github.com/google/cadvisor/info/v1"
+import (
+	info "github.com/google/cadvisor/info/v1"
+	"k8s.io/klog"
+)
 
-// GetNVMInfo returns information specific for non-volatile memory modules.
-// When libipmct is not available zero value is returned.
-func GetNVMInfo() (info.NVMInfo, error) {
+// GetInfo returns information specific for non-volatile memory modules.
+// When libipmctl is not available zero value is returned.
+func GetInfo() (info.NVMInfo, error) {
 	return info.NVMInfo{}, nil
+}
+
+// FinalizeLibimpctl un-initializes libipmctl. See https://github.com/google/cadvisor/issues/2457.
+// When libipmctl is not available it just logs that it's being called.
+func FinalizeLibimpctl() {
+	klog.V(4).Info("libimpctl not available, doing nothing.")
 }


### PR DESCRIPTION
Fixes #2457.

Files have been moved from `machine` to `nvm` in order to break a cycle.