### PR TITLE
Export entire smaps memory metrics instead of only referenced_memory

### DIFF
--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -88,7 +88,7 @@ var (
 		container.ProcessSchedulerMetrics:        struct{}{},
 		container.ProcessMetrics:                 struct{}{},
 		container.HugetlbUsageMetrics:            struct{}{},
-		container.ReferencedMemoryMetrics:        struct{}{},
+		container.SmapsMemoryMetrics:             struct{}{},
 		container.CPUTopologyMetrics:             struct{}{},
 		container.ResctrlMetrics:                 struct{}{},
 	}}
@@ -107,7 +107,7 @@ var (
 		container.ProcessSchedulerMetrics:        struct{}{},
 		container.ProcessMetrics:                 struct{}{},
 		container.HugetlbUsageMetrics:            struct{}{},
-		container.ReferencedMemoryMetrics:        struct{}{},
+		container.SmapsMemoryMetrics:             struct{}{},
 		container.CPUTopologyMetrics:             struct{}{},
 		container.ResctrlMetrics:                 struct{}{},
 	}
@@ -141,7 +141,7 @@ func (ml *metricSetValue) Set(value string) error {
 }
 
 func init() {
-	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'accelerator', 'cpu_topology','disk', 'diskIO', 'memory_numa', 'network', 'tcp', 'udp', 'percpu', 'sched', 'process', 'hugetlb', 'referenced_memory', 'resctrl'.")
+	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'accelerator', 'cpu_topology','disk', 'diskIO', 'memory_numa', 'network', 'tcp', 'udp', 'percpu', 'sched', 'process', 'hugetlb', 'resctrl', 'smaps_memory'.")
 
 	// Default logging verbosity to V(2)
 	flag.Set("v", "2")

--- a/cmd/cadvisor_test.go
+++ b/cmd/cadvisor_test.go
@@ -40,10 +40,10 @@ func TestUdpMetricsAreDisabledByDefault(t *testing.T) {
 	assert.True(t, ignoreMetrics.Has(container.NetworkUdpUsageMetrics))
 }
 
-func TestReferencedMemoryMetricsIsDisabledByDefault(t *testing.T) {
-	assert.True(t, ignoreMetrics.Has(container.ReferencedMemoryMetrics))
+func TestSmapsMemoryMetricsIsDisabledByDefault(t *testing.T) {
+	assert.True(t, ignoreMetrics.Has(container.SmapsMemoryMetrics))
 	flag.Parse()
-	assert.True(t, ignoreMetrics.Has(container.ReferencedMemoryMetrics))
+	assert.True(t, ignoreMetrics.Has(container.SmapsMemoryMetrics))
 }
 
 func TestCPUTopologyMetricsAreDisabledByDefault(t *testing.T) {
@@ -105,7 +105,7 @@ func TestToIncludedMetrics(t *testing.T) {
 			container.AppMetrics:                     struct{}{},
 			container.HugetlbUsageMetrics:            struct{}{},
 			container.PerfMetrics:                    struct{}{},
-			container.ReferencedMemoryMetrics:        struct{}{},
+			container.SmapsMemoryMetrics:             struct{}{},
 			container.CPUTopologyMetrics:             struct{}{},
 			container.ResctrlMetrics:                 struct{}{},
 		},

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -40,6 +40,7 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.4.15 h1:qkLXKzb1QoVatRyd/YlXZ/Kg0m5K3SPuoD82jjSOaBc=
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
+github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Rican7/retry v0.1.1-0.20160712041035-272ad122d6e5 h1:6olZmdYuK84eO0PeCQX1iy2EFWlOl8G+JNBi4vFmcU8=
 github.com/Rican7/retry v0.1.1-0.20160712041035-272ad122d6e5/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
 github.com/SeanDolphin/bqschema v0.0.0-20150424181127-f92a08f515e1 h1:4EBKNUkI0tKxZb75f41jFGQQBPG4A/qbbgmgJ1MTTvw=
@@ -120,6 +121,8 @@ github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:SiUATuP//KecDjpOK2tvZJgeScYAklvyjfK8JZlU6fo=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.0+incompatible h1:4g8Xjho+7quMwzsTrhtrWpdQU9UTc2rX57A3iALaBmE=
+github.com/docker/docker v20.10.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/cmd/internal/storage/influxdb/influxdb.go
+++ b/cmd/internal/storage/influxdb/influxdb.go
@@ -94,14 +94,14 @@ const (
 	setHugetlbFailcnt = "hugetlb_failcnt"
 	// Perf statistics
 	serPerfStat = "perf_stat"
-	// Referenced memory
-	serReferencedMemory = "referenced_memory"
 	// Resctrl - Total memory bandwidth
 	serResctrlMemoryBandwidthTotal = "resctrl_memory_bandwidth_total"
 	// Resctrl - Local memory bandwidth
 	serResctrlMemoryBandwidthLocal = "resctrl_memory_bandwidth_local"
 	// Resctrl - Last level cache usage
 	serResctrlLLCOccupancy = "resctrl_llc_occupancy"
+	// Smaps memory prefix
+	serSmapsPrefix = "smaps_"
 )
 
 func new() (storage.StorageDriver, error) {
@@ -230,8 +230,10 @@ func (s *influxdbStorage) containerStatsToPoints(
 	points = append(points, makePoint(serTxBytes, stats.Network.TxBytes))
 	points = append(points, makePoint(serTxErrors, stats.Network.TxErrors))
 
-	// Referenced Memory
-	points = append(points, makePoint(serReferencedMemory, stats.ReferencedMemory))
+	// Smaps Memory
+	for k, v := range stats.SmapsMemory {
+		points = append(points, makePoint(serSmapsPrefix+k, v))
+	}
 
 	s.tagPoints(cInfo, stats, points)
 

--- a/cmd/internal/storage/influxdb/influxdb_test.go
+++ b/cmd/internal/storage/influxdb/influxdb_test.go
@@ -231,7 +231,7 @@ func TestContainerStatsToPoints(t *testing.T) {
 
 	// Then
 	assert.NotEmpty(t, points)
-	assert.Len(t, points, 34+len(stats.Cpu.Usage.PerCpu))
+	assert.Len(t, points, 52+len(stats.Cpu.Usage.PerCpu))
 
 	// CPU stats
 	assertContainsPointWithValue(t, points, serCpuUsageTotal, stats.Cpu.Usage.Total)
@@ -276,7 +276,9 @@ func TestContainerStatsToPoints(t *testing.T) {
 	}
 
 	// Reference memory
-	assertContainsPointWithValue(t, points, serReferencedMemory, stats.ReferencedMemory)
+	for k, v := range stats.SmapsMemory {
+		assertContainsPointWithValue(t, points, serSmapsPrefix+k, v)
+	}
 
 	// Resource Control stats - memory bandwidth
 	for _, rdtMemoryBandwidth := range stats.Resctrl.MemoryBandwidth {
@@ -359,8 +361,28 @@ func createTestStats() (*info.ContainerInfo, *info.ContainerStats) {
 			"1GB": {Usage: 1234, MaxUsage: 5678, Failcnt: 9},
 			"2GB": {Usage: 9876, MaxUsage: 5432, Failcnt: 1},
 		},
-		ReferencedMemory: 12345,
-		PerfStats:        []info.PerfStat{{Cpu: 1, Name: "cycles", ScalingRatio: 1.5, Value: 4589}},
+		SmapsMemory: map[string]uint64{
+			"AnonHugePages":   1,
+			"Anonymous":       2,
+			"KernelPageSize":  3,
+			"LazyFree":        4,
+			"Locked":          5,
+			"MMUPageSize":     6,
+			"Private_Clean":   7,
+			"Private_Dirty":   8,
+			"Private_Hugetlb": 9,
+			"Pss":             10,
+			"Referenced":      11,
+			"Rss":             12,
+			"Shared_Clean":    13,
+			"Shared_Dirty":    14,
+			"Shared_Hugetlb":  15,
+			"ShmemPmdMapped":  16,
+			"Size":            17,
+			"Swap":            18,
+			"SwapPss":         19,
+		},
+		PerfStats: []info.PerfStat{{Cpu: 1, PerfValue: info.PerfValue{Name: "cycles", ScalingRatio: 1.5, Value: 4589}}},
 		Resctrl: info.ResctrlStats{
 			MemoryBandwidth: []info.MemoryBandwidthStats{
 				{TotalBytes: 11234, LocalBytes: 4567},

--- a/cmd/internal/storage/statsd/statsd.go
+++ b/cmd/internal/storage/statsd/statsd.go
@@ -83,14 +83,14 @@ const (
 	setHugetlbFailcnt string = "hugetlb_failcnt"
 	// Perf statistics
 	serPerfStat string = "perf_stat"
-	// Referenced memory
-	serReferencedMemory string = "referenced_memory"
 	// Resctrl - Total memory bandwidth
 	serResctrlMemoryBandwidthTotal string = "resctrl_memory_bandwidth_total"
 	// Resctrl - Local memory bandwidth
 	serResctrlMemoryBandwidthLocal string = "resctrl_memory_bandwidth_local"
 	// Resctrl - Last level cache usage
 	serResctrlLLCOccupancy string = "resctrl_llc_occupancy"
+	// Smaps prefix
+	serSmaps string = "smaps_"
 )
 
 func new() (storage.StorageDriver, error) {
@@ -126,8 +126,10 @@ func (s *statsdStorage) containerStatsToValues(stats *info.ContainerStats) (seri
 	series[serTxBytes] = stats.Network.TxBytes
 	series[serTxErrors] = stats.Network.TxErrors
 
-	// Referenced Memory
-	series[serReferencedMemory] = stats.ReferencedMemory
+	// Smaps
+	for k, v := range stats.SmapsMemory {
+		series[serSmaps+k] = v
+	}
 
 	return series
 }

--- a/cmd/internal/storage/stdout/stdout.go
+++ b/cmd/internal/storage/stdout/stdout.go
@@ -85,14 +85,14 @@ const (
 	setHugetlbFailcnt string = "hugetlb_failcnt"
 	// Perf statistics
 	serPerfStat string = "perf_stat"
-	// Referenced memory
-	serReferencedMemory string = "referenced_memory"
 	// Resctrl - Total memory bandwidth
 	serResctrlMemoryBandwidthTotal string = "resctrl_memory_bandwidth_total"
 	// Resctrl - Local memory bandwidth
 	serResctrlMemoryBandwidthLocal string = "resctrl_memory_bandwidth_local"
 	// Resctrl - Last level cache usage
 	serResctrlLLCOccupancy string = "resctrl_llc_occupancy"
+	// Smaps series
+	serSmapsPrefix string = "smaps_"
 )
 
 func new() (storage.StorageDriver, error) {
@@ -131,8 +131,10 @@ func (driver *stdoutStorage) containerStatsToValues(stats *info.ContainerStats) 
 	series[serTxBytes] = stats.Network.TxBytes
 	series[serTxErrors] = stats.Network.TxErrors
 
-	// Referenced Memory
-	series[serReferencedMemory] = stats.ReferencedMemory
+	// Smaps Memory
+	for k, v := range stats.SmapsMemory {
+		series[serSmapsPrefix+k] = v
+	}
 
 	return series
 }

--- a/container/factory.go
+++ b/container/factory.go
@@ -60,7 +60,7 @@ const (
 	ProcessMetrics                 MetricKind = "process"
 	HugetlbUsageMetrics            MetricKind = "hugetlb"
 	PerfMetrics                    MetricKind = "perf_event"
-	ReferencedMemoryMetrics        MetricKind = "referenced_memory"
+	SmapsMemoryMetrics             MetricKind = "smaps_memory"
 	CPUTopologyMetrics             MetricKind = "cpu_topology"
 	ResctrlMetrics                 MetricKind = "resctrl"
 )
@@ -84,7 +84,7 @@ var AllMetrics = MetricSet{
 	AppMetrics:                     struct{}{},
 	HugetlbUsageMetrics:            struct{}{},
 	PerfMetrics:                    struct{}{},
-	ReferencedMemoryMetrics:        struct{}{},
+	SmapsMemoryMetrics:             struct{}{},
 	CPUTopologyMetrics:             struct{}{},
 	ResctrlMetrics:                 struct{}{},
 }

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.13
 require (
 	cloud.google.com/go v0.54.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
-	github.com/Microsoft/go-winio v0.4.15 // indirect
+	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/aws/aws-sdk-go v1.35.24
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/containerd v1.4.3
 	github.com/containerd/ttrpc v1.0.2 // indirect
 	github.com/containerd/typeurl v1.0.1
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect
-	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
+	github.com/docker/docker v20.10.0+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Microsoft/go-winio v0.4.15 h1:qkLXKzb1QoVatRyd/YlXZ/Kg0m5K3SPuoD82jjSOaBc=
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
+github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
+github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -74,6 +76,8 @@ github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:SiUATuP//KecDjpOK2tvZJgeScYAklvyjfK8JZlU6fo=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.0+incompatible h1:4g8Xjho+7quMwzsTrhtrWpdQU9UTc2rX57A3iALaBmE=
+github.com/docker/docker v20.10.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -952,11 +952,11 @@ type ContainerStats struct {
 	// Applies only for root container.
 	PerfUncoreStats []PerfUncoreStat `json:"perf_uncore_stats,omitempty"`
 
-	// Referenced memory
-	ReferencedMemory uint64 `json:"referenced_memory,omitempty"`
-
 	// Resource Control (resctrl) statistics
 	Resctrl ResctrlStats `json:"resctrl,omitempty"`
+
+	// Referenced memory
+	SmapsMemory map[string]uint64 `json:"smaps_memory,omitempty"`
 }
 
 func timeEq(t1, t2 time.Time, tolerance time.Duration) bool {

--- a/info/v1/test/datagen.go
+++ b/info/v1/test/datagen.go
@@ -47,7 +47,12 @@ func GenerateRandomStats(numStats, numCores int, duration time.Duration) []*info
 		stats.Memory.Cache = uint64(rand.Int63n(4096))
 		stats.Memory.RSS = uint64(rand.Int63n(4096))
 		stats.Memory.MappedFile = uint64(rand.Int63n(4096))
-		stats.ReferencedMemory = uint64(rand.Int63n(1000))
+		stats.SmapsMemory = map[string]uint64{}
+		for _, t := range []string{"Size", "KernelPageSize", "MMUPageSize", "Rss", "Pss", "Shared_Clean", "Shared_Dirty",
+			"Private_Clean", "Private_Dirty", "Referenced", "Anonymous", "LazyFree", "AnonHugePages", "ShmemPmdMapped",
+			"Shared_Hugetlb", "Private_Hugetlb", "Swap", "SwapPss", "Locked"} {
+			stats.SmapsMemory[t] = uint64(rand.Int63n(1000))
+		}
 		ret[i] = stats
 	}
 	return ret

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -142,10 +142,10 @@ type DeprecatedContainerStats struct {
 	// Statistics originating from perf uncore events.
 	// Applies only for root container.
 	PerfUncoreStats []v1.PerfUncoreStat `json:"perf_uncore_stats,omitempty"`
-	// Referenced memory
-	ReferencedMemory uint64 `json:"referenced_memory,omitempty"`
 	// Resource Control (resctrl) statistics
 	Resctrl v1.ResctrlStats `json:"resctrl,omitempty"`
+	// Smaps memory
+	SmapsMemory map[string]uint64 `json:"smaps_memory,omitempty"`
 }
 
 type ContainerStats struct {
@@ -179,10 +179,10 @@ type ContainerStats struct {
 	// Statistics originating from perf uncore events.
 	// Applies only for root container.
 	PerfUncoreStats []v1.PerfUncoreStat `json:"perf_uncore_stats,omitempty"`
-	// Referenced memory
-	ReferencedMemory uint64 `json:"referenced_memory,omitempty"`
 	// Resource Control (resctrl) statistics
 	Resctrl v1.ResctrlStats `json:"resctrl,omitempty"`
+	// Smaps memory statistics
+	SmapsMemory map[string]uint64 `json:"smaps,omitempty"`
 }
 
 type Percentiles struct {

--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -101,8 +101,8 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 	var last *v1.ContainerStats
 	for _, val := range stats {
 		stat := &ContainerStats{
-			Timestamp:        val.Timestamp,
-			ReferencedMemory: val.ReferencedMemory,
+			Timestamp:   val.Timestamp,
+			SmapsMemory: val.SmapsMemory,
 		}
 		if spec.HasCpu {
 			stat.Cpu = &val.Cpu
@@ -180,7 +180,7 @@ func DeprecatedStatsFromV1(cont *v1.ContainerInfo) []DeprecatedContainerStats {
 			HasFilesystem:    cont.Spec.HasFilesystem,
 			HasDiskIo:        cont.Spec.HasDiskIo,
 			HasCustomMetrics: cont.Spec.HasCustomMetrics,
-			ReferencedMemory: val.ReferencedMemory,
+			SmapsMemory:      val.SmapsMemory,
 		}
 		if stat.HasCpu {
 			stat.Cpu = val.Cpu

--- a/info/v2/conversion_test.go
+++ b/info/v2/conversion_test.go
@@ -233,7 +233,6 @@ func TestContainerStatsFromV1(t *testing.T) {
 				PMU:    "17",
 			},
 		},
-		ReferencedMemory: uint64(1234),
 		Resctrl: v1.ResctrlStats{
 			MemoryBandwidth: []v1.MemoryBandwidthStats{
 				{
@@ -254,6 +253,27 @@ func TestContainerStatsFromV1(t *testing.T) {
 				},
 			},
 		},
+		SmapsMemory: map[string]uint64{
+			"AnonHugePages":   1,
+			"Anonymous":       2,
+			"KernelPageSize":  3,
+			"LazyFree":        4,
+			"Locked":          5,
+			"MMUPageSize":     6,
+			"Private_Clean":   7,
+			"Private_Dirty":   8,
+			"Private_Hugetlb": 9,
+			"Pss":             10,
+			"Referenced":      11,
+			"Rss":             12,
+			"Shared_Clean":    13,
+			"Shared_Dirty":    14,
+			"Shared_Hugetlb":  15,
+			"ShmemPmdMapped":  16,
+			"Size":            17,
+			"Swap":            18,
+			"SwapPss":         19,
+		},
 	}
 	expectedV2Stats := ContainerStats{
 		Timestamp: timestamp,
@@ -270,11 +290,11 @@ func TestContainerStatsFromV1(t *testing.T) {
 			BaseUsageBytes:  &v1Stats.Filesystem[0].BaseUsage,
 			InodeUsage:      &v1Stats.Filesystem[0].Inodes,
 		},
-		Accelerators:     v1Stats.Accelerators,
-		PerfStats:        v1Stats.PerfStats,
-		PerfUncoreStats:  v1Stats.PerfUncoreStats,
-		ReferencedMemory: v1Stats.ReferencedMemory,
-		Resctrl:          v1Stats.Resctrl,
+		Accelerators:    v1Stats.Accelerators,
+		PerfStats:       v1Stats.PerfStats,
+		PerfUncoreStats: v1Stats.PerfUncoreStats,
+		Resctrl:         v1Stats.Resctrl,
+		SmapsMemory:     v1Stats.SmapsMemory,
 	}
 
 	v2Stats := ContainerStatsFromV1("test", &v1Spec, []*v1.ContainerStats{&v1Stats})

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -687,7 +687,27 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 							PMU:    "uncore_imc_0",
 						},
 					},
-					ReferencedMemory: 1234,
+					SmapsMemory: map[string]uint64{
+						"AnonHugePages":   1,
+						"Anonymous":       2,
+						"KernelPageSize":  3,
+						"LazyFree":        4,
+						"Locked":          5,
+						"MMUPageSize":     6,
+						"Private_Clean":   7,
+						"Private_Dirty":   8,
+						"Private_Hugetlb": 9,
+						"Pss":             10,
+						"Referenced":      11,
+						"Rss":             12,
+						"Shared_Clean":    13,
+						"Shared_Dirty":    14,
+						"Shared_Hugetlb":  15,
+						"ShmemPmdMapped":  16,
+						"Size":            17,
+						"Swap":            18,
+						"SwapPss":         19,
+					},
 					Resctrl: info.ResctrlStats{
 						MemoryBandwidth: []info.MemoryBandwidthStats{
 							{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -364,12 +364,30 @@ container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",containe
 # HELP container_processes Number of processes running inside the container.
 # TYPE container_processes gauge
 container_processes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1 1395066363000
-# HELP container_referenced_bytes Container referenced bytes during last measurements cycle
-# TYPE container_referenced_bytes gauge
-container_referenced_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1234 1395066363000
 # HELP container_scrape_error 1 if there was an error while getting container metrics, 0 otherwise
 # TYPE container_scrape_error gauge
 container_scrape_error 0
+# HELP container_smaps_bytes Container smaps statistics, for type=referenced during last measurements cycle
+# TYPE container_smaps_bytes gauge
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="AnonHugePages",zone_name="hello"} 1 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Anonymous",zone_name="hello"} 2 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="KernelPageSize",zone_name="hello"} 3 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="LazyFree",zone_name="hello"} 4 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Locked",zone_name="hello"} 5 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="MMUPageSize",zone_name="hello"} 6 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Private_Clean",zone_name="hello"} 7 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Private_Dirty",zone_name="hello"} 8 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Private_Hugetlb",zone_name="hello"} 9 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Pss",zone_name="hello"} 10 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Referenced",zone_name="hello"} 11 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Rss",zone_name="hello"} 12 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Shared_Clean",zone_name="hello"} 13 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Shared_Dirty",zone_name="hello"} 14 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Shared_Hugetlb",zone_name="hello"} 15 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="ShmemPmdMapped",zone_name="hello"} 16 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Size",zone_name="hello"} 17 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="Swap",zone_name="hello"} 18 1395066363000
+container_smaps_bytes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",type="SwapPss",zone_name="hello"} 19 1395066363000
 # HELP container_sockets Number of open sockets for the container.
 # TYPE container_sockets gauge
 container_sockets{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3 1395066363000


### PR DESCRIPTION
#2495 introduced parsing smaps memory metrics, but only exposes referenced memory. As proposed in #2634, also other metrics in here are of interest, specifically LazyFree; but generally also the others seem of interest.

This commit replaces the referenced memory metrics by a generic smaps series of metrics. Runtime costs in cadvisor are not really impacted, as all the smaps parsing already happens anyway. The cardinality per container extends from 1 to 19 metrics, though. I think this is acceptable: also referenced memory scraping was disabled by default, so is scraping smaps.

Resolves #2634. It slightly extends the original proposal by simply exposing all metrics, but once I started work on the proposal it felt reasonable to do so. I'm fine with major changes, though!

While the code works (and the change is actually smaller than it looks, most of the lines only affect unit tests), I guess there is definitely more work to do.

- [ ] all unit tests run successfully, let's wait for the entire integration test suite
- [ ] do we want this approach at all?
- [ ] do we need downwards compatibility for `referenced_memory`?

As soon as there is agreement on the chosen approach, tasks needed to make merge-ready:

- [ ] some cleanup work, maybe extract (or get rid of) the array of smaps labels
- [ ] check whether documentation is required somewhere

This PR likely also affects #2715, which proposes optimizations to smaps data collection.

<sup>Jens Erat <jens.erat@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>