### PR TITLE
update canary job to go 1.14

### DIFF
--- a/deploy/canary/Dockerfile
+++ b/deploy/canary/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.11
-MAINTAINER vmarmol@google.com
+FROM golang:1.14
+MAINTAINER dashpole@google.com
 
 RUN apt-get update && apt-get install -y git dmsetup && apt-get clean
 RUN git clone https://github.com/google/cadvisor.git /go/src/github.com/google/cadvisor


### PR DESCRIPTION
The job is broken on testgrid: https://k8s-testgrid.appspot.com/sig-node-cadvisor#cadvisor-push
Its complaining about not being able to find dependencies: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cadvisor-canarypush/1262135885336416257