### PR TITLE
Fix test with different order of Topology's nodes

### DIFF
--- a/machine/topology_test.go
+++ b/machine/topology_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
 
 	info "github.com/google/cadvisor/info/v1"
@@ -263,6 +264,9 @@ func TestTopologyWithoutNodes(t *testing.T) {
 	sysFs.SetPhysicalPackageIDs(physicalPackageIDs, nil)
 
 	topology, numCores, err := GetTopology(sysFs)
+	sort.SliceStable(topology, func(i, j int) bool {
+		return topology[i].Id < topology[j].Id
+	})
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(topology))
 	assert.Equal(t, 4, numCores)


### PR DESCRIPTION
GetTopology provides Nodes not in order of Node.Id.
PR https://github.com/google/cadvisor/pull/2551 removed that check,
as result test acidentially passed.

Fixes: #2557

Signed-off-by: Alexey Perevalov <alexey.perevalov@huawei.com>