### PR TITLE
Add missing flag to runtime_options.md

### DIFF
--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -119,6 +119,7 @@ cAdvisor stores the latest historical data in memory. How long of a history it s
 --collector_key="": Key for the collector's certificate
 --disable_metrics=tcp,advtcp,udp,sched,process,hugetlb: comma-separated list of metrics to be disabled. Options are 'disk', 'network', 'tcp', 'advtcp', 'udp', 'sched', 'process', 'hugetlb'. Note: tcp and udp are disabled by default due to high CPU usage. (default tcp,advtcp,udp,sched,process,hugetlb)
 --prometheus_endpoint="/metrics": Endpoint to expose Prometheus metrics on (default "/metrics")
+--disable_root_cgroup_stats=false: Disable collecting root Cgroup stats
 ```
 
 ## Storage Drivers


### PR DESCRIPTION
Flag was merged in https://github.com/google/cadvisor/pull/2283, but never added to the docs