### PR TITLE
Try to read from sysfs before giving up on non-x86_64

### DIFF
--- a/machine/machine.go
+++ b/machine/machine.go
@@ -90,11 +90,6 @@ func GetSockets(procInfo []byte) int {
 
 // GetClockSpeed returns the CPU clock speed, given a []byte formatted as the /proc/cpuinfo file.
 func GetClockSpeed(procInfo []byte) (uint64, error) {
-	// s390/s390x, mips64, riscv64, aarch64 and arm32 changes
-	if isMips64() || isSystemZ() || isAArch64() || isArm32() || isRiscv64() {
-		return 0, nil
-	}
-
 	// First look through sys to find a max supported cpu frequency.
 	if utils.FileExists(maxFreqFile) {
 		val, err := ioutil.ReadFile(maxFreqFile)
@@ -108,6 +103,11 @@ func GetClockSpeed(procInfo []byte) (uint64, error) {
 		}
 		return maxFreq, nil
 	}
+	// s390/s390x, mips64, riscv64, aarch64 and arm32 changes
+	if isMips64() || isSystemZ() || isAArch64() || isArm32() || isRiscv64() {
+		return 0, nil
+	}
+
 	// Fall back to /proc/cpuinfo
 	matches := cpuClockSpeedMHz.FindSubmatch(procInfo)
 	if len(matches) != 2 {


### PR DESCRIPTION
cAdvisor is currently giving up reading CPU frequency for some platforms (such as `aarch64`) before looking into `/sys/devices/system/cpu/`. I think it's wrong, even knowing that on big.LITTLE platforms wrong information will be displayed.