### PR TITLE
Command to run container on a RHEL docker host

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,6 @@ sudo docker run \
   gcr.io/cadvisor/cadvisor:$VERSION
 ```
 
-**Note**: For a redhat docker host the above command throws oci errors. Please use the command below if the host is redhat:
-```
-docker run
---volume=/:/rootfs:ro
---volume=/var/run:/var/run:rw
---volume=/sys/fs/cgroup/cpu,cpuacct:/sys/fs/cgroup/cpuacct,cpu
---volume=/var/lib/docker/:/var/lib/docker:ro
---publish=8080:8080
---detach=true
---name=cadvisor
---privileged=true
-google/cadvisor:latest
-```
-
 cAdvisor is now running (in the background) on `http://localhost:8080`. The setup includes directories with Docker state cAdvisor needs to observe.
 
 **Note**: If you're running on CentOS, Fedora, or RHEL (or are using LXC), take a look at our [running instructions](docs/running.md).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ sudo docker run \
   gcr.io/cadvisor/cadvisor:$VERSION
 ```
 
+**Note**: For a redhat docker host the above command throws oci errors. Please use the command below if the host is redhat:
+```
+docker run
+--volume=/:/rootfs:ro
+--volume=/var/run:/var/run:rw
+--volume=/sys/fs/cgroup/cpu,cpuacct:/sys/fs/cgroup/cpuacct,cpu
+--volume=/var/lib/docker/:/var/lib/docker:ro
+--publish=8080:8080
+--detach=true
+--name=cadvisor
+--privileged=true
+google/cadvisor:latest
+```
+
 cAdvisor is now running (in the background) on `http://localhost:8080`. The setup includes directories with Docker state cAdvisor needs to observe.
 
 **Note**: If you're running on CentOS, Fedora, or RHEL (or are using LXC), take a look at our [running instructions](docs/running.md).

--- a/docs/running.md
+++ b/docs/running.md
@@ -74,6 +74,21 @@ RHEL and CentOS lock down their containers a bit more. cAdvisor needs access to 
 
 On some versions of RHEL and CentOS the cgroup hierarchies are mounted in `/cgroup` so run cAdvisor with an additional Docker option of `--volume=/cgroup:/cgroup:ro \`.
 
+**Note**: For a RedHat 7 docker host the default run commands from above throw oci errors. Please use the command below if the host is RedHat 7:
+```
+docker run
+--volume=/:/rootfs:ro
+--volume=/var/run:/var/run:rw
+--volume=/sys/fs/cgroup/cpu,cpuacct:/sys/fs/cgroup/cpuacct,cpu
+--volume=/var/lib/docker/:/var/lib/docker:ro
+--publish=8080:8080
+--detach=true
+--name=cadvisor
+--privileged=true
+google/cadvisor:latest
+```
+
+
 ### Debian
 
 By default, Debian disables the memory cgroup which does not allow cAdvisor to gather memory stats. To enable the memory cgroup take a look at [these instructions](https://github.com/google/cadvisor/issues/432).


### PR DESCRIPTION
Updated README.md to include a docker run command that works on a redhat docker host.

Running the container on a Redhat docker host was throwing and oci error. The comments in the github issue #2155 suggested a slightly different docker command that worked when it was executed on an RHEL7 docker host.
