### PR TITLE
Feat: use memory limit from cgroup when set and lower

### DIFF
--- a/machine/machine.go
+++ b/machine/machine.go
@@ -129,11 +129,19 @@ func GetMachineMemoryCapacity() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-
 	memoryCapacity, err := parseCapacity(out, memoryCapacityRegexp)
 	if err != nil {
 		return 0, err
 	}
+	out2, err2 := ioutil.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+	if err2 == nil && len(out2) > 0 {
+		lines := strings.Split(string(out2), "\n")
+		cgroupMemoryLimitInBytes, err2 := strconv.ParseUint(string(lines[0]), 10, 64)
+		if err2 == nil && cgroupMemoryLimitInBytes < memoryCapacity {
+			return cgroupMemoryLimitInBytes, err2
+		}
+	}
+
 	return memoryCapacity, err
 }
 


### PR DESCRIPTION
## Motivation
When you run kubelet in container if you set some memory limit cadvisor still uses system memory. But the memory is limit by the cgroup and the process may be killed if it uses more memory than the limit.

This is describe in issue #2698 

### The strategy for resolve this is:
- by default use the system memory limit
- if there is cgroup memory limit read it
  - compare the system memory limit and the cgroup memory limit, take the lower
- return the lower memory limit found

## Tests
For testing the idea, I directly change the code of cAdvisor in K3S (only and only for test), and I make a container of this custom K3S.
This is available on [docker hub](https://hub.docker.com/layers/louiznk/k3s/v1.19.2-poc-mem/images/sha256-edba27921337c5b3be568b47afb06950cfe175cf0e715fd0e02a7b9c301c02fd?context=explore) and [github](https://github.com/louiznk/k3s/commit/fb9e4cfef25f6edef8490a3267de441d46f0a705).

#### Start k3s in docker
```
$ docker run --privileged --rm -d -p 6443:6443 -p 80:80 -p 443:443 --memory=2g --memory-swap=-1 louiznk/k3s:v1.19.2-poc-mem server
2063b98137b27da3350f6fb479cf2578807d54feba421d049c8e0dd560129a0d
```
✅ the container is started

#### Check the memory limit of the container

```
$ docker stats --no-stream                                                                                                                
CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT   MEM %               NET I/O             BLOCK I/O           PIDS
2063b98137b2        wonderful_snyder    10.72%              624MiB / 2GiB       30.47%              115MB / 515kB       369kB / 70.2MB      223
```

✅ the container use 2 GiB

#### Check the memory available for kubelet
Open a shell in the container
```
$ docker exec -it 2063b98137b27da3350f6fb479cf2578807d54feba421d049c8e0dd560129a0d sh
/ # grep MemTotal /proc/meminfo 
MemTotal:       32486464 kB
```
❗ the system memory is still 32 GiB 
```
/ # cat /sys/fs/cgroup/memory/memory.limit_in_bytes
2147483648
```
✅ and the memory is still limit at 2 GiB

```
/ # kubectl get node -o=jsonpath="{.items[*]['status.capacity.memory']}"
2Gi

/ # kubectl top node
NAME           CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
2063b98137b2   150m         1%     667Mi           32%
```
**✅ 🎉 and for kubelet the memory available is 2 GiB, kubelet use the memory limit fix by the docker container 🎉** 

#### Usefull documentation
https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
https://docs.docker.com/config/containers/resource_constraints/

