### PR TITLE
do not initialize libipmctl package when getting an error from nvm_init()

### DIFF
--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -40,6 +40,7 @@ func init() {
 		// Unfortunately klog does not seem to work here. I believe it's better to
 		// output information using fmt rather then let it disappear silently.
 		fmt.Printf("libipmctl initialization failed with status %d", cErr)
+		return
 	}
 	isNVMLibInitialized = true
 }


### PR DESCRIPTION
Fixes #2721

@iwankgb 


Signed-off-by: Paweł Szulik <pawel.szulik@intel.com>