### PR TITLE
Upgrading golangci-lint to 1.28.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   lint:
     env:
-      GOLANGCI_LINT_V: 1.26.0
+      GOLANGCI_LINT_V: 1.28.0
     strategy:
       matrix:
         environment-variables: [build/config/plain.sh, build/config/libpfm4.sh]


### PR DESCRIPTION
This is pretty straightforward change that brings `golangci-lint` up-to-date.