### PR TITLE
Fixed https proxy issue by installing 'full' wget in Docker alpine-based build stage

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12 AS build
 
-RUN apk --no-cache add libc6-compat device-mapper findutils zfs  build-base linux-headers go bash git && \
+RUN apk --no-cache add libc6-compat device-mapper findutils zfs  build-base linux-headers go bash git wget && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
The default alpine 'wget' cannot handle https proxies. The solution is installing wget via `apk add wget`. 

More about it you can read here: https://gitlab.alpinelinux.org/alpine/aports/-/issues/10446

### Before:
```
Executing busybox-1.31.1-r16.trigger
OK: 632 MiB in 105 packages
Removing intermediate container 2c082d006a1d
 ---> 62ad5850270c
Step 3/19 : RUN wget https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.10.1.tar.gz &&   tar -xzf libpfm-4.10.1.tar.gz &&   rm libpfm-4.10.1.tar.gz
 ---> Running in 4e852f499181
Connecting to proxy [...]
wget: server returned error: HTTP/1.1 400 Bad Request
```

### After:
```
Executing busybox-1.31.1-r16.trigger
OK: 634 MiB in 108 packages
Removing intermediate container fb9929f9946a
 ---> f43faec7c894
Step 3/19 : RUN wget https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.10.1.tar.gz &&   tar -xzf libpfm-4.10.1.tar.gz &&   rm libpfm-4.10.1.tar.gz
 ---> Running in ea6de57879c2
--2020-08-20 12:38:30--  https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.10.1.tar.gz
Resolving proxy [...]
Proxy request sent, awaiting response... 200 OK
Length: 1005988 (982K) [application/x-gzip]
Saving to: 'libpfm-4.10.1.tar.gz'
[...]
2020-08-20 12:38:55 (673 KB/s) - 'libpfm-4.10.1.tar.gz' saved [1005988/1005988]
```
