### PR TITLE
Using upstream golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,28 +4,22 @@ jobs:
   lint:
     strategy:
       matrix:
-        go-versions: [1.14]
-        platform: [ubuntu-latest]
         environment-variables: [build/config/plain.sh, build/config/libpfm4.sh]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
     - name: Install Go
       uses: actions/setup-go@v1
       with:
-        go-version: ${{ matrix.go-versions }}
-#    This is not the most elegant way of installing golangci-lint but I have filed a PR
-#    and I will fix it as soon as it's merged: https://github.com/golangci/golangci-lint/pull/1036
-#    cAdvisor has existed for a while without golint and we need to figure out how to
-#    fix issues affecting exported identifiers that are part of public API. Let's avoid breaking Kubernetes.
+        go-version: 1.14
     - name: Install golangci-lint
-      run: |
-        go get -d github.com/golangci/golangci-lint/cmd/golangci-lint &&
-        cd $(go env GOPATH)/src/github.com/golangci/golangci-lint/ &&
-        git remote add iwankgb https://github.com/iwankgb/golangci-lint.git &&
-        git fetch iwankgb &&
-        git reset --hard iwankgb/exclude-case-sensitive &&
-        go install -i github.com/golangci/golangci-lint/cmd/golangci-lint
+      run: >
+        cd /tmp &&
+        mkdir -p $(go env GOPATH)/bin &&
+        wget -q https://github.com/golangci/golangci-lint/releases/download/v1.26.0/golangci-lint-1.26.0-linux-amd64.tar.gz &&
+        tar xf golangci-lint-1.26.0-linux-amd64.tar.gz &&
+        mv golangci-lint-1.26.0-linux-amd64/golangci-lint $(go env GOPATH)/bin &&
+        rm -fr golangci-lint-1.26.0-linux-amd64.tar.gz golangci-lint-1.26.0-linux-amd64
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 on: [push, pull_request]
 jobs:
   lint:
+    env:
+      GOLANGCI_LINT_V: 1.26.0
     strategy:
       matrix:
         environment-variables: [build/config/plain.sh, build/config/libpfm4.sh]
@@ -16,10 +18,10 @@ jobs:
       run: >
         cd /tmp &&
         mkdir -p $(go env GOPATH)/bin &&
-        wget -q https://github.com/golangci/golangci-lint/releases/download/v1.26.0/golangci-lint-1.26.0-linux-amd64.tar.gz &&
-        tar xf golangci-lint-1.26.0-linux-amd64.tar.gz &&
-        mv golangci-lint-1.26.0-linux-amd64/golangci-lint $(go env GOPATH)/bin &&
-        rm -fr golangci-lint-1.26.0-linux-amd64.tar.gz golangci-lint-1.26.0-linux-amd64
+        wget -q https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_V}/golangci-lint-${GOLANGCI_LINT_V}-linux-amd64.tar.gz &&
+        tar xf golangci-lint-${GOLANGCI_LINT_V}-linux-amd64.tar.gz &&
+        mv golangci-lint-${GOLANGCI_LINT_V}-linux-amd64/golangci-lint $(go env GOPATH)/bin &&
+        rm -fr golangci-lint-*
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run golangci-lint

--- a/integration/tests/api/machine_test.go
+++ b/integration/tests/api/machine_test.go
@@ -33,7 +33,7 @@ func TestMachineInformationIsReturned(t *testing.T) {
 	if machineInfo.NumCores <= 0 || machineInfo.NumCores >= 1000000 {
 		t.Errorf("Machine info has unexpected number of cores: %v", machineInfo.NumCores)
 	}
-	if machineInfo.MemoryCapacity <= 0 || machineInfo.MemoryCapacity >= (1<<50 /* 1PB */) {
+	if machineInfo.MemoryCapacity == 0 || machineInfo.MemoryCapacity >= (1<<50 /* 1PB */) {
 		t.Errorf("Machine info has unexpected amount of memory: %v", machineInfo.MemoryCapacity)
 	}
 	if len(machineInfo.Filesystems) == 0 {


### PR DESCRIPTION
Replacing `golangci-lint` from my fork with upstream version.