### PR TITLE
Returning more error information from stats.Manager and stats.Collector

### DIFF
--- a/accelerators/nvidia.go
+++ b/accelerators/nvidia.go
@@ -53,15 +53,14 @@ func NewNvidiaManager() stats.Manager {
 }
 
 // Setup initializes NVML if nvidia devices are present on the node.
-func (nm *nvidiaManager) Setup() {
+func (nm *nvidiaManager) Setup() error {
 	if !detectDevices(nvidiaVendorId) {
-		klog.V(4).Info("No NVIDIA devices found.")
-		return
+		return fmt.Errorf("No NVIDIA devices found.")
 	}
 
 	nm.devicesPresent = true
 
-	initializeNVML(nm)
+	return initializeNVML(nm)
 }
 
 // detectDevices returns true if a device with given pci id is present on the node.
@@ -89,34 +88,34 @@ func detectDevices(vendorId string) bool {
 
 // initializeNVML initializes the NVML library and sets up the nvmlDevices map.
 // This is defined as a variable to help in testing.
-var initializeNVML = func(nm *nvidiaManager) {
+var initializeNVML = func(nm *nvidiaManager) error {
 	if err := gonvml.Initialize(); err != nil {
 		// This is under a logging level because otherwise we may cause
 		// log spam if the drivers/nvml is not installed on the system.
-		klog.V(4).Infof("Could not initialize NVML: %v", err)
-		return
+		return fmt.Errorf("Could not initialize NVML: %v", err)
 	}
 	nm.nvmlInitialized = true
 	numDevices, err := gonvml.DeviceCount()
 	if err != nil {
-		klog.Warningf("GPU metrics would not be available. Failed to get the number of nvidia devices: %v", err)
-		return
+		return fmt.Errorf("GPU metrics would not be available. Failed to get the number of nvidia devices: %v", err)
+	}
+	if numDevices == 0 {
+		return fmt.Errorf("no nvidia devices found")
 	}
 	klog.V(1).Infof("NVML initialized. Number of nvidia devices: %v", numDevices)
 	nm.nvidiaDevices = make(map[int]gonvml.Device, numDevices)
 	for i := 0; i < int(numDevices); i++ {
 		device, err := gonvml.DeviceHandleByIndex(uint(i))
 		if err != nil {
-			klog.Warningf("Failed to get nvidia device handle %d: %v", i, err)
-			continue
+			return fmt.Errorf("Failed to get nvidia device handle %d: %v", i, err)
 		}
 		minorNumber, err := device.MinorNumber()
 		if err != nil {
-			klog.Warningf("Failed to get nvidia device minor number: %v", err)
-			continue
+			return fmt.Errorf("Failed to get nvidia device minor number: %v", err)
 		}
 		nm.nvidiaDevices[int(minorNumber)] = device
 	}
+	return nil
 }
 
 // Destroy shuts down NVML.
@@ -131,28 +130,30 @@ func (nm *nvidiaManager) Destroy() {
 func (nm *nvidiaManager) GetCollector(devicesCgroupPath string) (stats.Collector, error) {
 	nc := &nvidiaCollector{}
 
-	if !nm.devicesPresent {
-		return nc, nil
+	if !nm.devicesPresent || len(nm.nvidiaDevices) == 0 {
+		return &stats.NoopCollector{}, nil
 	}
 	// Makes sure that we don't call initializeNVML() concurrently and
 	// that we only call initializeNVML() when it's not initialized.
 	nm.Lock()
 	if !nm.nvmlInitialized {
-		initializeNVML(nm)
-	}
-	if !nm.nvmlInitialized || len(nm.nvidiaDevices) == 0 {
-		nm.Unlock()
-		return nc, nil
+		err := initializeNVML(nm)
+		if err != nil {
+			nm.Unlock()
+			klog.Warningf("Unable to initialize NVML: %s", err)
+			return &stats.NoopCollector{}, nil
+		}
 	}
 	nm.Unlock()
 	nvidiaMinorNumbers, err := parseDevicesCgroup(devicesCgroupPath)
 	if err != nil {
-		return nc, err
+		return nil, err
 	}
+
 	for _, minor := range nvidiaMinorNumbers {
 		device, ok := nm.nvidiaDevices[minor]
 		if !ok {
-			return nc, fmt.Errorf("nvidia device minor number %d not found in cached devices", minor)
+			return &stats.NoopCollector{}, fmt.Errorf("nvidia device minor number %d not found in cached devices", minor)
 		}
 		nc.devices = append(nc.devices, device)
 	}
@@ -216,6 +217,8 @@ var parseDevicesCgroup = func(devicesCgroupPath string) ([]int, error) {
 type nvidiaCollector struct {
 	// Exposed for testing
 	devices []gonvml.Device
+
+	stats.NoopSetupDestroy
 }
 
 func NewNvidiaCollector(devices []gonvml.Device) stats.Collector {

--- a/accelerators/nvidia_test.go
+++ b/accelerators/nvidia_test.go
@@ -14,6 +14,7 @@
 package accelerators
 
 import (
+	"github.com/google/cadvisor/stats"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -72,7 +73,9 @@ func TestGetCollector(t *testing.T) {
 	}
 	parseDevicesCgroup = mockParser
 	originalInitializeNVML := initializeNVML
-	initializeNVML = func(_ *nvidiaManager) {}
+	initializeNVML = func(_ *nvidiaManager) error {
+		return nil
+	}
 	defer func() {
 		parseDevicesCgroup = originalParser
 		initializeNVML = originalInitializeNVML
@@ -84,27 +87,25 @@ func TestGetCollector(t *testing.T) {
 	ac, err := nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok := ac.(*nvidiaCollector)
+	_, ok := ac.(*stats.NoopCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.devices))
 
 	// When nvmlInitialized is false, empty collector should be returned.
 	nm.devicesPresent = true
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*nvidiaCollector)
+	_, ok = ac.(*stats.NoopCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.devices))
 
 	// When nvidiaDevices is empty, empty collector should be returned.
 	nm.nvmlInitialized = true
+	nm.nvidiaDevices = map[int]gonvml.Device{}
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*nvidiaCollector)
+	_, ok = ac.(*stats.NoopCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.devices))
 
 	// nvidiaDevices contains devices but they are different than what
 	// is returned by parseDevicesCgroup. We should get an error.
@@ -112,9 +113,8 @@ func TestGetCollector(t *testing.T) {
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.NotNil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*nvidiaCollector)
+	_, ok = ac.(*stats.NoopCollector)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(nc.devices))
 
 	// nvidiaDevices contains devices returned by parseDevicesCgroup.
 	// No error should be returned and collectors devices array should be
@@ -124,7 +124,7 @@ func TestGetCollector(t *testing.T) {
 	ac, err = nm.GetCollector("does-not-matter")
 	assert.Nil(t, err)
 	assert.NotNil(t, ac)
-	nc, ok = ac.(*nvidiaCollector)
+	nc, ok := ac.(*nvidiaCollector)
 	assert.True(t, ok)
 	assert.Equal(t, 2, len(nc.devices))
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -268,7 +268,7 @@ func (self *manager) Start() error {
 	if err != nil {
 		// We intentionally do nothing here. If Setup() fails then GetCollector()
 		// will return stats.NoopCollector
-		klog.Warningf("Setting up nvidia manager failed: %s", err)
+		klog.Warningf("NVidia GPU metrics will not be available: %s", err)
 	}
 
 	// Create root and then recover all containers.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -264,7 +264,12 @@ func (self *manager) Start() error {
 	}
 
 	// Setup collection of nvidia GPU metrics if any of them are attached to the machine.
-	self.nvidiaManager.Setup()
+	err = self.nvidiaManager.Setup()
+	if err != nil {
+		// We intentionally do nothing here. If Setup() fails then GetCollector()
+		// will return stats.NoopCollector
+		klog.Warningf("Setting up nvidia manager failed: %s", err)
+	}
 
 	// Create root and then recover all containers.
 	err = self.createContainer("/", watcher.Raw)

--- a/stats/noop.go
+++ b/stats/noop.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Noop perf Manager and Collector.
+package stats
+
+import (
+	v1 "github.com/google/cadvisor/info/v1"
+	"k8s.io/klog"
+)
+
+type NoopManager struct {
+	NoopSetupDestroy
+}
+
+type NoopSetupDestroy struct{}
+
+func (nsd NoopSetupDestroy) Setup() error {
+	klog.V(5).Info("No-op Destroy function called")
+	return nil
+}
+
+func (nsd NoopSetupDestroy) Destroy() {
+	klog.V(5).Info("No-op Destroy function called")
+}
+
+func (m *NoopManager) GetCollector(cgroup string) (Collector, error) {
+	return &NoopCollector{}, nil
+}
+
+type NoopCollector struct {
+	NoopSetupDestroy
+}
+
+func (c *NoopCollector) UpdateStats(stats *v1.ContainerStats) error {
+	return nil
+}

--- a/stats/types.go
+++ b/stats/types.go
@@ -24,12 +24,14 @@ import info "github.com/google/cadvisor/info/v1"
 // GetCollector() is supposed to return an object that can update
 // accelerator stats for that container.
 type Manager interface {
-	Setup()
+	Setup() error
 	Destroy()
 	GetCollector(deviceCgroup string) (Collector, error)
 }
 
 // Collector can update ContainerStats by adding more metrics.
 type Collector interface {
+	Setup() error
+	Destroy()
 	UpdateStats(*info.ContainerStats) error
 }


### PR DESCRIPTION
@dashpole I would appreciate if you took a look - I need these changes to proceed with #2419.

Not changed:
* when `nil` and real `error` are returned.

Changed:
* `stats.NoopCollector` might be returned sometimes.
* `stats.Manager.Setup()` may return an error
* `stats.Collector.Setup()` may return an error