### PR TITLE
Check the error return from GetCPUPhysicalPackageID()

### DIFF
--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -282,7 +282,11 @@ func getCpusByPhysicalPackageID(sysFs sysfs.SysFs, cpusPaths []string) (map[int]
 	cpuPathsByPhysicalPackageID := make(map[int][]string, 0)
 	for _, cpuPath := range cpusPaths {
 
-		rawPhysicalPackageID, _ := sysFs.GetCPUPhysicalPackageID(cpuPath)
+		rawPhysicalPackageID, err := sysFs.GetCPUPhysicalPackageID(cpuPath)
+		if err != nil {
+			return nil, err
+		}
+
 		physicalPackageID, err := strconv.Atoi(rawPhysicalPackageID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR adds error return checking for GetCPUPhysicalPackageID().