### PR TITLE
Lengthen timeout and add additional information for debugging flakes

### DIFF
--- a/integration/tests/api/docker_test.go
+++ b/integration/tests/api/docker_test.go
@@ -274,7 +274,8 @@ func TestDockerContainerNetworkStats(t *testing.T) {
 	containerID := fm.Docker().RunBusybox("watch", "-n1", "wget", "http://www.google.com/")
 	waitForContainer(containerID, fm)
 
-	time.Sleep(10 * time.Second)
+	// Wait for at least one additional housekeeping interval
+	time.Sleep(20 * time.Second)
 	request := &info.ContainerInfoRequest{
 		NumStats: 1,
 	}
@@ -300,8 +301,8 @@ func TestDockerContainerNetworkStats(t *testing.T) {
 	assert.NotEqual(0, ifaceStats.TxPackets, "Network tx packets should not be zero")
 	assert.NotEqual(0, ifaceStats.RxBytes, "Network rx bytes should not be zero")
 	assert.NotEqual(0, ifaceStats.RxPackets, "Network rx packets should not be zero")
-	assert.NotEqual(ifaceStats.RxBytes, ifaceStats.TxBytes, "Network tx and rx bytes should not be equal")
-	assert.NotEqual(ifaceStats.RxPackets, ifaceStats.TxPackets, "Network tx and rx packets should not be equal")
+	assert.NotEqual(ifaceStats.RxBytes, ifaceStats.TxBytes, fmt.Sprintf("Network tx (%d) and rx (%d) bytes should not be equal", ifaceStats.TxBytes, ifaceStats.RxBytes))
+	assert.NotEqual(ifaceStats.RxPackets, ifaceStats.TxPackets, fmt.Sprintf("Network tx (%d) and rx (%d) packets should not be equal", ifaceStats.TxPackets, ifaceStats.RxPackets))
 }
 
 func TestDockerFilesystemStats(t *testing.T) {


### PR DESCRIPTION
There are a number of flakes in the ci job: https://k8s-testgrid.appspot.com/sig-node-cadvisor#cadvisor-e2e

For example: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cadvisor-e2e/1259431819728654336

```
I0517 03:04:22.588] === RUN   TestDockerContainerNetworkStats
I0517 03:04:22.588] I0517 03:04:07.218068    2342 framework.go:332] About to run - [sudo docker run -d busybox watch -n1 wget http://www.google.com/]
I0517 03:04:22.588] I0517 03:04:18.022055    2342 framework.go:332] About to run - [sudo docker rm -f 4b92991560acd1df0f3eac769ea616391ea6a2e3a8b88c7fc90d874da514f119]
I0517 03:04:22.588] --- FAIL: TestDockerContainerNetworkStats (11.06s)
I0517 03:04:22.589]     docker_test.go:304: 
I0517 03:04:22.589]         	Error Trace:	docker_test.go:304
I0517 03:04:22.589]         	Error:      	Should not be: 0x57
I0517 03:04:22.589]         	Test:       	TestDockerContainerNetworkStats
I0517 03:04:22.589]         	Messages:   	Network tx and rx packets should not be equal
```

The test creates the busybox container, waits 10 seconds, and then verifies metrics.  My suspicion is that:

1. The stats collected immediately after container creation often have the same network tx and rx.
2. The 10 second wait time is likely only collecting a single sample since housekeeping is 10s long + jitter.

This PR does 2 things to address this:

1. Increase the sleep to 20s.  This guarantees we get at least 2 samples.
2. Add debug information so we can tell what the identical values are.

cc @dims @iwankgb 