### PR TITLE
Make a copy of the maps of MachineInfo

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -211,6 +211,44 @@ type MachineInfo struct {
 	InstanceID InstanceID `json:"instance_id"`
 }
 
+func (m *MachineInfo) Clone() *MachineInfo {
+	memoryByType := m.MemoryByType
+	if len(m.MemoryByType) > 0 {
+		memoryByType = make(map[string]*MemoryInfo)
+		for memoryType, memoryInfo := range m.MemoryByType {
+			memoryByType[memoryType] = memoryInfo
+		}
+	}
+	diskMap := m.DiskMap
+	if len(m.DiskMap) > 0 {
+		diskMap = make(map[string]DiskInfo)
+		for k, info := range m.DiskMap {
+			diskMap[k] = info
+		}
+	}
+	copy := MachineInfo{
+		NumCores:         m.NumCores,
+		NumPhysicalCores: m.NumPhysicalCores,
+		NumSockets:       m.NumSockets,
+		CpuFrequency:     m.CpuFrequency,
+		MemoryCapacity:   m.MemoryCapacity,
+		MemoryByType:     memoryByType,
+		NVMInfo:          m.NVMInfo,
+		HugePages:        m.HugePages,
+		MachineID:        m.MachineID,
+		SystemUUID:       m.SystemUUID,
+		BootID:           m.BootID,
+		Filesystems:      m.Filesystems,
+		DiskMap:          diskMap,
+		NetworkDevices:   m.NetworkDevices,
+		Topology:         m.Topology,
+		CloudProvider:    m.CloudProvider,
+		InstanceType:     m.InstanceType,
+		InstanceID:       m.InstanceID,
+	}
+	return &copy
+}
+
 type MemoryInfo struct {
 	// The amount of memory (in bytes).
 	Capacity uint64 `json:"capacity"`

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -792,28 +792,7 @@ func (self *manager) GetFsInfo(label string) ([]v2.FsInfo, error) {
 func (m *manager) GetMachineInfo() (*info.MachineInfo, error) {
 	m.machineMu.RLock()
 	defer m.machineMu.RUnlock()
-	// Copy and return the MachineInfo.
-	copy := info.MachineInfo{
-		NumCores:         m.machineInfo.NumCores,
-		NumPhysicalCores: m.machineInfo.NumPhysicalCores,
-		NumSockets:       m.machineInfo.NumSockets,
-		CpuFrequency:     m.machineInfo.CpuFrequency,
-		MemoryCapacity:   m.machineInfo.MemoryCapacity,
-		MemoryByType:     m.machineInfo.MemoryByType,
-		NVMInfo:          m.machineInfo.NVMInfo,
-		HugePages:        m.machineInfo.HugePages,
-		MachineID:        m.machineInfo.MachineID,
-		SystemUUID:       m.machineInfo.SystemUUID,
-		BootID:           m.machineInfo.BootID,
-		Filesystems:      m.machineInfo.Filesystems,
-		DiskMap:          m.machineInfo.DiskMap,
-		NetworkDevices:   m.machineInfo.NetworkDevices,
-		Topology:         m.machineInfo.Topology,
-		CloudProvider:    m.machineInfo.CloudProvider,
-		InstanceType:     m.machineInfo.InstanceType,
-		InstanceID:       m.machineInfo.InstanceID,
-	}
-	return &copy, nil
+	return m.machineInfo.Clone(), nil
 }
 
 func (m *manager) GetVersionInfo() (*info.VersionInfo, error) {


### PR DESCRIPTION
For manager#GetMachineInfo(), we should duplicate the maps inside MachineInfo when copying.

This completes #2490