### PR TITLE
Increase golang ci lint timeout to 5 minutes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 run:
+  timeout: 5m
   linters-settings:
     govet:
       enable-all: true


### PR DESCRIPTION
Some of the CI linters appear to be timing out, e.g. on https://github.com/google/cadvisor/pull/2697 

```
2020-10-28T21:26:44.8348743Z >> running golangci-lint using configuration at .golangci.yml
2020-10-28T21:27:45.0836302Z level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
2020-10-28T21:27:45.0960089Z ##[error]make: *** [Makefile:99: lint] Error 4
2020-10-28T21:27:45.0966521Z ##[error]Process completed with exit code 2.
```

Default timeout appears to be [1m](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml), so bumping to 5 minutes to avoid `golangci-lint` from timing out 