### PR TITLE
machine, topology_test: not read system file

### DIFF
--- a/machine/machine.go
+++ b/machine/machine.go
@@ -50,9 +50,9 @@ var (
 	isMemoryController = regexp.MustCompile("mc[0-9]+")
 	isDimm             = regexp.MustCompile("dimm[0-9]+")
 	machineArch        = getMachineArch()
+	maxFreqFile        = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
 )
 
-const maxFreqFile = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"
 const sysFsCPUCoreID = "core_id"
 const sysFsCPUPhysicalPackageID = "physical_package_id"
 const sysFsCPUTopology = "topology"

--- a/machine/topology_test.go
+++ b/machine/topology_test.go
@@ -393,6 +393,7 @@ func TestMemoryInfoOnArchThatDoNotExposeMemoryController(t *testing.T) {
 }
 
 func TestClockSpeedOnCpuUpperCase(t *testing.T) {
+	maxFreqFile = ""                            // do not read the system max frequency
 	machineArch = ""                            // overwrite package variable
 	testfile := "./testdata/cpuinfo_upper_case" // mock cpuinfo with CPU MHz
 
@@ -407,6 +408,7 @@ func TestClockSpeedOnCpuUpperCase(t *testing.T) {
 }
 
 func TestClockSpeedOnCpuLowerCase(t *testing.T) {
+	maxFreqFile = ""                            // do not read the system max frequency
 	machineArch = ""                            // overwrite package variable
 	testfile := "./testdata/cpuinfo_lower_case" // mock cpuinfo with cpu MHz
 


### PR DESCRIPTION
GetClockSpeed() uses the information from the file
/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq when it exists.

Make sure it is not used for tests.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>