### PR TITLE
Fix incorrect diskstats for dm devices

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -418,7 +418,17 @@ func (i *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error
 					Major:  uint(partition.major),
 					Minor:  uint(partition.minor),
 				}
-				fs.DiskStats = diskStatsMap[device]
+
+				if val, ok := diskStatsMap[device]; ok {
+					fs.DiskStats = val
+				} else {
+					for k, v := range diskStatsMap {
+						if v.MajorNum == uint64(partition.major) && v.MinorNum == uint64(partition.minor) {
+							fs.DiskStats = diskStatsMap[k]
+							break
+						}
+					}
+				}
 				filesystems = append(filesystems, fs)
 			}
 		}
@@ -450,13 +460,22 @@ func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
 		}
 		// 8      50 sdd2 40 0 280 223 7 0 22 108 0 330 330
 		deviceName := path.Join("/dev", words[2])
+
+		var error error
+		devInfo := make([]uint64, 2)
+		for i := 0; i < len(devInfo); i++ {
+			devInfo[i], error = strconv.ParseUint(words[i], 10, 64)
+			if error != nil {
+				return nil, error
+			}
+		}
+
 		wordLength := len(words)
 		offset := 3
 		var stats = make([]uint64, wordLength-offset)
 		if len(stats) < 11 {
 			return nil, fmt.Errorf("could not parse all 11 columns of /proc/diskstats")
 		}
-		var error error
 		for i := offset; i < wordLength; i++ {
 			stats[i-offset], error = strconv.ParseUint(words[i], 10, 64)
 			if error != nil {
@@ -464,6 +483,8 @@ func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
 			}
 		}
 		diskStats := DiskStats{
+			MajorNum:        devInfo[0],
+			MinorNum:        devInfo[1],
 			ReadsCompleted:  stats[0],
 			ReadsMerged:     stats[1],
 			SectorsRead:     stats[2],

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -79,6 +79,22 @@ func TestGetDiskStatsMap(t *testing.T) {
 	}
 }
 
