### PR TITLE
Remove redundant installation of libpfm4

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,10 +13,6 @@ RUN export DBG="-g -Wall" && \
   make -e -C libpfm-4.10.1 && \
   make install -C libpfm-4.10.1
 
-RUN export DBG="-g -Wall" && \
-  make -e -C libpfm-4.10.1 && \
-  make install -C libpfm-4.10.1
-
 ADD . /go/src/github.com/google/cadvisor
 WORKDIR /go/src/github.com/google/cadvisor
 


### PR DESCRIPTION
Signed-off-by: Katarzyna Kujawa <katarzyna.kujawa@intel.com>

libpfm4 was built and installed twice, see lines 12-14 and lines 16-18 in Dockerfile