### PR TITLE
Add healthcheck url env variable

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,7 +11,9 @@ ADD cadvisor /usr/bin/cadvisor
 
 EXPOSE 8080
 
+ENV CADVISOR_HEALTHCHECK_URL=http://localhost:8080/healthz
+
 HEALTHCHECK --interval=30s --timeout=3s \
-  CMD wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
+  CMD wget --quiet --tries=1 --spider $CADVISOR_HEALTHCHECK_URL || exit 1
 
 ENTRYPOINT ["/usr/bin/cadvisor", "-logtostderr"]


### PR DESCRIPTION
In case we change setting:
- ``url_base_prefix``
- ``port``

The default healthcheck URL is wrong, and so, the container is always marqued down.

I propose a simple solution, a new env variable ``CADVISOR_HEALTHCHECK_URL`` , so it's easy to specify the full URL to check.