### PR TITLE
Fix pull-cadvisor-e2e test due outdated asset file

### DIFF
--- a/cmd/internal/pages/static/assets.go
+++ b/cmd/internal/pages/static/assets.go
@@ -352,6 +352,9 @@ var _bindata = map[string]func() (*asset, error){
 	"cmd/internal/pages/assets/styles/containers.css":                 cmdInternalPagesAssetsStylesContainersCss,
 }
 
+// AssetDebug is true if the assets were built with the debug flag enabled.
+const AssetDebug = false
+
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the


### PR DESCRIPTION
Ran:

```
FORCE=true build/assets.sh
```

it looks like `AssetDebug` was added in https://github.com/google/cadvisor/pull/2599 but `cmd/internal/pages/static/assets.go` wasn't updated.

This should fix the test failure on https://github.com/google/cadvisor/pull/2672