### PR TITLE
Cherrypick to v0.38: Fix timeout flooding issue after containerd restart

### DIFF
--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -65,11 +65,10 @@ func Client(address, namespace string) (ContainerdClient, error) {
 		tryConn.Close()
 
 		connParams := grpc.ConnectParams{
-			Backoff: backoff.Config{
-				BaseDelay: baseBackoffDelay,
-				MaxDelay:  maxBackoffDelay,
-			},
+			Backoff: backoff.DefaultConfig,
 		}
+		connParams.Backoff.BaseDelay = baseBackoffDelay
+		connParams.Backoff.MaxDelay = maxBackoffDelay
 		gopts := []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithContextDialer(dialer.ContextDialer),


### PR DESCRIPTION
Backport pick fixes from https://github.com/google/cadvisor/pull/2749