### PR TITLE
Add socket id into Core

### DIFF
--- a/info/v1/machine.go
+++ b/info/v1/machine.go
@@ -47,9 +47,10 @@ type Node struct {
 }
 
 type Core struct {
-	Id      int     `json:"core_id"`
-	Threads []int   `json:"thread_ids"`
-	Caches  []Cache `json:"caches"`
+	Id       int     `json:"core_id"`
+	Threads  []int   `json:"thread_ids"`
+	Caches   []Cache `json:"caches"`
+	SocketID int     `json:"socket_id"`
 }
 
 type Cache struct {

--- a/machine/topology_test.go
+++ b/machine/topology_test.go
@@ -167,6 +167,21 @@ func TestTopology(t *testing.T) {
 	}
 	sysFs.SetHugePagesNr(hugePageNr, nil)
 
+	physicalPackageIDs := map[string]string{
+		"/fakeSysfs/devices/system/node/node0/cpu0":  "0",
+		"/fakeSysfs/devices/system/node/node0/cpu1":  "0",
+		"/fakeSysfs/devices/system/node/node0/cpu2":  "0",
+		"/fakeSysfs/devices/system/node/node0/cpu3":  "0",
+		"/fakeSysfs/devices/system/node/node0/cpu4":  "0",
+		"/fakeSysfs/devices/system/node/node0/cpu5":  "0",
+		"/fakeSysfs/devices/system/node/node0/cpu6":  "1",
+		"/fakeSysfs/devices/system/node/node0/cpu7":  "1",
+		"/fakeSysfs/devices/system/node/node0/cpu8":  "1",
+		"/fakeSysfs/devices/system/node/node0/cpu9":  "1",
+		"/fakeSysfs/devices/system/node/node0/cpu10": "1",
+		"/fakeSysfs/devices/system/node/node0/cpu11": "1",
+	}
+	sysFs.SetPhysicalPackageIDs(physicalPackageIDs, nil)
 	topology, numCores, err := GetTopology(sysFs)
 	assert.Nil(t, err)
 	assert.Equal(t, 12, numCores)
@@ -257,7 +272,7 @@ func TestTopologyWithoutNodes(t *testing.T) {
 	topologyJSON2, err := json.Marshal(topology[1])
 	assert.Nil(t, err)
 
-	expectedTopology1 := `{"node_id":0,"memory":0,"hugepages":null,"cores":[{"core_id":0,"thread_ids":[0,2],"caches":[{"size":32768,"type":"unified","level":0}]}],"caches":null}`
+	expectedTopology1 := `{"node_id":0,"memory":0,"hugepages":null,"cores":[{"core_id":0,"thread_ids":[0,2],"caches":[{"size":32768,"type":"unified","level":0}], "socket_id": 0}],"caches":null}`
 	expectedTopology2 := `
 		{
 			"node_id":1,
@@ -276,7 +291,8 @@ func TestTopologyWithoutNodes(t *testing.T) {
 						"type":"unified",
 						"level":0
 					}
-					]
+					],
+					"socket_id": 1
 				}
 			],
 			"caches":null
@@ -284,12 +300,9 @@ func TestTopologyWithoutNodes(t *testing.T) {
 
 	json1 := string(topologyJSON1)
 	json2 := string(topologyJSON2)
-	if expectedTopology1 == json1 {
-		assert.JSONEq(t, expectedTopology2, json2)
-	} else {
-		assert.JSONEq(t, expectedTopology2, json1)
-		assert.JSONEq(t, expectedTopology1, json2)
-	}
+
+	assert.JSONEq(t, expectedTopology1, json1)
+	assert.JSONEq(t, expectedTopology2, json2)
 }
 
 func TestTopologyWithNodesWithoutCPU(t *testing.T) {

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -403,6 +403,17 @@ func getCoresInfo(sysFs sysfs.SysFs, cpuDirs []string) ([]info.Core, error) {
 		} else {
 			desiredCore.Threads = append(desiredCore.Threads, cpuID)
 		}
+
+		rawPhysicalPackageID, err := sysFs.GetCPUPhysicalPackageID(cpuDir)
+		if err != nil {
+			return nil, err
+		}
+
+		physicalPackageID, err := strconv.Atoi(rawPhysicalPackageID)
+		if err != nil {
+			return nil, err
+		}
+		desiredCore.SocketID = physicalPackageID
 	}
 	return cores, nil
 }

--- a/utils/sysinfo/sysinfo_test.go
+++ b/utils/sysinfo/sysinfo_test.go
@@ -153,6 +153,14 @@ func TestGetNodesInfo(t *testing.T) {
 	}
 	fakeSys.SetHugePagesNr(hugePageNr, nil)
 
+	physicalPackageIDs := map[string]string{
+		"/fakeSysfs/devices/system/node/node0/cpu0": "0",
+		"/fakeSysfs/devices/system/node/node0/cpu1": "0",
+		"/fakeSysfs/devices/system/node/node0/cpu2": "1",
+		"/fakeSysfs/devices/system/node/node0/cpu3": "1",
+	}
+	fakeSys.SetPhysicalPackageIDs(physicalPackageIDs, nil)
+
 	nodes, cores, err := GetNodesInfo(fakeSys)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(nodes))
@@ -178,7 +186,8 @@ func TestGetNodesInfo(t *testing.T) {
               0,
               1
             ],
-            "caches": null
+            "caches": null,
+	    "socket_id": 0
           }
         ],
         "caches": [
@@ -205,7 +214,8 @@ func TestGetNodesInfo(t *testing.T) {
               2,
               3
             ],
-            "caches": null
+            "caches": null,
+	    "socket_id": 1
           }
         ],
         "caches": [
@@ -317,6 +327,14 @@ func TestGetNodesInfoWithoutCacheInfo(t *testing.T) {
 	}
 	fakeSys.SetHugePagesNr(hugePageNr, nil)
 
+	physicalPackageIDs := map[string]string{
+		"/fakeSysfs/devices/system/node/node0/cpu0": "0",
+		"/fakeSysfs/devices/system/node/node0/cpu1": "0",
+		"/fakeSysfs/devices/system/node/node0/cpu2": "1",
+		"/fakeSysfs/devices/system/node/node0/cpu3": "1",
+	}
+	fakeSys.SetPhysicalPackageIDs(physicalPackageIDs, nil)
+
 	nodes, cores, err := GetNodesInfo(fakeSys)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(nodes))
@@ -342,7 +360,8 @@ func TestGetNodesInfoWithoutCacheInfo(t *testing.T) {
               0,
               1
             ],
-            "caches": null
+            "caches": null,
+	    "socket_id": 0
           }
         ],
         "caches": null
@@ -363,7 +382,8 @@ func TestGetNodesInfoWithoutCacheInfo(t *testing.T) {
               2,
               3
             ],
-            "caches": null
+            "caches": null,
+	    "socket_id": 1
           }
         ],
         "caches": null
@@ -411,6 +431,14 @@ func TestGetNodesInfoWithoutHugePagesInfo(t *testing.T) {
 	memTotal := "MemTotal:       32817192 kB"
 	fakeSys.SetMemory(memTotal, nil)
 
+	physicalPackageIDs := map[string]string{
+		"/fakeSysfs/devices/system/node/node0/cpu0": "0",
+		"/fakeSysfs/devices/system/node/node0/cpu1": "0",
+		"/fakeSysfs/devices/system/node/node0/cpu2": "1",
+		"/fakeSysfs/devices/system/node/node0/cpu3": "1",
+	}
+	fakeSys.SetPhysicalPackageIDs(physicalPackageIDs, nil)
+
 	nodes, cores, err := GetNodesInfo(fakeSys)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(nodes))
@@ -437,7 +465,8 @@ func TestGetNodesInfoWithoutHugePagesInfo(t *testing.T) {
                 "type": "unified",
                 "level": 2
               }
-            ]
+            ],
+	    "socket_id": 0
           }
         ],
         "caches": null
@@ -459,7 +488,8 @@ func TestGetNodesInfoWithoutHugePagesInfo(t *testing.T) {
                 "type": "unified",
                 "level": 2
               }
-            ]
+            ],
+	    "socket_id": 1
           }
         ],
         "caches": null
@@ -539,7 +569,8 @@ func TestGetNodesInfoWithoutNodes(t *testing.T) {
 						"type":"unified",
 						"level":1
 					 }
-				  ]
+				  ],
+				  "socket_id": 0
 			   }
 			],
 			"caches":null
@@ -561,7 +592,8 @@ func TestGetNodesInfoWithoutNodes(t *testing.T) {
 						"type":"unified",
 						"level":1
 					 }
-				  ]
+				  ],
+				  "socket_id": 1
 			   }
 			],
 			"caches":null


### PR DESCRIPTION
Now cadvisor in MachineInfo.Topology keeps NUMA nodes.
There is no socket information, except number of sockets.
Since socket - NUMA nodes relationship could be many-to-many,
it's more reasonable to keep socket_id per Core, not per NUMA node.

This socket id could be used in kubernetes cpu manager to provide
per socket allocations.

Signed-off-by: Alexey Perevalov <alexey.perevalov@huawei.com>