### PR TITLE
Don't fail permenantly when nvml isn't installed

### DIFF
--- a/accelerators/nvidia.go
+++ b/accelerators/nvidia.go
@@ -58,9 +58,7 @@ func NewNvidiaManager(includedMetrics container.MetricSet) stats.Manager {
 	manager := &nvidiaManager{}
 	err := manager.setup()
 	if err != nil {
-		klog.Warningf("NVIDIA GPU metrics will not be available: %s", err)
-		manager.Destroy()
-		return &stats.NoopManager{}
+		klog.V(2).Infof("NVIDIA setup failed: %s", err)
 	}
 	return manager
 }


### PR DESCRIPTION
Reverts a small part of https://github.com/google/cadvisor/pull/2419, which changed how the nvidia collector is setup.  NVIDIA driver and library installation is often done via daemonset.  If cadvisor starts before the library is installed, youdon't get any GPU metrics.  

This should fix the problem by returning a manager instead of a noop.  Setup will be retried when GetCollector is called.

cc @RenaudWasTaken @iwankgb @bobbypage 

I'd like to cherrypick this back to v0.37 as well.