### PR TITLE
CRI-O client should check Unix Transport error

### DIFF
--- a/container/crio/client.go
+++ b/container/crio/client.go
@@ -71,7 +71,9 @@ func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 // Client returns a new configured CRI-O client
 func Client() (crioClient, error) {
 	tr := new(http.Transport)
-	configureUnixTransport(tr, "unix", CrioSocket)
+	if err := configureUnixTransport(tr, "unix", CrioSocket); err != nil {
+		return nil, err
+	}
 	c := &http.Client{
 		Transport: tr,
 	}


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

Currently the error return from configureUnixTransport is ignored for CRI-O client construction.

This PR checks the error return.