### PR TITLE
Ability to run unit tests in podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,12 @@ test:
 	@$(GO) test -short -race $(pkgs)
 	@cd cmd && $(GO) test -short -race $(cmd_pkgs)
 
-docker-test:
-	@echo ">> runinng tests in docker"
-	@./build/unit-in-docker.sh
+container-test:
+	@echo ">> runinng tests in a container"
+	@./build/unit-in-container.sh
 
+docker-test: container-test
+	@echo "docker-test target is deprecated, use container-test instead"
 
 test-integration:
 	GO_FLAGS="-race" ./build/build.sh

--- a/build/unit-in-container.sh
+++ b/build/unit-in-container.sh
@@ -16,6 +16,15 @@
 
 set -e
 
+CONTAINER_ENGINE=$(command -v docker || true)
+if [ "$CONTAINER_ENGINE" == "" ]; then
+  CONTAINER_ENGINE=$(command -v podman || true)
+fi
+if [ "$CONTAINER_ENGINE" == "" ]; then
+  echo "Unable to find docker and podman. Exiting."
+  exit 1
+fi
+
 function run_tests() {
   BUILD_CMD="go test $GO_FLAGS $(go list $GO_FLAGS ./... | grep -v 'vendor\|integration' | tr '\n' ' ') && \
     cd cmd && go test $GO_FLAGS $(go list $GO_FLAGS ./... | grep -v 'vendor\|integration' | tr '\n' ' ')"
@@ -24,7 +33,7 @@ function run_tests() {
     $BUILD_CMD"
   fi
 
-  docker run --rm \
+  $CONTAINER_ENGINE run --rm \
     -w /go/src/github.com/google/cadvisor \
     -v ${PWD}:/go/src/github.com/google/cadvisor \
     golang:${GOLANG_VERSION} \


### PR DESCRIPTION
Centos/RHEL 8 and Fedora >= 31 do not provide `docker` by default. It would be great if running unit tests in `podman` were possible.

Unfortunately integration tests can't be run in `podman` at the moment. https://github.com/containers/libpod/issues/4131 might help, eventually.