### PR TITLE
 Using unexported return type from exported function shall be forbidden

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,8 +32,6 @@ issues:
     - "(method|func) [A-Z].* should be .*"
 #   Stuttering affects exported names:
     - "type name will be used as .*\\.[A-Z]{1}.* by other packages, and that stutters"
-#   We would have to change exported function return type:
-    - "exported func .* returns unexported type"
   exclude-rules:
 #   container/containerd/client.go:67:4: SA1019: grpc.WithDialer is deprecated: use WithContextDialer instead.  Will be supported throughout 1.x.  (staticcheck)
 #   There are more similar issues in following lines.
@@ -46,9 +44,6 @@ issues:
 #   utils/cloudinfo/aws/aws.go:60:28: SA1019: session.New is deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.  (staticcheck)
     - path: utils/cloudinfo/aws/aws.go
       text: "SA1019:"
-#   events/handler.go:151:51: exported func NewEventManager returns unexported type *github.com/google/cadvisor/events.events, which can be annoying to use (golint)
-    - path: events/handler.go
-      text: "exported func NewEventManager returns unexported type .{1}github.com/google/cadvisor/events.events, which can be annoying to use"
 #   manager/manager_test.go:277:29: Error return value of `(*github.com/google/cadvisor/container/testing.MockContainerHandler).GetSpec` is not checked (errcheck)
     - path: manager/manager_test.go
       text: "Error return value of `.{2}github.com/google/cadvisor/container/testing.MockContainerHandler.{1}.GetSpec` is not checked"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - deadcode
     - typecheck
     - golint
