### PR TITLE
Fix description of cpu_cores metrics in docs

### DIFF
--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -92,8 +92,8 @@ The table below lists the Prometheus hardware metrics exposed by cAdvisor (in al
 Metric name | Type | Description | Unit (where applicable)
 :-----------|:-----|:------------|:-----------------------
 `machine_cpu_cache_capacity_bytes` | Gauge |  Cache size in bytes assigned to NUMA node and CPU core | bytes
-`machine_cpu_cores` | Gauge | Number of physical CPU cores |
-`machine_cpu_physical_cores` | Gauge | Number of logical CPU cores |
+`machine_cpu_cores` | Gauge | Number of logical CPU cores |
+`machine_cpu_physical_cores` | Gauge | Number of physical CPU cores |
 `machine_cpu_sockets` | Gauge | Number of CPU sockets |
 `machine_dimm_capacity_bytes` | Gauge | Total RAM DIMM capacity (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 | bytes
 `machine_dimm_count` | Gauge | Number of RAM DIMM (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 |


### PR DESCRIPTION
The description of machine_cpu_cores and machine_cpu_physical_cores was swapped.