### PR TITLE
Add command arguments to GetProcessList

### DIFF
--- a/cmd/internal/api/versions.go
+++ b/cmd/internal/api/versions.go
@@ -454,6 +454,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 		klog.V(4).Infof("Api - Spec for container %q, options %+v", name, opt)
 		ps, err := m.GetProcessList(name, opt)
 		if err != nil {
+			klog.V(4).Infof("process listing failed: %v", err)
 			return fmt.Errorf("process listing failed: %v", err)
 		}
 		return writeResult(ps, w)

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -286,9 +286,10 @@ type ProcessInfo struct {
 	Status        string  `json:"status"`
 	RunningTime   string  `json:"running_time"`
 	CgroupPath    string  `json:"cgroup_path"`
-	Cmd           string  `json:"cmd"`
+	Comm          string  `json:"comm"`
 	FdCount       int     `json:"fd_count"`
 	Psr           int     `json:"psr"`
+	Cmd           string  `json:"cmd"`
 }
 
 type TcpStat struct {

--- a/manager/container.go
+++ b/manager/container.go
@@ -335,7 +335,10 @@ func (cd *containerData) GetProcessList(cadvisorContainer string, inHostNamespac
 		vs *= 1024
 		psr, err := strconv.Atoi(fields[11])
 		if err != nil {
-			return nil, fmt.Errorf("invalid psr %q: %v", fields[11], err)
+			// to avoid defunct processes
+			//return nil, fmt.Errorf("invalid psr %q: %v", fields[11], err)
+			klog.V(4).Infof("invalid psr for pid %q: %q: %v", pid, fields[11], err)
+			psr = -1
 		}
 
 		cgroup, err := cd.getCgroupPath(fields[12])


### PR DESCRIPTION
It will be useful to see `cmd` format option in GetProcessList method. 

What is done:
1. Added `cmd` option to getPsOutput format inside GetProcessList method
2. Renamed previous `cmd` option with actual `comm` option
3. Updated ProcessInfo structure