### PR TITLE
Remove go-cmp from from cache comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/go-ini/ini v1.9.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e // indirect
 	github.com/gogo/protobuf v1.3.1
-	github.com/google/go-cmp v0.3.1
+	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -22,7 +22,6 @@ import (
 
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/utils/sysfs"
-	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/klog/v2"
 )
@@ -328,7 +327,7 @@ func addCacheInfo(sysFs sysfs.SysFs, node *info.Node) error {
 				// Add a node-level cache.
 				cacheFound := false
 				for _, nodeCache := range node.Caches {
-					if cmp.Equal(nodeCache, c) {
+					if nodeCache == c {
 						cacheFound = true
 					}
 				}


### PR DESCRIPTION
Signed-off-by: Katarzyna Kujawa <katarzyna.kujawa@intel.com>

As indicated [here](https://godoc.org/github.com/google/go-cmp/cmp) go-cmp should not be used in production environment because  it may panic if it cannot compare the values.