### PR TITLE
Fix race between `OnDemandHousekeeping` and `housekeepingTick`

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -139,7 +139,7 @@ func (cd *containerData) allowErrorLogging() bool {
 // can have serious performance costs.
 func (cd *containerData) OnDemandHousekeeping(maxAge time.Duration) {
 	cd.lock.Lock()
-	timeSinceStatsLastUpdate := cd.clock.Since(statsLastUpdatedTime)
+	timeSinceStatsLastUpdate := cd.clock.Since(cd.statsLastUpdatedTime)
 	cd.lock.Unlock()
 	if timeSinceStatsLastUpdate > maxAge {
 		housekeepingFinishedChan := make(chan struct{})

--- a/manager/container.go
+++ b/manager/container.go
@@ -140,7 +140,7 @@ func (cd *containerData) allowErrorLogging() bool {
 func (cd *containerData) OnDemandHousekeeping(maxAge time.Duration) {
 	cd.lock.Lock()
 	timeSinceStatsLastUpdate := cd.clock.Since(statsLastUpdatedTime)
-	cd.lock.Unock()
+	cd.lock.Unlock()
 	if timeSinceStatsLastUpdate > maxAge {
 		housekeepingFinishedChan := make(chan struct{})
 		cd.onDemandChan <- housekeepingFinishedChan
@@ -559,7 +559,7 @@ func (cd *containerData) housekeepingTick(timer <-chan time.Time, longHousekeepi
 	}
 	cd.notifyOnDemand()
 	cd.lock.Lock()
-	defer cd.lock.Unock()
+	defer cd.lock.Unlock()
 	cd.statsLastUpdatedTime = cd.clock.Now()
 	return true
 }


### PR DESCRIPTION
This fixes the data race between the functions which could be running
in different goroutines.

Signed-off-by: Pradyumna Agrawal <pradyumnaa@vmware.com>

Fixes #2754 