### PR TITLE
runner: fix goroutine leak

### DIFF
--- a/integration/runner/runner.go
+++ b/integration/runner/runner.go
@@ -111,7 +111,7 @@ func PushAndRunTests(host, testDir string) (result error) {
 	// Start cAdvisor.
 	klog.Infof("Running cAdvisor on %q...", host)
 	portStr := strconv.Itoa(*port)
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		err = RunSshCommand("ssh", host, "--", fmt.Sprintf("sudo GORACE='halt_on_error=1' %s --port %s --logtostderr --docker_env_metadata_whitelist=TEST_VAR  &> %s/log.txt", path.Join(testDir, cadvisorBinary), portStr, testDir))
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>
The send operation to the channel done will certainly be executed, but the receive operation may not, if the goroutine times out. Hence the goroutine might get stuck and cause a leak. A simple fix is to use a buffered channel so that the goroutine can write to it without having to care if there's a reader or not. This PR converts the channel to a buffered channel.