### PR TITLE
add clean operation when watchForNewContainers/Start failed

### DIFF
--- a/container/raw/watcher.go
+++ b/container/raw/watcher.go
@@ -70,11 +70,19 @@ func NewRawContainerWatcher() (watcher.ContainerWatcher, error) {
 
 func (w *rawContainerWatcher) Start(events chan watcher.ContainerEvent) error {
 	// Watch this container (all its cgroups) and all subdirectories.
+	watched := make([]string, 0)
 	for _, cgroupPath := range w.cgroupPaths {
 		_, err := w.watchDirectory(events, cgroupPath, "/")
 		if err != nil {
+			for _, watchedCgroupPath := range watched {
+				_, removeErr := w.watcher.RemoveWatch("/", watchedCgroupPath)
+				if removeErr != nil {
+					klog.Warningf("Failed to remove inotify watch for %q with error: %v", watchedCgroupPath, removeErr)
+				}
+			}
 			return err
 		}
+		watched = append(watched, cgroupPath)
 	}
 
 	// Process the events received from the kernel.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1137,11 +1137,19 @@ func (m *manager) detectSubcontainers(containerName string) error {
 
 // Watches for new containers started in the system. Runs forever unless there is a setup error.
 func (m *manager) watchForNewContainers(quit chan error) error {
+	watched := make([]watcher.ContainerWatcher, 0)
 	for _, watcher := range m.containerWatchers {
 		err := watcher.Start(m.eventsChannel)
 		if err != nil {
+			for _, w := range watched {
+				stopErr := w.Stop()
+				if stopErr != nil {
+					klog.Warningf("Failed to stop wacher %v with error: %v", w, stopErr)
+				}
+			}
 			return err
 		}
+		watched = append(watched, watcher)
 	}
 
 	// There is a race between starting the watch and new container creation so we do a detection before we read new containers.


### PR DESCRIPTION
when watchForNewContainers and rawContainerWatcher  Start fails and return err, but it does not have some clean operations since some ContainerWatchers already execute the Start() functions. so this commit tries to add clean operations when this happens.