### PR TITLE
Return correct DeviceInfo from GetDirFsDevice on / path for Btrfs - Fix kubernetes issue #94335

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -27,6 +27,20 @@ import (
 	"k8s.io/utils/mount"
 )
 
+func TestMountInfoFromDir(t *testing.T) {
+	as := assert.New(t)
+	fsInfo := &RealFsInfo{
+		mounts: map[string]mount.MountInfo{
+			"/": {},
+		},
+	}
+	testDirs := []string{"/var/lib/kubelet", "/var/lib/rancher"}
+	for _, testDir := range testDirs {
+		_, found := fsInfo.mountInfoFromDir(testDir)
+		as.True(found, "failed to find MountInfo %s from FsInfo %s", testDir, fsInfo)
+	}
+}
+
 func TestGetDiskStatsMap(t *testing.T) {
 	diskStatsMap, err := getDiskStatsMap("test_resources/diskstats")
 	if err != nil {


### PR DESCRIPTION
Fix kubernetes issue #94335

- Issue: kubernetes/kubernetes#94335
- Fix `GetDirFsDevice` to return correct `*DeviceInfo` when "/" is Btrfs
    - Refactor to call new function `mountInfoFromDir` that returns
      `*MountInfo` which `dir` belongs
- Add TestMountInfoFromDir to verify the fix

Signed-off-by: Geonju Kim <rjswn042@gmail.com>