+func TestGetDiskStatsMapMajorMinorNum(t *testing.T) {
+	diskStatsMap, err := getDiskStatsMap("test_resources/diskstats")
+	if err != nil {
+		t.Errorf("Error calling getDiskStatMap %s", err)
+	}
+	if len(diskStatsMap) != 30 {
+		t.Errorf("diskStatsMap %+v not valid", diskStatsMap)
+	}
+
+	if stat, ok := diskStatsMap["/dev/dm-0"]; ok {
+		if stat.MajorNum != 252 && stat.MinorNum != 1 {
+			t.Fatalf("getDiskStatsMap did not return correct major (%d) and minor (%d) numbers", stat.MajorNum, stat.MinorNum)
+		}
+	}
+}
+
 func TestFileNotExist(t *testing.T) {
 	_, err := getDiskStatsMap("/file_does_not_exist")
 	if err != nil {

--- a/fs/types.go
+++ b/fs/types.go
@@ -64,6 +64,8 @@ type Fs struct {
 }
 
 type DiskStats struct {
+	MajorNum        uint64
+	MinorNum        uint64
 	ReadsCompleted  uint64
 	ReadsMerged     uint64
 	SectorsRead     uint64


### PR DESCRIPTION
This PR fixes the issue of generating correct `DiskStats` if disk names do not match with the device name found in `/proc/diskstats`

When we have dm devices, the name of the root device may not match with the device name seen by `lsblk` of `/proc/self/mountinfo`. 

```bash
# lsblk -fs 
NAME                     FSTYPE      LABEL        UUID                                 MOUNTPOINT
sda1                     ext4        boot         fd9689d9-fbcc-488a-a70e-145fddf245e7 /boot
└─sda                                                                                  
sda2                     vfat        EFI-SYSTEM   4FC5-6A46                            /boot/efi
└─sda                                                                                  
sda3                                                                                   
└─sda                                                                                  
coreos-luks-root-nocrypt xfs         root         d2d725c8-d0aa-4f58-a6fb-811d90240135 /sysroot
└─sda4                   crypto_LUKS crypt_rootfs 00000000-0000-4000-a000-000000000002 
  └─sda            
```
```bash
# cat /proc/diskstats 
   8       0 sda 7512 11 827015 7436 321336 33931 10380796 582825 0 186009 438510 0 0 0 0
   8       1 sda1 144 0 8802 84 9 5 40 9 0 97 24 0 0 0 0
   8       2 sda2 443 0 11953 804 1 0 1 0 0 89 616 0 0 0 0
   8       3 sda3 26 0 208 17 0 0 0 0 0 14 8 0 0 0 0
   8       4 sda4 6823 11 802436 6487 255736 33926 10380755 573503 0 168713 436019 0 0 0 0
 253       0 dm-0 6816 0 798794 6565 355249 0 10941122 819340 0 186266 825905 0 0 0 0
```
In this scenario a Prometheus stats fails to return any metric for the root device

```
Prometheus query, container_fs_io_time_seconds_total{id="/"}, looks like,

container_fs_io_time_seconds_total{device="/dev/mapper/coreos-luks-root-nocrypt",endpoint="https-metrics",id="/",instance="10.0.0.3:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-m-2.c.openshift-gce-devel.internal",service="kubelet"}	0
container_fs_io_time_seconds_total{device="/dev/mapper/coreos-luks-root-nocrypt",endpoint="https-metrics",id="/",instance="10.0.0.4:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-m-1.c.openshift-gce-devel.internal",service="kubelet"}	0
container_fs_io_time_seconds_total{device="/dev/mapper/coreos-luks-root-nocrypt",endpoint="https-metrics",id="/",instance="10.0.0.5:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-m-0.c.openshift-gce-devel.internal",service="kubelet"}	0
container_fs_io_time_seconds_total{device="/dev/mapper/coreos-luks-root-nocrypt",endpoint="https-metrics",id="/",instance="10.0.32.2:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-w-c-ntcdh.c.openshift-gce-devel.internal",service="kubelet"}	0
container_fs_io_time_seconds_total{device="/dev/mapper/coreos-luks-root-nocrypt",endpoint="https-metrics",id="/",instance="10.0.32.3:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-w-a-br6nb.c.openshift-gce-devel.internal",service="kubelet"}	0
container_fs_io_time_seconds_total{device="/dev/mapper/coreos-luks-root-nocrypt",endpoint="https-metrics",id="/",instance="10.0.32.4:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-w-b-w6tbg.c.openshift-gce-devel.internal",service="kubelet"}	0
container_fs_io_time_seconds_total{device="/dev/sda1",endpoint="https-metrics",id="/",instance="10.0.0.3:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-m-2.c.openshift-gce-devel.internal",service="kubelet"}	0.000000131
container_fs_io_time_seconds_total{device="/dev/sda1",endpoint="https-metrics",id="/",instance="10.0.0.4:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-m-1.c.openshift-gce-devel.internal",service="kubelet"}	0.000000079
container_fs_io_time_seconds_total{device="/dev/sda1",endpoint="https-metrics",id="/",instance="10.0.0.5:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-m-0.c.openshift-gce-devel.internal",service="kubelet"}	0.000000103
container_fs_io_time_seconds_total{device="/dev/sda1",endpoint="https-metrics",id="/",instance="10.0.32.2:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-w-c-ntcdh.c.openshift-gce-devel.internal",service="kubelet"}	0.000000106
container_fs_io_time_seconds_total{device="/dev/sda1",endpoint="https-metrics",id="/",instance="10.0.32.3:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-w-a-br6nb.c.openshift-gce-devel.internal",service="kubelet"}	0.000000097
container_fs_io_time_seconds_total{device="/dev/sda1",endpoint="https-metrics",id="/",instance="10.0.32.4:10250",job="kubelet",metrics_path="/metrics/cadvisor",node="debug-plxnc-w-b-w6tbg.c.openshift-gce-devel.internal",service="kubelet"}	0.000000101
``` 

This happens because the while executing `fs.GetFsInfoForPath` the devices found in `/proc/diskstats` may not have the same name as found in `/proc/self/mountinfo`. 

To fix this issue, this PR will introduce changes which will look the device using the major and the minor number to assign correct `DiskStats` to the corresponding `Fs` (filesystem) struct. 

I have observed this issue on RHCOS and Fedora 31 system with root device coming from dm. 





Signed-off-by: Harshal Patil <harpatil@redhat.com>