### PR TITLE
Make a copy of MachineInfo in GetMachineInfo()

### DIFF
--- a/machine/topology_test.go
+++ b/machine/topology_test.go
@@ -252,32 +252,13 @@ func TestTopologyWithoutNodes(t *testing.T) {
 	assert.Equal(t, 2, len(topology))
 	assert.Equal(t, 4, numCores)
 
-	topologyJSON, err := json.Marshal(topology)
+	topologyJSON1, err := json.Marshal(topology[0])
+	assert.Nil(t, err)
+	topologyJSON2, err := json.Marshal(topology[1])
 	assert.Nil(t, err)
 
-	expectedTopology := `[
-		{
-			"node_id":0,
-			"memory":0,
-			"hugepages":null,
-			"cores":[
-				{
-					"core_id":0,
-					"thread_ids":[
-					0,
-					2
-					],
-					"caches":[
-					{
-						"size":32768,
-						"type":"unified",
-						"level":0
-					}
-					]
-				}
-			],
-			"caches":null
-		},
+	expectedTopology1 := `{"node_id":0,"memory":0,"hugepages":null,"cores":[{"core_id":0,"thread_ids":[0,2],"caches":[{"size":32768,"type":"unified","level":0}]}],"caches":null}`
+	expectedTopology2 := `
 		{
 			"node_id":1,
 			"memory":0,
@@ -299,9 +280,16 @@ func TestTopologyWithoutNodes(t *testing.T) {
 				}
 			],
 			"caches":null
-		}
-	]`
-	assert.JSONEq(t, expectedTopology, string(topologyJSON))
+		}`
+
+	json1 := string(topologyJSON1)
+	json2 := string(topologyJSON2)
+	if expectedTopology1 == json1 {
+		assert.JSONEq(t, expectedTopology2, json2)
+	} else {
+		assert.JSONEq(t, expectedTopology2, json1)
+		assert.JSONEq(t, expectedTopology1, json2)
+	}
 }
 
 func TestTopologyWithNodesWithoutCPU(t *testing.T) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -793,7 +793,27 @@ func (m *manager) GetMachineInfo() (*info.MachineInfo, error) {
 	m.machineMu.RLock()
 	defer m.machineMu.RUnlock()
 	// Copy and return the MachineInfo.
-	return &m.machineInfo, nil
+	copy := info.MachineInfo{
+		NumCores:         m.machineInfo.NumCores,
+		NumPhysicalCores: m.machineInfo.NumPhysicalCores,
+		NumSockets:       m.machineInfo.NumSockets,
+		CpuFrequency:     m.machineInfo.CpuFrequency,
+		MemoryCapacity:   m.machineInfo.MemoryCapacity,
+		MemoryByType:     m.machineInfo.MemoryByType,
+		NVMInfo:          m.machineInfo.NVMInfo,
+		HugePages:        m.machineInfo.HugePages,
+		MachineID:        m.machineInfo.MachineID,
+		SystemUUID:       m.machineInfo.SystemUUID,
+		BootID:           m.machineInfo.BootID,
+		Filesystems:      m.machineInfo.Filesystems,
+		DiskMap:          m.machineInfo.DiskMap,
+		NetworkDevices:   m.machineInfo.NetworkDevices,
+		Topology:         m.machineInfo.Topology,
+		CloudProvider:    m.machineInfo.CloudProvider,
+		InstanceType:     m.machineInfo.InstanceType,
+		InstanceID:       m.machineInfo.InstanceID,
+	}
+	return &copy, nil
 }
 
 func (m *manager) GetVersionInfo() (*info.VersionInfo, error) {


### PR DESCRIPTION
Fixes #2487

The data race was due to manager.machineInfo being read after manager#GetMachineInfo() returns.

This PR makes a copy of MachineInfo and returns the pointer to the copy.