### PR TITLE
Some linting errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,15 +42,6 @@ issues:
 #   There are more similar issues in this file
     - path: utils/cpuload/netlink/netlink.go
       text: "Error return value of `binary.Write` is not checked"
-#   utils/cloudinfo/aws/aws.go:60:28: SA1019: session.New is deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.  (staticcheck)
-    - path: utils/cloudinfo/aws/aws.go
-      text: "SA1019:"
 #   manager/manager_test.go:277:29: Error return value of `(*github.com/google/cadvisor/container/testing.MockContainerHandler).GetSpec` is not checked (errcheck)
     - path: manager/manager_test.go
       text: "Error return value of `.{2}github.com/google/cadvisor/container/testing.MockContainerHandler.{1}.GetSpec` is not checked"
-#   utils/sysinfo/sysinfo.go:208:7: ineffectual assignment to `err` (ineffassign)
-    - path: utils/sysinfo/sysinfo.go
-      text: "ineffectual assignment to `err`|SA4006:"
-#   cache/memory/memory_test.go:81:23: Error return value of `memoryCache.AddStats` is not checked (errcheck)
-    - path: cache/memory/memory_test.go
-      text: "Error return value of `memoryCache.AddStats` is not checked"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,3 @@ issues:
 #   There are more similar issues in this file
     - path: utils/cpuload/netlink/netlink.go
       text: "Error return value of `binary.Write` is not checked"
-#   manager/manager_test.go:277:29: Error return value of `(*github.com/google/cadvisor/container/testing.MockContainerHandler).GetSpec` is not checked (errcheck)
-    - path: manager/manager_test.go
-      text: "Error return value of `.{2}github.com/google/cadvisor/container/testing.MockContainerHandler.{1}.GetSpec` is not checked"

--- a/cache/memory/memory_test.go
+++ b/cache/memory/memory_test.go
@@ -67,36 +67,36 @@ func TestAddStats(t *testing.T) {
 }
 
 func TestRecentStatsNoRecentStats(t *testing.T) {
-	memoryCache := makeWithStats(0)
+	memoryCache := makeWithStats(t, 0)
 
 	_, err := memoryCache.RecentStats(containerName, zero, zero, 60)
 	assert.NotNil(t, err)
 }
 
 // Make an instance of InMemoryCache with n stats.
-func makeWithStats(n int) *InMemoryCache {
+func makeWithStats(t *testing.T, n int) *InMemoryCache {
 	memoryCache := New(60*time.Second, nil)
 
 	for i := 0; i < n; i++ {
-		memoryCache.AddStats(&cInfo, makeStat(i))
+		assert.NoError(t, memoryCache.AddStats(&cInfo, makeStat(i)))
 	}
 	return memoryCache
 }
 
 func TestRecentStatsGetZeroStats(t *testing.T) {
-	memoryCache := makeWithStats(10)
+	memoryCache := makeWithStats(t, 10)
 
 	assert.Len(t, getRecentStats(t, memoryCache, 0), 0)
 }
 
 func TestRecentStatsGetSomeStats(t *testing.T) {
-	memoryCache := makeWithStats(10)
+	memoryCache := makeWithStats(t, 10)
 
 	assert.Len(t, getRecentStats(t, memoryCache, 5), 5)
 }
 
 func TestRecentStatsGetAllStats(t *testing.T) {
-	memoryCache := makeWithStats(10)
+	memoryCache := makeWithStats(t, 10)
 
 	assert.Len(t, getRecentStats(t, memoryCache, -1), 10)
 }

--- a/integration/tests/api/machine_test.go
+++ b/integration/tests/api/machine_test.go
@@ -33,7 +33,7 @@ func TestMachineInformationIsReturned(t *testing.T) {
 	if machineInfo.NumCores <= 0 || machineInfo.NumCores >= 1000000 {
 		t.Errorf("Machine info has unexpected number of cores: %v", machineInfo.NumCores)
 	}
-	if machineInfo.MemoryCapacity <= 0 || machineInfo.MemoryCapacity >= (1<<50 /* 1PB */) {
+	if machineInfo.MemoryCapacity == 0 || machineInfo.MemoryCapacity >= (1<<50 /* 1PB */) {
 		t.Errorf("Machine info has unexpected amount of memory: %v", machineInfo.MemoryCapacity)
 	}
 	if len(machineInfo.Filesystems) == 0 {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -274,7 +274,8 @@ func TestGetContainerInfoV2Failure(t *testing.T) {
 
 	// Make GetSpec fail on /c2
 	mockErr := fmt.Errorf("intentional GetSpec failure")
-	handlerMap[failing].GetSpec() // Use up default GetSpec call, and replace below
+	_, err = handlerMap[failing].GetSpec()
+	assert.NoError(t, err) // Use up default GetSpec call, and replace below
 	handlerMap[failing].On("GetSpec").Return(info.ContainerSpec{}, mockErr)
 	handlerMap[failing].On("Exists").Return(true)
 	m.containers[namespacedContainerName{Name: failing}].infoLastUpdatedTime = time.Time{} // Force GetSpec.

--- a/utils/cloudinfo/aws/aws.go
+++ b/utils/cloudinfo/aws/aws.go
@@ -57,7 +57,11 @@ func fileContainsAmazonIdentifier(filename string) bool {
 }
 
 func getAwsMetadata(name string) string {
-	client := ec2metadata.New(session.New(&aws.Config{}))
+	sess, err := session.NewSession(&aws.Config{})
+	if err != nil {
+		return info.UnknownInstance
+	}
+	client := ec2metadata.New(sess)
 	data, err := client.GetMetadata(name)
 	if err != nil {
 		return info.UnknownInstance

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -205,6 +205,9 @@ func GetNodesInfo(sysFs sysfs.SysFs) ([]info.Node, int, error) {
 
 	for _, nodeDir := range nodesDirs {
 		id, err := getMatchedInt(nodeDirRegExp, nodeDir)
+		if err != nil {
+			return nil, 0, err
+		}
 		node := info.Node{Id: id}
 
 		cpuDirs, err := sysFs.GetCPUsPaths(nodeDir)


### PR DESCRIPTION
The only remaining errors (besides fixed in #2513) are those from `utils/cpuload/netlink/netlink.go` - do you think it's worth fixing them? `netlink.addAttribute()` is used in two places and in both cases buffers are based on slice of bytes; I can't imagine when it would be impossible to write to them.