### PR TITLE
oomparser_test: fix data race

### DIFF
--- a/utils/oomparser/oomparser_test.go
+++ b/utils/oomparser/oomparser_test.go
@@ -450,11 +450,11 @@ func TestStreamOOMs(t *testing.T) {
 	}
 
 	for _, pair := range testPairs {
-		go func() {
+		go func(pair interface{}) {
 			for _, x := range pair.in {
 				writeAll(x.msgs, x.time)
 			}
-		}()
+		}(pair)
 		for _, expected := range pair.out {
 			oom := <-oomsOut
 			assert.Equal(t, expected, oom)

--- a/utils/oomparser/oomparser_test.go
+++ b/utils/oomparser/oomparser_test.go
@@ -450,11 +450,12 @@ func TestStreamOOMs(t *testing.T) {
 	}
 
 	for _, pair := range testPairs {
-		go func(pair interface{}) {
+		pair := pair
+		go func() {
 			for _, x := range pair.in {
 				writeAll(x.msgs, x.time)
 			}
-		}(pair)
+		}()
 		for _, expected := range pair.out {
 			oom := <-oomsOut
 			assert.Equal(t, expected, oom)


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>
Capture the iterator variable pair in the goroutine to avoid data race.