### PR TITLE
Go version must be passed to docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,22 +24,20 @@ jobs:
   test-integration:
     strategy:
       matrix:
-        go-versions: [1.13.x, 1.14.x]
+        go-versions: [1.13, 1.14]
         platform: [ubuntu-latest]
         environment-variables: [build/config/plain.sh, build/config/libpfm4.sh]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
           path: go/src/github.com/google/cadvisor
       - name: Run integration tests
+        env:
+          GOLANG_VERSION: ${{ matrix.go-versions }}
         run: |
           cd $GITHUB_WORKSPACE/go/src/github.com/google/cadvisor && source ${{ matrix.environment-variables }} && make docker-test-integration
       - name: Upload cAdvisor log file

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -40,7 +40,7 @@ function run_tests() {
   docker run --rm \
     -w /go/src/github.com/google/cadvisor \
     -v ${PWD}:/go/src/github.com/google/cadvisor \
-    golang:1.13 \
+    golang:"$GOLANG_VERSION" \
     bash -c "$BUILD_CMD"
 
   EXTRA_DOCKER_OPTS="-e DOCKER_IN_DOCKER_ENABLED=true"
@@ -65,4 +65,5 @@ GO_FLAGS=${GO_FLAGS:-"-tags=netgo -race"}
 PACKAGES=${PACKAGES:-"sudo"}
 BUILD_PACKAGES=${BUILD_PACKAGES:-}
 CADVISOR_ARGS=${CADVISOR_ARGS:-}
+GOLANG_VERSION=${GOLANG_VERSION:-"1.14"}
 run_tests "$GO_FLAGS" "$PACKAGES" "$BUILD_PACKAGES" "$CADVISOR_ARGS"


### PR DESCRIPTION
Instead of installing requested Go version in a VM we should use proper version of container image.