### PR TITLE
Add missing fields to ContainerSpec#Eq

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -202,7 +202,13 @@ func (self *ContainerSpec) Eq(b *ContainerSpec) bool {
 	if !reflect.DeepEqual(self.Memory, b.Memory) {
 		return false
 	}
+	if self.HasHugetlb != b.HasHugetlb {
+		return false
+	}
 	if self.HasNetwork != b.HasNetwork {
+		return false
+	}
+	if self.HasProcesses != b.HasProcesses {
 		return false
 	}
 	if self.HasFilesystem != b.HasFilesystem {
@@ -212,6 +218,9 @@ func (self *ContainerSpec) Eq(b *ContainerSpec) bool {
 		return false
 	}
 	if self.HasCustomMetrics != b.HasCustomMetrics {
+		return false
+	}
+	if self.Image != b.Image {
 		return false
 	}
 	return true


### PR DESCRIPTION
There were some recently added fields of ContainerSpec missing in Eq().

This PR adds them.