### PR TITLE
update docker client method

### DIFF
--- a/container/docker/client.go
+++ b/container/docker/client.go
@@ -52,11 +52,10 @@ func Client() (*dclient.Client, error) {
 				TLSClientConfig: tlsc,
 			}
 		}
-		dockerClient, dockerClientErr = dclient.NewClient(*ArgDockerEndpoint,
-			"",
-			client,
-			nil)
-
+		dockerClient, dockerClientErr = dclient.NewClientWithOpts(
+			dclient.WithHost(*ArgDockerEndpoint),
+			dclient.WithHTTPClient(client),
+			dclient.WithAPIVersionNegotiation())
 	})
 	return dockerClient, dockerClientErr
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug 
/kind cleanup 

**What this PR does / why we need it**:

`dockerclient.NewClient` has been deprecated. And change to recommended public methods `dockerclient.NewClientWithOpts`.  
 
using WithAPIVersionNegotiation() makes the Docker client negotiate down to a lower version if Docker's current API version is newer than the server version.

ref: [kubelet: pod metrics not visible with Docker 18 (19.03 works) ](https://github.com/kubernetes/kubernetes/issues/94281)

After https://github.com/kubernetes/kubernetes/pull/89687 merged(docker client dependency update to newer), We find that kubelet failed to register cadvisor  docker factory when we use k8s v1.19 with docker 18.X. And info as fellow: 
```
[factory.go:161] Registration of the docker container factory failed: failed to validate Docker info: failed to detect Docker info: Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
```

The error `Registration of the docker container factory ` is from 
https://github.com/google/cadvisor/blob/0f8972ff6e050aa81903df1219c6c52a3b86df9c/container/factory.go#L160-L163

the error `failed to validate` is from

https://github.com/google/cadvisor/blob/0f8972ff6e050aa81903df1219c6c52a3b86df9c/container/docker/docker.go#L124-L127


we find in advisor, docker client is created by `Client()`. And it seems no  negotiating to old server version if we use deprecated `NewClient` with higher docker client version. 

https://github.com/google/cadvisor/blob/0f8972ff6e050aa81903df1219c6c52a3b86df9c/container/docker/client.go#L55-L58


**what does this PR do**:
update dockerclient.NewClient to dockerclient.NewClientWithOpts
and enable client negotiate down to a lower version server version.

