### PR TITLE
Remove exclude guest flag from perf event attrs. 

### DIFF
--- a/perf/collector_libpfm.go
+++ b/perf/collector_libpfm.go
@@ -345,7 +345,7 @@ func createPerfEventAttr(event CustomEvent) *unix.PerfEventAttr {
 func setAttributes(config *unix.PerfEventAttr, leader bool) {
 	config.Sample_type = unix.PERF_SAMPLE_IDENTIFIER
 	config.Read_format = unix.PERF_FORMAT_TOTAL_TIME_ENABLED | unix.PERF_FORMAT_TOTAL_TIME_RUNNING | unix.PERF_FORMAT_GROUP | unix.PERF_FORMAT_ID
-	config.Bits = unix.PerfBitInherit | unix.PerfBitExcludeGuest
+	config.Bits = unix.PerfBitInherit
 
 	// Group leader should have this flag set to disable counting until all group would be prepared.
 	if leader {

--- a/perf/collector_libpfm_test.go
+++ b/perf/collector_libpfm_test.go
@@ -172,13 +172,13 @@ func TestSetGroupAttributes(t *testing.T) {
 	setAttributes(attributes, true)
 	assert.Equal(t, uint64(65536), attributes.Sample_type)
 	assert.Equal(t, uint64(0xf), attributes.Read_format)
-	assert.Equal(t, uint64(0x100003), attributes.Bits)
+	assert.Equal(t, uint64(0x3), attributes.Bits)
 
 	attributes = createPerfEventAttr(event)
 	setAttributes(attributes, false)
 	assert.Equal(t, uint64(65536), attributes.Sample_type)
 	assert.Equal(t, uint64(0xf), attributes.Read_format)
-	assert.Equal(t, uint64(0x100002), attributes.Bits)
+	assert.Equal(t, uint64(0x2), attributes.Bits)
 }
 
 func TestNewCollector(t *testing.T) {


### PR DESCRIPTION
From https://man7.org/linux/man-pages/man2/perf_event_open.2.html :
```
exclude_guest (since Linux 3.2)
              When conducting measurements that include processes running VM
              instances (i.e., have executed a KVM_RUN ioctl(2)), do not
              measure events happening inside guest instances.  This is only
              meaningful outside the guests; this setting does not change
              counts gathered inside of a guest.  Currently, this function‐
              ality is x86 only.
```

Depend on the kernel version, `perf_event_open` can throw `invalid_argument` for uncore events with this flag set.
For core events it's also unnecessary.

Signed-off-by: Paweł Szulik <pawel.szulik@intel.com>