+    - gofmt
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/container/common/container_hints.go
+++ b/container/common/container_hints.go
@@ -27,7 +27,7 @@ import (
 
 var ArgContainerHints = flag.String("container_hints", "/etc/cadvisor/container_hints.json", "location of the container hints file")
 
-type containerHints struct {
+type ContainerHints struct {
 	AllHosts []containerHint `json:"all_hosts,omitempty"`
 }
 
@@ -47,12 +47,12 @@ type networkInterface struct {
 	VethChild string `json:"veth_child,omitempty"`
 }
 
-func GetContainerHintsFromFile(containerHintsFile string) (containerHints, error) {
+func GetContainerHintsFromFile(containerHintsFile string) (ContainerHints, error) {
 	dat, err := ioutil.ReadFile(containerHintsFile)
 	if os.IsNotExist(err) {
-		return containerHints{}, nil
+		return ContainerHints{}, nil
 	}
-	var cHints containerHints
+	var cHints ContainerHints
 	if err == nil {
 		err = json.Unmarshal(dat, &cHints)
 	}

--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -37,14 +37,14 @@ type client struct {
 	versionService   versionapi.VersionClient
 }
 
-type containerdClient interface {
+type ContainerdClient interface {
 	LoadContainer(ctx context.Context, id string) (*containers.Container, error)
 	TaskPid(ctx context.Context, id string) (uint32, error)
 	Version(ctx context.Context) (string, error)
 }
 
 var once sync.Once
-var ctrdClient containerdClient = nil
+var ctrdClient ContainerdClient = nil
 
 const (
 	maxBackoffDelay   = 3 * time.Second
@@ -52,7 +52,7 @@ const (
 )
 
 // Client creates a containerd client
-func Client(address, namespace string) (containerdClient, error) {
+func Client(address, namespace string) (ContainerdClient, error) {
 	var retErr error
 	once.Do(func() {
 		tryConn, err := net.DialTimeout("unix", address, connectionTimeout)

--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -45,7 +45,7 @@ func (c *containerdClientMock) TaskPid(ctx context.Context, id string) (uint32, 
 	return 2389, nil
 }
 
-func mockcontainerdClient(cntrs map[string]*containers.Container, returnErr error) containerdClient {
+func mockcontainerdClient(cntrs map[string]*containers.Container, returnErr error) ContainerdClient {
 	return &containerdClientMock{
 		cntrs:     cntrs,
 		returnErr: returnErr,

--- a/container/containerd/factory.go
+++ b/container/containerd/factory.go
@@ -43,7 +43,7 @@ var containerdCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
 
 type containerdFactory struct {
 	machineInfoFactory info.MachineInfoFactory
-	client             containerdClient
+	client             ContainerdClient
 	version            string
 	// Information about the mounted cgroup subsystems.
 	cgroupSubsystems libcontainer.CgroupSubsystems

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -56,7 +56,7 @@ var _ container.ContainerHandler = &containerdContainerHandler{}
 
 // newContainerdContainerHandler returns a new container.ContainerHandler
 func newContainerdContainerHandler(
-	client containerdClient,
+	client ContainerdClient,
 	name string,
 	machineInfoFactory info.MachineInfoFactory,
 	fsInfo fs.FsInfo,

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -35,7 +35,7 @@ func init() {
 func TestHandler(t *testing.T) {
 	as := assert.New(t)
 	type testCase struct {
-		client             containerdClient
+		client             ContainerdClient
 		name               string
 		machineInfoFactory info.MachineInfoFactory
 		fsInfo             fs.FsInfo

--- a/container/crio/client.go
+++ b/container/crio/client.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	theClient      crioClient
+	theClient      CrioClient
 	clientErr      error
 	crioClientOnce sync.Once
 )
@@ -56,7 +56,7 @@ type ContainerInfo struct {
 	IPs         []string          `json:"ip_addresses"`
 }
 
-type crioClient interface {
+type CrioClient interface {
 	Info() (Info, error)
 	ContainerInfo(string) (*ContainerInfo, error)
 }
@@ -78,7 +78,7 @@ func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 }
 
 // Client returns a new configured CRI-O client
-func Client() (crioClient, error) {
+func Client() (CrioClient, error) {
 	crioClientOnce.Do(func() {
 		tr := new(http.Transport)
 		theClient = nil

--- a/container/crio/client_test.go
+++ b/container/crio/client_test.go
@@ -40,7 +40,7 @@ func (c *crioClientMock) ContainerInfo(id string) (*ContainerInfo, error) {
 	return cInfo, nil
 }
 
-func mockCrioClient(info Info, containersInfo map[string]*ContainerInfo, err error) crioClient {
+func mockCrioClient(info Info, containersInfo map[string]*ContainerInfo, err error) CrioClient {
 	return &crioClientMock{
 		err:            err,
 		info:           info,

--- a/container/crio/factory.go
+++ b/container/crio/factory.go
@@ -57,7 +57,7 @@ type crioFactory struct {
 
 	includedMetrics container.MetricSet
 
-	client crioClient
+	client CrioClient
 }
 
 func (f *crioFactory) String() string {

--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -32,7 +32,7 @@ import (
 )
 
 type crioContainerHandler struct {
-	client crioClient
+	client CrioClient
 	name   string
 
 	machineInfoFactory info.MachineInfoFactory
@@ -79,7 +79,7 @@ var _ container.ContainerHandler = &crioContainerHandler{}
 
 // newCrioContainerHandler returns a new container.ContainerHandler
 func newCrioContainerHandler(
-	client crioClient,
+	client CrioClient,
 	name string,
 	machineInfoFactory info.MachineInfoFactory,
 	fsInfo fs.FsInfo,

--- a/container/crio/handler_test.go
+++ b/container/crio/handler_test.go
@@ -28,7 +28,7 @@ import (
 func TestHandler(t *testing.T) {
 	as := assert.New(t)
 	type testCase struct {
-		client             crioClient
+		client             CrioClient
 		name               string
 		machineInfoFactory info.MachineInfoFactory
 		fsInfo             fs.FsInfo

--- a/events/handler.go
+++ b/events/handler.go
@@ -195,7 +195,7 @@ func getMaxEventsReturned(request *Request, eSlice []*info.Event) []*info.Event 
 // container path is a prefix of the event container path.  Otherwise,
 // it checks that the container paths of the event and request are
 // equivalent
-func checkIfIsSubcontainer(request *Request, event *info.Event) bool {
+func isSubcontainer(request *Request, event *info.Event) bool {
 	if request.IncludeSubcontainers {
 		return request.ContainerName == "/" || strings.HasPrefix(event.ContainerName+"/", request.ContainerName+"/")
 	}
@@ -221,7 +221,7 @@ func checkIfEventSatisfiesRequest(request *Request, event *info.Event) bool {
 		return false
 	}
 	if request.ContainerName != "" {
-		return checkIfIsSubcontainer(request, event)
+		return isSubcontainer(request, event)
 	}
 	return true
 }

--- a/events/handler.go
+++ b/events/handler.go
@@ -148,7 +148,7 @@ func DefaultStoragePolicy() StoragePolicy {
 }
 
 // returns a pointer to an initialized Events object.
-func NewEventManager(storagePolicy StoragePolicy) *events {
+func NewEventManager(storagePolicy StoragePolicy) EventManager {
 	return &events{
 		eventStore:    make(map[info.EventType]*utils.TimedStore),
 		watchers:      make(map[int]*watch),

--- a/events/handler_test.go
+++ b/events/handler_test.go
@@ -48,7 +48,8 @@ func initializeScenario(t *testing.T) (*events, *Request, *info.Event, *info.Eve
 	fakeEvent := makeEvent(createOldTime(t), "/")
 	fakeEvent2 := makeEvent(time.Now(), "/")
 
-	return NewEventManager(DefaultStoragePolicy()), NewRequest(), fakeEvent, fakeEvent2
+	manager := NewEventManager(DefaultStoragePolicy())
+	return manager.(*events), NewRequest(), fakeEvent, fakeEvent2
 }
 
 func checkNumberOfEvents(t *testing.T, numEventsExpected int, numEventsReceived int) {

--- a/events/handler_test.go
+++ b/events/handler_test.go
@@ -142,7 +142,7 @@ func TestAddEventAddsEventsToEventManager(t *testing.T) {
 	assert.NoError(t, err)
 
 	events, err := myEventHolder.GetEvents(&Request{
-		EventType:     map[info.EventType]bool{info.EventOom: true},
+		EventType:         map[info.EventType]bool{info.EventOom: true},
 		MaxEventsReturned: -1,
 	})
 

--- a/events/handler_test.go
+++ b/events/handler_test.go
@@ -44,29 +44,15 @@ func makeEvent(inTime time.Time, containerName string) *info.Event {
 }
 
 // returns EventManager and Request to use in tests
-func initializeScenario(t *testing.T) (*events, *Request, *info.Event, *info.Event) {
+func initializeScenario(t *testing.T) (EventManager, *Request, *info.Event, *info.Event) {
 	fakeEvent := makeEvent(createOldTime(t), "/")
 	fakeEvent2 := makeEvent(time.Now(), "/")
 
 	manager := NewEventManager(DefaultStoragePolicy())
-	return manager.(*events), NewRequest(), fakeEvent, fakeEvent2
+	return manager, NewRequest(), fakeEvent, fakeEvent2
 }
 
-func checkNumberOfEvents(t *testing.T, numEventsExpected int, numEventsReceived int) {
-	if numEventsReceived != numEventsExpected {
-		t.Fatalf("Expected to return %v events but received %v",
-			numEventsExpected, numEventsReceived)
-	}
-}
-
-func ensureProperEventReturned(t *testing.T, expectedEvent *info.Event, eventObjectFound *info.Event) {
-	if eventObjectFound != expectedEvent {
-		t.Errorf("Expected to find test object %v but found a different object: %v",
-			expectedEvent, eventObjectFound)
-	}
-}
-
-func TestCheckIfIsSubcontainer(t *testing.T) {
+func TestIsSubcontainer(t *testing.T) {
 	myRequest := NewRequest()
 	myRequest.ContainerName = "/root"
 	rootRequest := NewRequest()
@@ -82,15 +68,15 @@ func TestCheckIfIsSubcontainer(t *testing.T) {
 		ContainerName: "/root-completely-different-container",
 	}
 
-	if checkIfIsSubcontainer(rootRequest, sameContainerEvent) {
+	if isSubcontainer(rootRequest, sameContainerEvent) {
 		t.Errorf("should not have found %v to be a subcontainer of %v",
 			sameContainerEvent, rootRequest)
 	}
-	if !checkIfIsSubcontainer(myRequest, sameContainerEvent) {
+	if !isSubcontainer(myRequest, sameContainerEvent) {
 		t.Errorf("should have found %v and %v had the same container name",
 			myRequest, sameContainerEvent)
 	}
-	if checkIfIsSubcontainer(myRequest, subContainerEvent) {
+	if isSubcontainer(myRequest, subContainerEvent) {
 		t.Errorf("should have found %v and %v had different containers",
 			myRequest, subContainerEvent)
 	}
@@ -98,19 +84,19 @@ func TestCheckIfIsSubcontainer(t *testing.T) {
 	rootRequest.IncludeSubcontainers = true
 	myRequest.IncludeSubcontainers = true
 
-	if !checkIfIsSubcontainer(rootRequest, sameContainerEvent) {
+	if !isSubcontainer(rootRequest, sameContainerEvent) {
 		t.Errorf("should have found %v to be a subcontainer of %v",
 			sameContainerEvent.ContainerName, rootRequest.ContainerName)
 	}
-	if !checkIfIsSubcontainer(myRequest, sameContainerEvent) {
+	if !isSubcontainer(myRequest, sameContainerEvent) {
 		t.Errorf("should have found %v and %v had the same container",
 			myRequest.ContainerName, sameContainerEvent.ContainerName)
 	}
-	if !checkIfIsSubcontainer(myRequest, subContainerEvent) {
+	if !isSubcontainer(myRequest, subContainerEvent) {
 		t.Errorf("should have found %v was a subcontainer of %v",
 			subContainerEvent.ContainerName, myRequest.ContainerName)
 	}
-	if checkIfIsSubcontainer(myRequest, differentContainerEvent) {
+	if isSubcontainer(myRequest, differentContainerEvent) {
 		t.Errorf("should have found %v and %v had different containers",
 			myRequest.ContainerName, differentContainerEvent.ContainerName)
 	}
@@ -120,7 +106,7 @@ func TestWatchEventsDetectsNewEvents(t *testing.T) {
 	myEventHolder, myRequest, fakeEvent, fakeEvent2 := initializeScenario(t)
 	myRequest.EventType[info.EventOom] = true
 	returnEventChannel, err := myEventHolder.WatchEvents(myRequest)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	err = myEventHolder.AddEvent(fakeEvent)
 	assert.NoError(t, err)
@@ -140,9 +126,9 @@ func TestWatchEventsDetectsNewEvents(t *testing.T) {
 		for event := range returnEventChannel.GetChannel() {
 			eventsFound++
 			if eventsFound == 1 {
-				ensureProperEventReturned(t, fakeEvent, event)
+				assert.Equal(t, fakeEvent, event)
 			} else if eventsFound == 2 {
-				ensureProperEventReturned(t, fakeEvent2, event)
+				assert.Equal(t, fakeEvent2, event)
 				break
 			}
 		}
@@ -153,10 +139,16 @@ func TestAddEventAddsEventsToEventManager(t *testing.T) {
 	myEventHolder, _, fakeEvent, _ := initializeScenario(t)
 
 	err := myEventHolder.AddEvent(fakeEvent)
+	assert.NoError(t, err)
+
+	events, err := myEventHolder.GetEvents(&Request{
+		EventType:     map[info.EventType]bool{info.EventOom: true},
+		MaxEventsReturned: -1,
+	})
 
 	assert.NoError(t, err)
-	checkNumberOfEvents(t, 1, len(myEventHolder.eventStore))
-	ensureProperEventReturned(t, fakeEvent, myEventHolder.eventStore[info.EventOom].Get(0).(*info.Event))
+	assert.Len(t, events, 1)
+	assert.Equal(t, fakeEvent, events[0])
 }
 
 func TestGetEventsForOneEvent(t *testing.T) {
@@ -170,9 +162,9 @@ func TestGetEventsForOneEvent(t *testing.T) {
 	assert.NoError(t, err)
 
 	receivedEvents, err := myEventHolder.GetEvents(myRequest)
-	assert.Nil(t, err)
-	checkNumberOfEvents(t, 1, len(receivedEvents))
-	ensureProperEventReturned(t, fakeEvent2, receivedEvents[0])
+	assert.NoError(t, err)
+	assert.Len(t, receivedEvents, 1)
+	assert.Equal(t, fakeEvent2, receivedEvents[0])
 }
 
 func TestGetEventsForTimePeriod(t *testing.T) {
@@ -187,10 +179,9 @@ func TestGetEventsForTimePeriod(t *testing.T) {
 	assert.NoError(t, err)
 
 	receivedEvents, err := myEventHolder.GetEvents(myRequest)
-	assert.Nil(t, err)
-
-	checkNumberOfEvents(t, 1, len(receivedEvents))
-	ensureProperEventReturned(t, fakeEvent2, receivedEvents[0])
+	assert.NoError(t, err)
+	assert.Len(t, receivedEvents, 1)
+	assert.Equal(t, fakeEvent2, receivedEvents[0])
 }
 
 func TestGetEventsForNoTypeRequested(t *testing.T) {
@@ -202,6 +193,6 @@ func TestGetEventsForNoTypeRequested(t *testing.T) {
 	assert.NoError(t, err)
 
 	receivedEvents, err := myEventHolder.GetEvents(myRequest)
-	assert.Nil(t, err)
-	checkNumberOfEvents(t, 0, len(receivedEvents))
+	assert.NoError(t, err)
+	assert.Len(t, receivedEvents, 0)
 }

--- a/summary/percentiles.go
+++ b/summary/percentiles.go
@@ -72,6 +72,12 @@ func (m *mean) Add(value uint64) {
 	m.Mean = (m.Mean*(c-1) + v) / c
 }
 
+type Percentile interface {
+	Add(info.Percentiles)
+	AddSample(uint64)
+	GetAllPercentiles() info.Percentiles
+}
+
 type resource struct {
 	// list of samples being tracked.
 	samples Uint64Slice
@@ -119,7 +125,7 @@ func (r *resource) GetAllPercentiles() info.Percentiles {
 	return p
 }
 
-func NewResource(size int) *resource {
+func NewResource(size int) Percentile {
 	return &resource{
 		samples: make(Uint64Slice, 0, size),
 		mean:    mean{count: 0, Mean: 0},


### PR DESCRIPTION
I think we should be rather safe. I haven't check it (I don't really know how) but I don't think that any project would rely on unexported struct properties.