### PR TITLE
Return a NoopManager if metricset does not container the accelerator value

### DIFF
--- a/accelerators/nvidia.go
+++ b/accelerators/nvidia.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/cadvisor/container"
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/stats"
 
@@ -48,7 +49,12 @@ var sysFsPCIDevicesPath = "/sys/bus/pci/devices/"
 
 const nvidiaVendorID = "0x10de"
 
-func NewNvidiaManager() stats.Manager {
+func NewNvidiaManager(includedMetrics container.MetricSet) stats.Manager {
+	if !includedMetrics.Has(container.AcceleratorUsageMetrics) {
+		klog.V(2).Info("NVIDIA GPU metrics disabled")
+		return &stats.NoopManager{}
+	}
+
 	manager := &nvidiaManager{}
 	err := manager.setup()
 	if err != nil {

--- a/accelerators/nvidia.go
+++ b/accelerators/nvidia.go
@@ -58,14 +58,14 @@ func NewNvidiaManager(includedMetrics container.MetricSet) stats.Manager {
 	manager := &nvidiaManager{}
 	err := manager.setup()
 	if err != nil {
-		klog.Warningf("NVidia GPU metrics will not be available: %s", err)
+		klog.Warningf("NVIDIA GPU metrics will not be available: %s", err)
 		manager.Destroy()
 		return &stats.NoopManager{}
 	}
 	return manager
 }
 
-// setup initializes NVML if nvidia devices are present on the node.
+// setup initializes NVML if NVIDIA devices are present on the node.
 func (nm *nvidiaManager) setup() error {
 	if !detectDevices(nvidiaVendorID) {
 		return fmt.Errorf("no NVIDIA devices found")
@@ -110,21 +110,21 @@ var initializeNVML = func(nm *nvidiaManager) error {
 	nm.nvmlInitialized = true
 	numDevices, err := gonvml.DeviceCount()
 	if err != nil {
-		return fmt.Errorf("GPU metrics would not be available. Failed to get the number of nvidia devices: %v", err)
+		return fmt.Errorf("GPU metrics would not be available. Failed to get the number of NVIDIA devices: %v", err)
 	}
 	if numDevices == 0 {
 		return nil
 	}
-	klog.V(1).Infof("NVML initialized. Number of nvidia devices: %v", numDevices)
+	klog.V(1).Infof("NVML initialized. Number of NVIDIA devices: %v", numDevices)
 	nm.nvidiaDevices = make(map[int]gonvml.Device, numDevices)
 	for i := 0; i < int(numDevices); i++ {
 		device, err := gonvml.DeviceHandleByIndex(uint(i))
 		if err != nil {
-			return fmt.Errorf("Failed to get nvidia device handle %d: %v", i, err)
+			return fmt.Errorf("Failed to get NVIDIA device handle %d: %v", i, err)
 		}
 		minorNumber, err := device.MinorNumber()
 		if err != nil {
-			return fmt.Errorf("Failed to get nvidia device minor number: %v", err)
+			return fmt.Errorf("Failed to get NVIDIA device minor number: %v", err)
 		}
 		nm.nvidiaDevices[int(minorNumber)] = device
 	}
@@ -141,7 +141,7 @@ func (nm *nvidiaManager) Destroy() {
 	}
 }
 
-// GetCollector returns a collector that can fetch nvidia gpu metrics for nvidia devices
+// GetCollector returns a collector that can fetch NVIDIA gpu metrics for NVIDIA devices
 // present in the devices.list file in the given devicesCgroupPath.
 func (nm *nvidiaManager) GetCollector(devicesCgroupPath string) (stats.Collector, error) {
 	nc := &nvidiaCollector{}
@@ -171,7 +171,7 @@ func (nm *nvidiaManager) GetCollector(devicesCgroupPath string) (stats.Collector
 	for _, minor := range nvidiaMinorNumbers {
 		device, ok := nm.nvidiaDevices[minor]
 		if !ok {
-			return &stats.NoopCollector{}, fmt.Errorf("nvidia device minor number %d not found in cached devices", minor)
+			return &stats.NoopCollector{}, fmt.Errorf("NVIDIA device minor number %d not found in cached devices", minor)
 		}
 		nc.devices = append(nc.devices, device)
 	}

--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -93,6 +93,7 @@ var (
 
 	// List of metrics that can be ignored.
 	ignoreWhitelist = container.MetricSet{
+		container.AcceleratorUsageMetrics:        struct{}{},
 		container.DiskUsageMetrics:               struct{}{},
 		container.DiskIOMetrics:                  struct{}{},
 		container.NetworkUsageMetrics:            struct{}{},
@@ -136,7 +137,7 @@ func (ml *metricSetValue) Set(value string) error {
 }
 
 func init() {
-	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'cpu_topology','disk', 'diskIO', 'network', 'tcp', 'udp', 'percpu', 'sched', 'process', 'hugetlb', 'referenced_memory'.")
+	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'accelerator', 'cpu_topology','disk', 'diskIO', 'network', 'tcp', 'udp', 'percpu', 'sched', 'process', 'hugetlb', 'referenced_memory'.")
 
 	// Default logging verbosity to V(2)
 	flag.Set("v", "2")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -197,7 +197,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, houskeepingConfig
 		containerWatchers:                     []watcher.ContainerWatcher{},
 		eventsChannel:                         eventsChannel,
 		collectorHTTPClient:                   collectorHTTPClient,
-		nvidiaManager:                         accelerators.NewNvidiaManager(),
+		nvidiaManager:                         accelerators.NewNvidiaManager(includedMetricsSet),
 		rawContainerCgroupPathPrefixWhiteList: rawContainerCgroupPathPrefixWhiteList,
 	}
 


### PR DESCRIPTION
Hello!

This is a slight improvement of the NVIDIA API, this is needed because the NVIDIA manager opens a handle on nvml at NewNvidiaManager time.

This is problematic in a kubernetes setting where kubelet now has an open handle on the NVIDIA driver, preventing an update of the NVIDIA driver unless kubelet is restarted.

Additionally with the new metrics pipeline in Kubernetes, metrics are now expected to be collected through a container rather than through the kubelet itself.

I'm hoping that with the following enhancement in Kubernetes: https://github.com/kubernetes/kubernetes/pull/88841 we can add a knob for cluster admins to remove that reference on the driver.

For testing, here is an example output (slightly edited):
```
➜  cadvisor git:(master) ./cadvisor -v 2 --disable_metrics accelerator
I0605 00:08:04.623264   23501 storagedriver.go:55] Caching stats in memory for 2m0s
I0605 00:08:04.623564   23501 manager.go:161] cAdvisor running in container: "/sys/fs/cgroup/cpu,cpuacct/user.slice"
I0605 00:08:04.678097   23501 fs.go:127] Filesystem UUIDs:...


I0605 00:08:04.678198   23501 nvidia.go:54] NVIDIA GPU metrics disabled


I0605 00:08:04.686107   23501 manager.go:209] Machine: {Timestamp:2020-06-05 00:08:04.68455301 +0000 UTC m=+0.116460740 ...}
I0605 00:08:04.686301   23501 manager_no_libpfm.go:27] cAdvisor is build without cgo and/or libpfm support. Perf event counters are not available.
I0605 00:08:04.702497   23501 manager.go:220] Version: {KernelVersion:5.3.0-1017-aws ContainerOsVersion:Ubuntu 18.04.4 LTS DockerVersion:19.03.8 DockerAPIVersion:1.40 CadvisorVersion:v0.36.0.230+170bae8a5deee2 CadvisorRevision:170bae8a}
I0605 00:08:04.721440   23501 factory.go:370] Registering Docker factory
I0605 00:08:04.721469   23501 factory.go:55] Registering systemd factory
I0605 00:08:04.721666   23501 factory.go:101] Registering Raw factory
I0605 00:08:04.721854   23501 manager.go:1167] Started watching for new ooms in manager
I0605 00:08:04.722306   23501 manager.go:291] Starting recovery of all containers
I0605 00:08:04.816064   23501 manager.go:296] Recovery completed
I0605 00:08:04.857343   23501 cadvisor.go:206] Starting cAdvisor version: v0.36.0.230+170bae8a5deee2-170bae8a on port 8080
^C
I0605 00:08:05.669499   23501 manager.go:1157] Exiting thread watching subcontainers
I0605 00:08:05.669546   23501 manager.go:393] Exiting global housekeeping thread
I0605 00:08:05.669584   23501 collector_no_libpfm.go:32] cAdvisor is build without cgo and/or libpfm support. Nothing to be finalized
I0605 00:08:05.669611   23501 cadvisor.go:243] Exiting given signal: interrupt
```

/cc @dashpole 

Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>