### PR TITLE
Allow on-demand metrics collection for prometheus

### DIFF
--- a/cmd/internal/http/handlers.go
+++ b/cmd/internal/http/handlers.go
@@ -96,14 +96,28 @@ func RegisterHandlers(mux httpmux.Mux, containerManager manager.Manager, httpAut
 // the provided HTTP mux to handle the given Prometheus endpoint.
 func RegisterPrometheusHandler(mux httpmux.Mux, resourceManager manager.Manager, prometheusEndpoint string,
 	f metrics.ContainerLabelsFunc, includedMetrics container.MetricSet) {
-	r := prometheus.NewRegistry()
-	r.MustRegister(
-		metrics.NewPrometheusCollector(resourceManager, f, includedMetrics, clock.RealClock{}),
-		metrics.NewPrometheusMachineCollector(resourceManager, includedMetrics),
-		prometheus.NewGoCollector(),
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
-	)
-	mux.Handle(prometheusEndpoint, promhttp.HandlerFor(r, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
+	goCollector := prometheus.NewGoCollector()
+	processCollector := prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{})
+	machineCollector := metrics.NewPrometheusMachineCollector(resourceManager, includedMetrics)
+
+	mux.Handle(prometheusEndpoint, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		opts, err := api.GetRequestOptions(req)
+		if err != nil {
+			http.Error(w, "No metrics gathered, last error:\n\n"+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		opts.Count = 1        // we only want the latest datapoint
+		opts.Recursive = true // get all child containers
+
+		r := prometheus.NewRegistry()
+		r.MustRegister(
+			metrics.NewPrometheusCollector(resourceManager, f, includedMetrics, clock.RealClock{}, opts),
+			machineCollector,
+			goCollector,
+			processCollector,
+		)
+		promhttp.HandlerFor(r, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}).ServeHTTP(w, req)
+	}))
 }
 
 func staticHandlerNoAuth(w http.ResponseWriter, r *http.Request) {

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -19,7 +19,7 @@ import (
 
 	// TODO(rjnagal): Remove dependency after moving all stats structs from v1.
 	// using v1 now for easy conversion.
-	"github.com/google/cadvisor/info/v1"
+	v1 "github.com/google/cadvisor/info/v1"
 )
 
 const (

--- a/manager/container.go
+++ b/manager/container.go
@@ -33,7 +33,7 @@ import (
 	"github.com/google/cadvisor/collector"
 	"github.com/google/cadvisor/container"
 	info "github.com/google/cadvisor/info/v1"
-	"github.com/google/cadvisor/info/v2"
+	v2 "github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/stats"
 	"github.com/google/cadvisor/summary"
 	"github.com/google/cadvisor/utils/cpuload"

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	info "github.com/google/cadvisor/info/v1"
+	v2 "github.com/google/cadvisor/info/v2"
 )
 
 // metricValue describes a single metric value for a given set of label values
@@ -32,9 +33,8 @@ type metricValues []metricValue
 
 // infoProvider will usually be manager.Manager, but can be swapped out for testing.
 type infoProvider interface {
-	// SubcontainersInfo provides information about all subcontainers of the
-	// specified container including itself.
-	SubcontainersInfo(containerName string, query *info.ContainerInfoRequest) ([]*info.ContainerInfo, error)
+	// GetRequestedContainersInfo gets info for all requested containers based on the request options.
+	GetRequestedContainersInfo(containerName string, options v2.RequestOptions) (map[string]*info.ContainerInfo, error)
 	// GetVersionInfo provides information about the version.
 	GetVersionInfo() (*info.VersionInfo, error)
 	// GetMachineInfo provides information about the machine.

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	info "github.com/google/cadvisor/info/v1"
+	v2 "github.com/google/cadvisor/info/v2"
 )
 
 type testSubcontainersInfoProvider struct{}
@@ -264,9 +265,9 @@ func (p testSubcontainersInfoProvider) GetMachineInfo() (*info.MachineInfo, erro
 	}, nil
 }
 
-func (p testSubcontainersInfoProvider) SubcontainersInfo(string, *info.ContainerInfoRequest) ([]*info.ContainerInfo, error) {
-	return []*info.ContainerInfo{
-		{
+func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.RequestOptions) (map[string]*info.ContainerInfo, error) {
+	return map[string]*info.ContainerInfo{
+		"testcontainer": {
 			ContainerReference: info.ContainerReference{
 				Name:    "testcontainer",
 				Aliases: []string{"testcontaineralias"},
@@ -710,10 +711,10 @@ func (p *erroringSubcontainersInfoProvider) GetMachineInfo() (*info.MachineInfo,
 	return p.successfulProvider.GetMachineInfo()
 }
 
-func (p *erroringSubcontainersInfoProvider) SubcontainersInfo(
-	a string, r *info.ContainerInfoRequest) ([]*info.ContainerInfo, error) {
+func (p *erroringSubcontainersInfoProvider) GetRequestedContainersInfo(
+	a string, opt v2.RequestOptions) (map[string]*info.ContainerInfo, error) {
 	if p.shouldFail {
-		return []*info.ContainerInfo{}, errors.New("Oops 3")
+		return map[string]*info.ContainerInfo{}, errors.New("Oops 3")
 	}
-	return p.successfulProvider.SubcontainersInfo(a, r)
+	return p.successfulProvider.GetRequestedContainersInfo(a, opt)
 }


### PR DESCRIPTION
Fix #1989 
This is a rework of #2000 

This allows user to set v2.RequestOptions for PrometheusCollector to be
used when retrieving container stats. The options will only be set once
per collector to ensure that we don't race for concurrent metrics
request. This should not be a problem for prometheus scrapes as the
scrapes are usually in the same format.

One can design the on-demand metrics collection as such to minimize CPU
usage in housekeeping routine:

- assuming prometheus scrape interval is 60s
- increase housekeeping interval to a high value such as 300s
- set max_age paramether in scrape to a low value ( such as 1s ), so
that if we scrape just as housekeeping finish, we don't do any extra
work. When we scrape, if current metrics are older than 1s, we will
collect the metrics again.

Signed-off-by: Daniel Dao <dqminh89@gmail.com>