### PR TITLE
Fix timeout flooding issue after containerd restart

### DIFF
--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -65,11 +65,10 @@ func Client(address, namespace string) (ContainerdClient, error) {
 		tryConn.Close()
 
 		connParams := grpc.ConnectParams{
-			Backoff: backoff.Config{
-				BaseDelay: baseBackoffDelay,
-				MaxDelay:  maxBackoffDelay,
-			},
+			Backoff: backoff.DefaultConfig,
 		}
+		connParams.Backoff.BaseDelay = baseBackoffDelay
+		connParams.Backoff.MaxDelay = maxBackoffDelay
 		gopts := []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithContextDialer(dialer.ContextDialer),


### PR DESCRIPTION
Originally the gRPC backoff multiplier is not set so it got defaulted as zero. Once a connection timeout happens, gRPC exponential backoff will be triggered which results in setting the backoff durating to zero, causing retries flooding. Setting gRPC multiplier to 1.6 which is the default one from gRPC package will solve the issue.

Closes #2748 