### PR TITLE
Populate IP address for cri-o release with dual stack support

### DIFF
--- a/container/crio/client.go
+++ b/container/crio/client.go
@@ -45,6 +45,7 @@ type ContainerInfo struct {
 	LogPath     string            `json:"log_path"`
 	Root        string            `json:"root"`
 	IP          string            `json:"ip_address"`
+	IPs         []string          `json:"ip_addresses"`
 }
 
 type crioClient interface {
@@ -117,6 +118,7 @@ func (c *crioClientImpl) ContainerInfo(id string) (*ContainerInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	cInfo := ContainerInfo{}
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -129,9 +131,14 @@ func (c *crioClientImpl) ContainerInfo(id string) (*ContainerInfo, error) {
 		return nil, fmt.Errorf("Error finding container %s: Status %d returned error %s", id, resp.StatusCode, resp.Body)
 	}
 
-	cInfo := ContainerInfo{}
 	if err := json.NewDecoder(resp.Body).Decode(&cInfo); err != nil {
 		return nil, err
+	}
+	if len(cInfo.IP) > 0 {
+		return &cInfo, nil
+	}
+	if len(cInfo.IPs) > 0 {
+		cInfo.IP = cInfo.IPs[0]
 	}
 	return &cInfo, nil
 }


### PR DESCRIPTION
Signed-off-by: Ted Yu <yuzhihong@gmail.com>

via commit 2f2e88c93931f678201ef65ffd80161b1072f5f8 :
  Add dual stack IPv6 support

cri-o may return multiple IPs:
```
-       IP              string            `json:"ip_address"`
+       IPs             []string          `json:"ip_addresses"`
```
This PR introduces an internal struct, containerInfoDualStack, to crio client.
If IP is not obtained by parsing with single IP struct, we try with parsing using containerInfoDualStack struct.