### PR TITLE
Properly initialize nested struct in influxdb test

### DIFF
--- a/cmd/internal/storage/influxdb/influxdb_test.go
+++ b/cmd/internal/storage/influxdb/influxdb_test.go
@@ -360,7 +360,7 @@ func createTestStats() (*info.ContainerInfo, *info.ContainerStats) {
 			"2GB": {Usage: 9876, MaxUsage: 5432, Failcnt: 1},
 		},
 		ReferencedMemory: 12345,
-		PerfStats:        []info.PerfStat{{Cpu: 1, Name: "cycles", ScalingRatio: 1.5, Value: 4589}},
+		PerfStats:        []info.PerfStat{{Cpu: 1, PerfValue: info.PerfValue{Name: "cycles", ScalingRatio: 1.5, Value: 4589}}},
 		Resctrl: info.ResctrlStats{
 			MemoryBandwidth: []info.MemoryBandwidthStats{
 				{TotalBytes: 11234, LocalBytes: 4567},


### PR DESCRIPTION
If actually running the influxdb tests (not included in Makefile), a compiler error occured ("cannot use promoted field in struct literal of type") because direct access to promoted fields is only allowed in assignments, not when initializing structs (at least, unless golang/go#9859 gets implemented).

The tests run fine otherwise, as soon as the required tag is added.

<sup>Jens Erat <jens.erat@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>