### PR TITLE
Fix incorrect detection of images path

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -329,7 +329,8 @@ func (i *RealFsInfo) updateContainerImagesPath(label string, mounts []mount.Moun
 	for _, m := range mounts {
 		if _, ok := containerImagePaths[m.MountPoint]; ok {
 			if useMount == nil || (len(useMount.MountPoint) < len(m.MountPoint)) {
-				useMount = &m
+				useMount = new(mount.MountInfo)
+				*useMount = m
 			}
 		}
 	}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -361,6 +361,22 @@ func TestAddDockerImagesLabel(t *testing.T) {
 		expectedPartition              *partition
 	}{
 		{
+			name: "single partition, no dedicated image fs",
+			mounts: []mount.MountInfo{
+				{
+					Source:     "/dev/root",
+					MountPoint: "/",
+					FsType:     "ext4",
+				},
+				{
+					Source:     "/sys/fs/cgroup",
+					MountPoint: "/sys/fs/cgroup",
+					FsType:     "tmpfs",
+				},
+			},
+			expectedDockerDevice: "/dev/root",
+		},
+		{
 			name:         "devicemapper, not loopback",
 			driver:       "devicemapper",
 			driverStatus: map[string]string{"Pool Name": "vg_vagrant-docker--pool"},


### PR DESCRIPTION
Images path is incorrectly detected as the last one in the list of possible locations.
As all tests used the last value as the expected value, this issue was not detected earlier.

The issue has a pretty high risk as one can end up with:
* frequent unnecessary images GC
* no images GC at all
* nodes being tainted `node.kubernetes.io/disk-pressure: NoSchedule`

Ref: https://github.com/kubernetes/kubernetes/issues/91982