### PR TITLE
Update release documentation and process

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -42,19 +42,25 @@ build/build.sh
 
 # Build the docker image
 echo ">> building cadvisor docker image"
-docker_tag="google/cadvisor:$VERSION"
 gcr_tag="gcr.io/cadvisor/cadvisor:$VERSION"
-docker build -t $docker_tag -t $gcr_tag -f deploy/Dockerfile .
+docker build -t $gcr_tag -f deploy/Dockerfile .
 
 # Build the release binary without libpfm4 to not require libpfm4 in runtime environment
 unset GO_FLAGS
 build/build.sh
 
 echo
-echo "Release info:"
+echo "double-check the version below:"
 echo "VERSION=$VERSION"
+echo
+echo "To push docker image to gcr:"
+echo "docker push $gcr_tag"
+echo
+echo "Release info (copy to the release page):"
+echo
+echo "Docker Image: N/A"
+echo "gcr.io Image: $gcr_tag"
+echo
 sha256sum --tag cadvisor
-echo "docker image: $docker_tag"
-echo "gcr.io image: $gcr_tag"
 
 exit 0

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,7 +1,5 @@
 # cAdvisor Release Instructions
 
-Google internal-only version: [cAdvisor Release Instructions](http://go/cadvisor-release-instructions)
-
 ## 1. Send Release PR
 
 Example: https://github.com/google/cadvisor/pull/1281
@@ -18,32 +16,38 @@ Add release notes to [CHANGELOG.md](../../CHANGELOG.md)
 Skip this step for patch releases.
 
 ```
+# Example version
+VERSION=v0.23
+PATCH_VERSION=$VERSION.0
 # Sync to HEAD, or the commit to branch at
-$ git fetch upstream && git checkout upstream/master
+git fetch upstream && git checkout upstream/master
 # Create the branch
-$ git branch release-v0.XX
+git branch release-$VERSION
 # Push it to upstream
-$ git push git@github.com:google/cadvisor.git release-v0.XX
+git push git@github.com:google/cadvisor.git release-$VERSION
 ```
 
-### 2.b Tag the release
-
-For a release of minor version XX, patch version YY:
+### 2.b Tag the release (for all releases)
 
 ```
+# Example patch version
+VERSION=v0.23
+PATCH_VERSION=$VERSION.0
 # Checkout the release branch
-$ git fetch upstream && git checkout upstream/release-v0.XX
+git fetch upstream && git checkout upstream/release-$VERSION
 # Tag the release commit. If you aren't signing, ommit the -s
-$ git tag -s -a v0.XX.YY
+git tag -s -a $PATCH_VERSION
 # Push it to upstream
-$ git push git@github.com:google/cadvisor.git v0.XX.YY
+git push git@github.com:google/cadvisor.git $PATCH_VERSION
 ```
 
-## 3. Build release binary
+## 3. Build release artifacts
 
 Command: `make release`
 
 - Make sure your git client is synced to the release cut point
+- Use the same go version as kubernetes: [dependencies.yaml](https://github.com/kubernetes/kubernetes/blob/master/build/dependencies.yaml#L101)
+- Tip: use https://github.com/moovweb/gvm to manage multiple go versions.
 - Try to build it from the release branch, since we include that in the binary version
 - Verify the ldflags output, in particular check the Version, BuildUser, and GoVersion are expected
 
@@ -51,27 +55,11 @@ Once the build is complete, check the VERSION and note the sha256 hash.
 
 ## 4. Push the Docker images
 
-Docker Hub:
-```
-$ docker login
-Username: ****
-Password: ****
-$ docker push google/cadvisor:$VERSION
-$ docker logout # Good practice with shared account
-```
-
-Google Container Registry:
+`make release` should output a command to push the image.  Alternatively, run:
 
 ```
-$ gcloud auth login <account>
-...
-Go to the following link in your browser:
-
-    https://accounts.google.com/o/oauth2/auth?<redacted>
-
-Enter verification code: ****
-$ gcloud docker push gcr.io/cadvisor/cadvisor:$VERSION
-$ gcloud auth revoke # Log out of shared account
+$ PATCH_VERSION=v0.23.0
+$ docker push gcr.io/cadvisor/cadvisor:$PATCH_VERSION
 ```
 
 ## 5. Cut the release
@@ -81,14 +69,14 @@ Go to https://github.com/google/cadvisor/releases and click "Draft a new release
 - "Tag version" and "Release title" should be preceded by 'v' and then the version. Select the tag pushed in step 2.b
 - Copy an old release as a template (e.g. github.com/google/cadvisor/releases/tag/v0.23.1)
 - Body should start with release notes (from CHANGELOG.md)
-- Next is the Docker image: `google/cadvisor:$VERSION`
+- Next is the Docker image: `gcr.io/cadvisor/cadvisor:$VERSION`
 - Next are the binary hashes (from step 3)
 - Upload the binary build in step 3
-- If this is an alpha or beta release, mark the release as a "pre-release"
+- If this is a minor version release, mark the release as a "pre-release"
 - Click publish when done
 
 ## 6. Finalize the release
 
-~~Once you are satisfied with the release quality (consider waiting a week for bug reports to come in), it is time to promote the release to *latest*~~
+~~Once you are satisfied with the release quality (generally we wait until the next minor release), it is time to remove the "pre-release" tag~~
 
 cAdvisor is no longer pushed with the :latest tag.  This is to ensure tagged images are immutable.


### PR DESCRIPTION
Simplify where we push images, 
print out information to make it easier to write the github release,
clarify which go version we should use to build release artifacts,
remove `$` to make it easier to copy commands,
add instructions for updating the dependency in kubernetes.