### PR TITLE
golanci-lint based cleanup

### DIFF
--- a/accelerators/nvidia.go
+++ b/accelerators/nvidia.go
@@ -128,7 +128,10 @@ var initializeNVML = func(nm *nvidiaManager) error {
 // Destroy shuts down NVML.
 func (nm *nvidiaManager) Destroy() {
 	if nm.nvmlInitialized {
-		gonvml.Shutdown()
+		err := gonvml.Shutdown()
+		if err != nil {
+			klog.Warningf("nvml library shutdown failed: %s", err)
+		}
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,6 +27,8 @@ import (
 
 	info "github.com/google/cadvisor/info/v1"
 	itest "github.com/google/cadvisor/info/v1/test"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func cadvisorTestClient(path string, expectedPostObj *info.ContainerInfoRequest, replyObj interface{}, t *testing.T) (*Client, *httptest.Server, error) {
@@ -45,7 +47,8 @@ func cadvisorTestClient(path string, expectedPostObj *info.ContainerInfoRequest,
 				}
 			}
 			encoder := json.NewEncoder(w)
-			encoder.Encode(replyObj)
+			err := encoder.Encode(replyObj)
+			assert.NoError(t, err)
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprintf(w, "Page not found.")

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -45,7 +45,8 @@ func cadvisorTestClient(path string, expectedPostObj *v1.ContainerInfoRequest, r
 				}
 			}
 			encoder := json.NewEncoder(w)
-			encoder.Encode(replyObj)
+			err := encoder.Encode(replyObj)
+			assert.NoError(t, err)
 		} else if r.URL.Path == "/api/v2.1/version" {
 			fmt.Fprintf(w, "0.1.2")
 		} else {

--- a/collector/prometheus_collector.go
+++ b/collector/prometheus_collector.go
@@ -209,7 +209,7 @@ func prometheusLabelSetToCadvisorLabel(promLabels model.Metric) string {
 		b.WriteString(l.GetValue())
 	}
 
-	return string(b.Bytes())
+	return b.String()
 }
 
 // Returns collected metrics and the next collection time of the collector

--- a/collector/prometheus_collector_test.go
+++ b/collector/prometheus_collector_test.go
@@ -33,6 +33,7 @@ func TestPrometheus(t *testing.T) {
 
 	// Create a prometheus collector using the config file 'sample_config_prometheus.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus.json")
+	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
@@ -116,6 +117,7 @@ func TestPrometheusEndpointConfig(t *testing.T) {
 
 	//Create a prometheus collector using the config file 'sample_config_prometheus.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus_endpoint_config.json")
+	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
 	containerHandler.On("GetContainerIPAddress").Return(
 		"222.222.222.222",
@@ -132,6 +134,7 @@ func TestPrometheusShortResponse(t *testing.T) {
 
 	// Create a prometheus collector using the config file 'sample_config_prometheus.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus.json")
+	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
@@ -155,6 +158,7 @@ func TestPrometheusMetricCountLimit(t *testing.T) {
 
 	// Create a prometheus collector using the config file 'sample_config_prometheus.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus.json")
+	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 10, containerHandler, http.DefaultClient)
 	assert.NoError(err)
@@ -184,6 +188,7 @@ func TestPrometheusFiltersMetrics(t *testing.T) {
 
 	// Create a prometheus collector using the config file 'sample_config_prometheus_filtered.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus_filtered.json")
+	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
@@ -223,6 +228,7 @@ func TestPrometheusFiltersMetricsCountLimit(t *testing.T) {
 
 	// Create a prometheus collector using the config file 'sample_config_prometheus_filtered.json'
 	configFile, err := ioutil.ReadFile("config/sample_config_prometheus_filtered.json")
+	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
 	_, err = NewPrometheusCollector("Prometheus", configFile, 1, containerHandler, http.DefaultClient)
 	assert.Error(err)

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -43,7 +43,6 @@ func TestHandler(t *testing.T) {
 		inHostNamespace    bool
 		metadataEnvs       []string
 		includedMetrics    container.MetricSet
-		storageDir         string
 
 		hasErr         bool
 		errContains    string
@@ -67,7 +66,6 @@ func TestHandler(t *testing.T) {
 			false,
 			nil,
 			nil,
-			"",
 			true,
 			"unable to find container \"40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9\"",
 			nil,
@@ -81,7 +79,6 @@ func TestHandler(t *testing.T) {
 			false,
 			nil,
 			nil,
-			"",
 			false,
 			"",
 			&info.ContainerReference{

--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -17,7 +17,6 @@ package crio
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -105,7 +104,6 @@ func newCrioContainerHandler(
 	rootFs := "/"
 	if !inHostNamespace {
 		rootFs = "/rootfs"
-		storageDir = path.Join(rootFs, storageDir)
 	}
 
 	id := ContainerNameToCrioId(name)

--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -187,7 +187,7 @@ func processLimitsFile(fileData string) []info.UlimitSpec {
 		if strings.HasPrefix(lim, "Max") {
 
 			// Line format: Max open files            16384                16384                files
-			fields := regexp.MustCompile("[\\s]{2,}").Split(lim, -1)
+			fields := regexp.MustCompile(`[\s]{2,}`).Split(lim, -1)
 			name := strings.Replace(strings.ToLower(strings.TrimSpace(fields[0])), " ", "_", -1)
 
 			found := isUlimitWhitelisted(name)

--- a/container/libcontainer/helpers_test.go
+++ b/container/libcontainer/helpers_test.go
@@ -90,7 +90,7 @@ func TestGetCgroupSubsystems(t *testing.T) {
 		},
 		{
 			// most subsystems not mounted
-			mounts: append(cgroupMountsAt("/sys/fs/cgroup", []string{"cpu"})),
+			mounts: cgroupMountsAt("/sys/fs/cgroup", []string{"cpu"}),
 			expected: CgroupSubsystems{
 				MountPoints: map[string]string{
 					"cpu": "/sys/fs/cgroup/cpu",

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -200,8 +200,7 @@ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 		}
 	} else if self.includedMetrics.Has(container.DiskUsageMetrics) || self.includedMetrics.Has(container.DiskIOMetrics) {
 		if len(self.externalMounts) > 0 {
-			var mountSet map[string]struct{}
-			mountSet = make(map[string]struct{})
+			mountSet := make(map[string]struct{})
 			for _, mount := range self.externalMounts {
 				mountSet[mount.HostDir] = struct{}{}
 			}

--- a/devicemapper/thin_pool_watcher.go
+++ b/devicemapper/thin_pool_watcher.go
@@ -135,7 +135,10 @@ func (w *ThinPoolWatcher) Refresh() error {
 
 	defer func() {
 		klog.V(5).Infof("releasing metadata snapshot for thin-pool %v", w.poolName)
-		w.dmsetup.Message(w.poolName, 0, releaseMetadataMessage)
+		_, err := w.dmsetup.Message(w.poolName, 0, releaseMetadataMessage)
+		if err != nil {
+			klog.Warningf("Unable to release metadata snapshot for thin-pool %v: %s", w.poolName, err)
+		}
 	}()
 
 	klog.V(5).Infof("running thin_ls on metadata device %v", w.metadataDevice)

--- a/events/handler.go
+++ b/events/handler.go
@@ -150,7 +150,7 @@ func DefaultStoragePolicy() StoragePolicy {
 // returns a pointer to an initialized Events object.
 func NewEventManager(storagePolicy StoragePolicy) *events {
 	return &events{
-		eventStore:    make(map[info.EventType]*utils.TimedStore, 0),
+		eventStore:    make(map[info.EventType]*utils.TimedStore),
 		watchers:      make(map[int]*watch),
 		storagePolicy: storagePolicy,
 	}
@@ -196,7 +196,7 @@ func getMaxEventsReturned(request *Request, eSlice []*info.Event) []*info.Event 
 // it checks that the container paths of the event and request are
 // equivalent
 func checkIfIsSubcontainer(request *Request, event *info.Event) bool {
-	if request.IncludeSubcontainers == true {
+	if request.IncludeSubcontainers {
 		return request.ContainerName == "/" || strings.HasPrefix(event.ContainerName+"/", request.ContainerName+"/")
 	}
 	return event.ContainerName == request.ContainerName

--- a/events/handler_test.go
+++ b/events/handler_test.go
@@ -121,8 +121,10 @@ func TestWatchEventsDetectsNewEvents(t *testing.T) {
 	returnEventChannel, err := myEventHolder.WatchEvents(myRequest)
 	assert.Nil(t, err)
 
-	myEventHolder.AddEvent(fakeEvent)
-	myEventHolder.AddEvent(fakeEvent2)
+	err = myEventHolder.AddEvent(fakeEvent)
+	assert.NoError(t, err)
+	err = myEventHolder.AddEvent(fakeEvent2)
+	assert.NoError(t, err)
 
 	startTime := time.Now()
 	go func() {
@@ -149,8 +151,9 @@ func TestWatchEventsDetectsNewEvents(t *testing.T) {
 func TestAddEventAddsEventsToEventManager(t *testing.T) {
 	myEventHolder, _, fakeEvent, _ := initializeScenario(t)
 
-	myEventHolder.AddEvent(fakeEvent)
+	err := myEventHolder.AddEvent(fakeEvent)
 
+	assert.NoError(t, err)
 	checkNumberOfEvents(t, 1, len(myEventHolder.eventStore))
 	ensureProperEventReturned(t, fakeEvent, myEventHolder.eventStore[info.EventOom].Get(0).(*info.Event))
 }
@@ -160,8 +163,10 @@ func TestGetEventsForOneEvent(t *testing.T) {
 	myRequest.MaxEventsReturned = 1
 	myRequest.EventType[info.EventOom] = true
 
-	myEventHolder.AddEvent(fakeEvent)
-	myEventHolder.AddEvent(fakeEvent2)
+	err := myEventHolder.AddEvent(fakeEvent)
+	assert.NoError(t, err)
+	err = myEventHolder.AddEvent(fakeEvent2)
+	assert.NoError(t, err)
 
 	receivedEvents, err := myEventHolder.GetEvents(myRequest)
 	assert.Nil(t, err)
@@ -175,8 +180,10 @@ func TestGetEventsForTimePeriod(t *testing.T) {
 	myRequest.EndTime = time.Now().Add(time.Second * 10)
 	myRequest.EventType[info.EventOom] = true
 
-	myEventHolder.AddEvent(fakeEvent)
-	myEventHolder.AddEvent(fakeEvent2)
+	err := myEventHolder.AddEvent(fakeEvent)
+	assert.NoError(t, err)
+	err = myEventHolder.AddEvent(fakeEvent2)
+	assert.NoError(t, err)
 
 	receivedEvents, err := myEventHolder.GetEvents(myRequest)
 	assert.Nil(t, err)
@@ -188,8 +195,10 @@ func TestGetEventsForTimePeriod(t *testing.T) {
 func TestGetEventsForNoTypeRequested(t *testing.T) {
 	myEventHolder, myRequest, fakeEvent, fakeEvent2 := initializeScenario(t)
 
-	myEventHolder.AddEvent(fakeEvent)
-	myEventHolder.AddEvent(fakeEvent2)
+	err := myEventHolder.AddEvent(fakeEvent)
+	assert.NoError(t, err)
+	err = myEventHolder.AddEvent(fakeEvent2)
+	assert.NoError(t, err)
 
 	receivedEvents, err := myEventHolder.GetEvents(myRequest)
 	assert.Nil(t, err)

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -727,14 +727,6 @@ func getZfstats(poolName string) (uint64, uint64, uint64, error) {
 	return total, dataset.Avail, dataset.Avail, nil
 }
 
-// Simple io.Writer implementation that counts how many bytes were written.
-type byteCounter struct{ bytesWritten uint64 }
-
-func (b *byteCounter) Write(p []byte) (int, error) {
-	b.bytesWritten += uint64(len(p))
-	return len(p), nil
-}
-
 // Get major and minor Ids for a mount point using btrfs as filesystem.
 func getBtrfsMajorMinorIds(mount *mount.MountInfo) (int, int, error) {
 	// btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -109,8 +109,8 @@ func NewFsInfo(context Context) (FsInfo, error) {
 	excluded := []string{fmt.Sprintf("%s/devicemapper/mnt", context.Docker.Root)}
 	fsInfo := &RealFsInfo{
 		partitions:         processMounts(mounts, excluded),
-		labels:             make(map[string]string, 0),
-		mounts:             make(map[string]mount.MountInfo, 0),
+		labels:             make(map[string]string),
+		mounts:             make(map[string]mount.MountInfo),
 		dmsetup:            devicemapper.NewDmsetupClient(),
 		fsUUIDToDeviceName: fsUUIDToDeviceName,
 	}
@@ -163,7 +163,7 @@ func getFsUUIDToDeviceNameMap() (map[string]string, error) {
 }
 
 func processMounts(mounts []mount.MountInfo, excludedMountpointPrefixes []string) map[string]partition {
-	partitions := make(map[string]partition, 0)
+	partitions := make(map[string]partition)
 
 	supportedFsType := map[string]bool{
 		// all ext systems are checked through prefix.

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -984,9 +984,9 @@ type EventType string
 
 const (
 	EventOom               EventType = "oom"
-	EventOomKill                     = "oomKill"
-	EventContainerCreation           = "containerCreation"
-	EventContainerDeletion           = "containerDeletion"
+	EventOomKill           EventType = "oomKill"
+	EventContainerCreation EventType = "containerCreation"
+	EventContainerDeletion EventType = "containerDeletion"
 )
 
 // Extra information about an event. Only one type will be set.

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -907,10 +907,7 @@ func timeEq(t1, t2 time.Time, tolerance time.Duration) bool {
 		t1, t2 = t2, t1
 	}
 	diff := t2.Sub(t1)
-	if diff <= tolerance {
-		return true
-	}
-	return false
+	return diff <= tolerance
 }
 
 const (

--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -138,9 +138,9 @@ type CloudProvider string
 
 const (
 	GCE             CloudProvider = "GCE"
-	AWS                           = "AWS"
-	Azure                         = "Azure"
-	UnknownProvider               = "Unknown"
+	AWS             CloudProvider = "AWS"
+	Azure           CloudProvider = "Azure"
+	UnknownProvider CloudProvider = "Unknown"
 )
 
 type InstanceType string

--- a/integration/tests/api/machine_test.go
+++ b/integration/tests/api/machine_test.go
@@ -43,7 +43,7 @@ func TestMachineInformationIsReturned(t *testing.T) {
 		if fs.Device == "" {
 			t.Errorf("Expected a non-empty device name in: %+v", fs)
 		}
-		if fs.Capacity >= (1<<60 /* 1 EB*/) {
+		if fs.Capacity >= (1 << 60 /* 1 EB*/) {
 			t.Errorf("Unexpected capacity in device %q: %v", fs.Device, fs.Capacity)
 		}
 		if fs.Type == "" {

--- a/integration/tests/api/machine_test.go
+++ b/integration/tests/api/machine_test.go
@@ -43,7 +43,7 @@ func TestMachineInformationIsReturned(t *testing.T) {
 		if fs.Device == "" {
 			t.Errorf("Expected a non-empty device name in: %+v", fs)
 		}
-		if fs.Capacity < 0 || fs.Capacity >= (1<<60 /* 1 EB*/) {
+		if fs.Capacity >= (1<<60 /* 1 EB*/) {
 			t.Errorf("Unexpected capacity in device %q: %v", fs.Device, fs.Capacity)
 		}
 		if fs.Type == "" {

--- a/manager/container_test.go
+++ b/manager/container_test.go
@@ -237,7 +237,10 @@ func TestOnDemandHousekeeping(t *testing.T) {
 
 	cd, mockHandler, memoryCache, fakeClock := newTestContainerData(t)
 	mockHandler.On("GetStats").Return(stats, nil)
-	defer cd.Stop()
+	defer func() {
+		err := cd.Stop()
+		assert.NoError(t, err)
+	}()
 
 	// 0 seconds should always trigger an update
 	go cd.OnDemandHousekeeping(0 * time.Second)
@@ -261,7 +264,10 @@ func TestConcurrentOnDemandHousekeeping(t *testing.T) {
 
 	cd, mockHandler, memoryCache, fakeClock := newTestContainerData(t)
 	mockHandler.On("GetStats").Return(stats, nil)
-	defer cd.Stop()
+	defer func() {
+		err := cd.Stop()
+		assert.NoError(t, err)
+	}()
 
 	numConcurrentCalls := 5
 	var waitForHousekeeping sync.WaitGroup
@@ -303,7 +309,8 @@ func TestOnDemandHousekeepingReturnsAfterStopped(t *testing.T) {
 
 	fakeClock.Step(2 * time.Second)
 
-	cd.Stop()
+	err := cd.Stop()
+	assert.NoError(t, err)
 	// housekeeping tick should detect stop and not store any more metrics
 	assert.False(t, cd.housekeepingTick(fakeClock.NewTimer(time.Minute).C(), testLongHousekeeping))
 	fakeClock.Step(1 * time.Second)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -682,7 +682,7 @@ func (self *manager) getRequestedContainers(containerName string, options v2.Req
 	containersMap := make(map[string]*containerData)
 	switch options.IdType {
 	case v2.TypeName:
-		if options.Recursive == false {
+		if !options.Recursive {
 			cont, err := self.getContainer(containerName)
 			if err != nil {
 				return containersMap, err
@@ -695,7 +695,7 @@ func (self *manager) getRequestedContainers(containerName string, options v2.Req
 			}
 		}
 	case v2.TypeDocker:
-		if options.Recursive == false {
+		if !options.Recursive {
 			containerName = strings.TrimPrefix(containerName, "/")
 			cont, err := self.getDockerContainer(containerName)
 			if err != nil {
@@ -812,10 +812,7 @@ func (m *manager) Exists(containerName string) bool {
 	}
 
 	_, ok := m.containers[namespacedName]
-	if ok {
-		return true
-	}
-	return false
+	return ok
 }
 
 func (m *manager) GetProcessList(containerName string, options v2.RequestOptions) ([]v2.ProcessInfo, error) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -869,35 +869,6 @@ func (m *manager) registerCollectors(collectorConfigs map[string]string, cont *c
 	return nil
 }
 
-// Enables overwriting an existing containerData/Handler object for a given containerName.
-// Can't use createContainer as it just returns if a given containerName has a handler already.
-// Ex: rkt handler will want to take priority over the raw handler, but the raw handler might be created first.
-
-// Only allow raw handler to be overridden
-func (m *manager) overrideContainer(containerName string, watchSource watcher.ContainerWatchSource) error {
-	m.containersLock.Lock()
-	defer m.containersLock.Unlock()
-
-	namespacedName := namespacedContainerName{
-		Name: containerName,
-	}
-
-	if _, ok := m.containers[namespacedName]; ok {
-		containerData := m.containers[namespacedName]
-
-		if containerData.handler.Type() != container.ContainerTypeRaw {
-			return nil
-		}
-
-		err := m.destroyContainerLocked(containerName)
-		if err != nil {
-			return fmt.Errorf("overrideContainer: failed to destroy containerData/handler for %v: %v", containerName, err)
-		}
-	}
-
-	return m.createContainerLocked(containerName, watchSource)
-}
-
 // Create a container.
 func (m *manager) createContainer(containerName string, watchSource watcher.ContainerWatchSource) error {
 	m.containersLock.Lock()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -363,10 +363,10 @@ func (self *manager) globalHousekeeping(quit chan error) {
 		longHousekeeping = *globalHousekeepingInterval / 2
 	}
 
-	ticker := time.Tick(*globalHousekeepingInterval)
+	ticker := time.NewTicker(*globalHousekeepingInterval)
 	for {
 		select {
-		case t := <-ticker:
+		case t := <-ticker.C:
 			start := time.Now()
 
 			// Check for new containers.

--- a/metrics/prometheus_machine_test.go
+++ b/metrics/prometheus_machine_test.go
@@ -40,7 +40,7 @@ func TestPrometheusMachineCollector(t *testing.T) {
 		_, err := expfmt.MetricFamilyToText(&metricBuffer, metricFamily)
 		assert.Nil(t, err)
 	}
-	collectedMetrics := string(metricBuffer.Bytes())
+	collectedMetrics := metricBuffer.String()
 	expectedMetrics, err := ioutil.ReadFile(machineMetricsFile)
 	assert.Nil(t, err)
 	assert.Equal(t, string(expectedMetrics), collectedMetrics)
@@ -63,7 +63,7 @@ func TestPrometheusMachineCollectorWithFailure(t *testing.T) {
 		_, err := expfmt.MetricFamilyToText(&metricBuffer, metricFamily)
 		assert.Nil(t, err)
 	}
-	collectedMetrics := string(metricBuffer.Bytes())
+	collectedMetrics := metricBuffer.String()
 	expectedMetrics, err := ioutil.ReadFile(machineMetricsFailureFile)
 	assert.Nil(t, err)
 	assert.Equal(t, string(expectedMetrics), collectedMetrics)

--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -59,7 +59,7 @@ func getAvgPowerBudget() (uint, error) {
 
 	// Load basic device information for all the devices
 	// to obtain UID of the first one.
-	devices := make([]C.struct_device_discovery, count, count)
+	devices := make([]C.struct_device_discovery, count)
 	err = C.nvm_get_devices(&devices[0], C.uchar(count))
 	if err != C.NVM_SUCCESS {
 		klog.Warningf("Unable to get all NVM devices. Status code: %d", err)

--- a/perf/collector_libpfm_test.go
+++ b/perf/collector_libpfm_test.go
@@ -38,26 +38,29 @@ func TestCollector_UpdateStats(t *testing.T) {
 	collector := collector{}
 	notScaledBuffer := buffer{bytes.NewBuffer([]byte{})}
 	scaledBuffer := buffer{bytes.NewBuffer([]byte{})}
-	binary.Write(notScaledBuffer, binary.LittleEndian, ReadFormat{
+	err := binary.Write(notScaledBuffer, binary.LittleEndian, ReadFormat{
 		Value:       123456789,
 		TimeEnabled: 100,
 		TimeRunning: 100,
 		ID:          1,
 	})
-	binary.Write(scaledBuffer, binary.LittleEndian, ReadFormat{
+	assert.NoError(t, err)
+	err = binary.Write(scaledBuffer, binary.LittleEndian, ReadFormat{
 		Value:       333333333,
 		TimeEnabled: 3,
 		TimeRunning: 1,
 		ID:          2,
 	})
+	assert.NoError(t, err)
 	collector.cpuFiles = map[string]map[int]readerCloser{
 		"instructions": {0: notScaledBuffer},
 		"cycles":       {11: scaledBuffer},
 	}
 
 	stats := &info.ContainerStats{}
-	collector.UpdateStats(stats)
+	err = collector.UpdateStats(stats)
 
+	assert.NoError(t, err)
 	assert.Len(t, stats.PerfStats, 2)
 
 	assert.Equal(t, uint64(123456789), stats.PerfStats[0].Value)

--- a/perf/types.go
+++ b/perf/types.go
@@ -38,12 +38,12 @@ type ReadFormat struct {
 // pfmPerfEncodeArgT represents structure that is used to parse perf event nam
 // into perf_event_attr using libpfm.
 type pfmPerfEncodeArgT struct {
-	attr  unsafe.Pointer
-	fstr  unsafe.Pointer
-	size  C.size_t
-	idx   C.int
-	cpu   C.int
-	flags C.int
+	attr unsafe.Pointer
+	fstr unsafe.Pointer
+	size C.size_t
+	_    C.int // idx
+	_    C.int // cpu
+	_    C.int // flags
 }
 
 type readerCloser interface {

--- a/perf/types.go
+++ b/perf/types.go
@@ -18,7 +18,6 @@ package perf
 import "C"
 import (
 	"io"
-	"os"
 	"unsafe"
 )
 
@@ -50,10 +49,4 @@ type pfmPerfEncodeArgT struct {
 type readerCloser interface {
 	io.Reader
 	io.Closer
-}
-
-// metadata stores perf event meta information.
-type metadata struct {
-	name   string
-	cgroup *os.File
 }

--- a/summary/percentiles.go
+++ b/summary/percentiles.go
@@ -156,8 +156,7 @@ func getPercentComplete(stats []*secondSample) (percent int32) {
 
 // Calculate cpurate from two consecutive total cpu usage samples.
 func getCpuRate(latest, previous secondSample) (uint64, error) {
-	var elapsed int64
-	elapsed = latest.Timestamp.Sub(previous.Timestamp).Nanoseconds()
+	elapsed := latest.Timestamp.Sub(previous.Timestamp).Nanoseconds()
 	if elapsed < 10*milliSecondsToNanoSeconds {
 		return 0, fmt.Errorf("elapsed time too small: %d ns: time now %s last %s", elapsed, latest.Timestamp.String(), previous.Timestamp.String())
 	}

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -113,7 +113,6 @@ func (s *StatsSummary) updateLatestUsage() {
 	defer s.dataLock.Unlock()
 	s.derivedStats.LatestUsage = usage
 	s.derivedStats.Timestamp = latest.Timestamp
-	return
 }
 
 // Generate new derived stats based on current minute stats samples.

--- a/utils/cpuload/netlink/conn.go
+++ b/utils/cpuload/netlink/conn.go
@@ -75,8 +75,11 @@ func (self *Connection) WriteMessage(msg syscall.NetlinkMessage) error {
 	msg.Header.Seq = self.seq
 	self.seq++
 	msg.Header.Pid = self.pid
-	binary.Write(w, binary.LittleEndian, msg.Header)
-	_, err := w.Write(msg.Data)
+	err := binary.Write(w, binary.LittleEndian, msg.Header)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(msg.Data)
 	if err != nil {
 		return err
 	}

--- a/utils/cpuload/netlink/netlink.go
+++ b/utils/cpuload/netlink/netlink.go
@@ -66,7 +66,10 @@ func padding(size int, alignment int) int {
 // Get family id for taskstats subsystem.
 func getFamilyId(conn *Connection) (uint16, error) {
 	msg := prepareFamilyMessage()
-	conn.WriteMessage(msg.toRawMsg())
+	err := conn.WriteMessage(msg.toRawMsg())
+	if err != nil {
+		return 0, err
+	}
 
 	resp, err := conn.ReadMessage()
 	if err != nil {
@@ -203,7 +206,10 @@ func verifyHeader(msg syscall.NetlinkMessage) error {
 	case syscall.NLMSG_ERROR:
 		buf := bytes.NewBuffer(msg.Data)
 		var errno int32
-		binary.Read(buf, Endian, errno)
+		err := binary.Read(buf, Endian, errno)
+		if err != nil {
+			return err
+		}
 		return fmt.Errorf("netlink request failed with error %s", syscall.Errno(-errno))
 	}
 	return nil

--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -107,11 +107,8 @@ func getProcessNamePid(line string, currentOomInstance *OomInstance) (bool, erro
 
 // uses regex to see if line is the start of a kernel oom log
 func checkIfStartOfOomMessages(line string) bool {
-	potential_oom_start := firstLineRegexp.MatchString(line)
-	if potential_oom_start {
-		return true
-	}
-	return false
+	potentialOomStart := firstLineRegexp.MatchString(line)
+	return potentialOomStart
 }
 
 // StreamOoms writes to a provided a stream of OomInstance objects representing

--- a/utils/oomparser/oomparser_test.go
+++ b/utils/oomparser/oomparser_test.go
@@ -136,7 +136,9 @@ func TestLastLineRegex(t *testing.T) {
 	for _, name := range processNames {
 		line := fmt.Sprintf("Jan 21 22:01:49 localhost kernel: [62279.421192] Killed process 1234 (%s) total-vm:1460016kB, anon-rss:1414008kB, file-rss:4kB", name)
 		oomInfo := &OomInstance{}
-		getProcessNamePid(line, oomInfo)
+		isPid, err := getProcessNamePid(line, oomInfo)
+		assert.True(t, isPid)
+		assert.NoError(t, err)
 		assert.Equal(t, 1234, oomInfo.Pid)
 		assert.Equal(t, name, oomInfo.ProcessName)
 	}

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -29,8 +29,8 @@ import (
 
 var (
 	schedulerRegExp      = regexp.MustCompile(`.*\[(.*)\].*`)
-	nodeDirRegExp        = regexp.MustCompile("node/node(\\d*)")
-	cpuDirRegExp         = regexp.MustCompile("/cpu(\\d+)")
+	nodeDirRegExp        = regexp.MustCompile(`node/node(\d*)`)
+	cpuDirRegExp         = regexp.MustCompile(`/cpu(\d+)`)
 	memoryCapacityRegexp = regexp.MustCompile(`MemTotal:\s*([0-9]+) kB`)
 
 	cpusPath = "/sys/devices/system/cpu"
@@ -284,7 +284,7 @@ func getCPUTopology(sysFs sysfs.SysFs) ([]info.Node, int, error) {
 }
 
 func getCpusByPhysicalPackageID(sysFs sysfs.SysFs, cpusPaths []string) (map[int][]string, error) {
-	cpuPathsByPhysicalPackageID := make(map[int][]string, 0)
+	cpuPathsByPhysicalPackageID := make(map[int][]string)
 	for _, cpuPath := range cpusPaths {
 
 		rawPhysicalPackageID, err := sysFs.GetCPUPhysicalPackageID(cpuPath)

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -244,7 +244,7 @@ func validateCgroupMounts() (string, string) {
 	out += desc
 	info, err := ioutil.ReadFile("/proc/mounts")
 	if err != nil {
-		out := fmt.Sprintf("Could not read /proc/mounts.\n")
+		out := "Could not read /proc/mounts.\n"
 		out += desc
 		return Unsupported, out
 	}


### PR DESCRIPTION
Is something like this useful? Majority of fixes is about not checked errors (in and out of tests). After applying more complex ones it should be possible to use `golangci-lint` and I think it could benefit the project.