### PR TITLE
Use perf attributes from unix lib.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe // indirect
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
-	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1
+	golang.org/x/sys v0.0.0-20200819035508-9a32b3aa38f5
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775 h1:TC0v2RSO1u2kn1ZugjrFXkRZA
 golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200819035508-9a32b3aa38f5 h1:2r6BWB+sWBIRVv2mC6sYNpdbplZte/1k1drwUKUpS60=
+golang.org/x/sys v0.0.0-20200819035508-9a32b3aa38f5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=

--- a/perf/collector_libpfm.go
+++ b/perf/collector_libpfm.go
@@ -343,9 +343,9 @@ func createPerfEventAttr(event CustomEvent) *unix.PerfEventAttr {
 }
 
 func setAttributes(config *unix.PerfEventAttr, leader bool) {
-	config.Sample_type = perfSampleIdentifier
+	config.Sample_type = unix.PERF_SAMPLE_IDENTIFIER
 	config.Read_format = unix.PERF_FORMAT_TOTAL_TIME_ENABLED | unix.PERF_FORMAT_TOTAL_TIME_RUNNING | unix.PERF_FORMAT_GROUP | unix.PERF_FORMAT_ID
-	config.Bits = perfAttrBitsInherit | perfAttrBitsExcludeGuest
+	config.Bits = unix.PerfBitInherit | unix.PerfBitExcludeGuest
 
 	// Group leader should have this flag set to disable counting until all group would be prepared.
 	if leader {

--- a/perf/types_libpfm.go
+++ b/perf/types_libpfm.go
@@ -23,12 +23,6 @@ import (
 	"unsafe"
 )
 
-const (
-	perfSampleIdentifier     = 1 << 16
-	perfAttrBitsInherit      = 1 << 1
-	perfAttrBitsExcludeGuest = 1 << 20
-)
-
 // GroupReadFormat allows to read perf event's values for grouped events.
 // See https://man7.org/linux/man-pages/man2/perf_event_open.2.html section "Reading results" with PERF_FORMAT_GROUP specified.
 type GroupReadFormat struct {


### PR DESCRIPTION
Use perf attributes from unix lib.

Signed-off-by: Paweł Szulik <pawel.szulik@intel.com>