### PR TITLE
Change resources for cadvisor container in perf example

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -33,6 +33,8 @@ To generate and apply the daemonset with patches for cAdvisor with perf support:
 kustomize build deploy/kubernetes/overlays/examples_perf | kubectl apply -f -
 ```
 
+Be aware, that perf gathering generates more data, and the CPU may be a bottleneck. If the stats take too long to get, try increasing CPU limits in daemonset configuration.
+
 ## Kustomization
 
 On your own fork of cAdvisor, create your own overlay directoy with your patches.  Copy patches from the example folder if you intend to use them, but don't modify the originals.  Commit your changes in your local branch, and use git to manage them the same way you would any other piece of code.

--- a/deploy/kubernetes/overlays/examples_perf/cadvisor-perf.yaml
+++ b/deploy/kubernetes/overlays/examples_perf/cadvisor-perf.yaml
@@ -1,4 +1,4 @@
-# This patch is an example of setting arguments for the cAdvisor container to collect perf metrics 
+# This patch is an example of setting arguments for the cAdvisor container to collect perf metrics
 apiVersion: apps/v1 # for Kubernetes versions before 1.9.0 use apps/v1beta2
 kind: DaemonSet
 metadata:
@@ -9,8 +9,14 @@ spec:
     spec:
       containers:
       - name: cadvisor
+        # If the stats take too long to gather, try increasing CPU limits.
+        resources:
+          requests:
+            cpu: 1
+          limits:
+            cpu: 1
         args:
-          - --perf_events_config=/etc/config/perf-non-hardware.json
+          - --perf_events_config=/etc/config/perf-non-hardware.json --v=5
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Hi,
I tried to run cadvisor with perf example. A word about my setup: I have a machine in a cluster(I limited daemonset only to single node in 3 nodes cluster), which is running around 40 containers. The response times of curl for /metrics on default settings from example:
- running cadvisor with perf without container: did not measure, although it was pretty fast
- running cadvisor without perf with container: around 40 seconds
- running cadvisor with perf with container: after almost 20 minutes curl reports that i was unable to get all the data

I played a little bit with limits and it seems that this is CPU related. So i suggest this change in example and mention it in readme for examples.