### PR TITLE
Fix generating daemonset with example patches using Kustomize

### DIFF
--- a/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
+++ b/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
 kind: DaemonSet
 metadata:
   name: cadvisor
+  namespace: cadvisor
 spec:
   template:
     spec:

--- a/deploy/kubernetes/overlays/examples/critical-priority.yaml
+++ b/deploy/kubernetes/overlays/examples/critical-priority.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
 kind: DaemonSet
 metadata:
   name: cadvisor
+  namespace: cadvisor
 spec:
   template:
     metadata:

--- a/deploy/kubernetes/overlays/examples/gpu-privilages.yaml
+++ b/deploy/kubernetes/overlays/examples/gpu-privilages.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cadvisor
+  namespace: cadvisor
 spec:
   template:
     spec:

--- a/deploy/kubernetes/overlays/examples/stackdriver-sidecar.yaml
+++ b/deploy/kubernetes/overlays/examples/stackdriver-sidecar.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
 kind: DaemonSet
 metadata:
   name: cadvisor
+  namespace: cadvisor
 spec:
   template:
     spec:


### PR DESCRIPTION
Signed-off-by: Katarzyna Kujawa <katarzyna.kujawa@intel.com>

Without changes introduced in this PR I'm observing following error:
```
$ kustomize build deploy/kubernetes/overlays/examples
Error: no matches for OriginalId apps_v1_DaemonSet|~X|cadvisor; no matches for CurrentId apps_v1_DaemonSet|~X|cadvisor; failed to find unique target for patch apps_v1_DaemonSet|cadvisor
```

My Kustomize version:
```
$ kustomize version
{Version:kustomize/v3.5.4 GitCommit:3af514fa9f85430f0c1557c4a0291e62112ab026 BuildDate:2020-01-11T03:12:59Z GoOs:linux GoArch:amd64}
```
