### PR TITLE
Switch from k8s utils/mount to moby/sys mount

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -33,9 +33,9 @@ import (
 	"github.com/google/cadvisor/devicemapper"
 	"github.com/google/cadvisor/utils"
 	zfs "github.com/mistifyio/go-zfs"
+	mount "github.com/moby/sys/mountinfo"
 
 	"k8s.io/klog/v2"
-	"k8s.io/utils/mount"
 )
 
 const (
@@ -85,7 +85,7 @@ type RealFsInfo struct {
 	// Labels are intent-specific tags that are auto-detected.
 	labels map[string]string
 	// Map from mountpoint to mount information.
-	mounts map[string]mount.MountInfo
+	mounts map[string]mount.Info
 	// devicemapper client
 	dmsetup devicemapper.DmsetupClient
 	// fsUUIDToDeviceName is a map from the filesystem UUID to its device name.
@@ -93,7 +93,11 @@ type RealFsInfo struct {
 }
 
 func NewFsInfo(context Context) (FsInfo, error) {
-	mounts, err := mount.ParseMountInfo("/proc/self/mountinfo")
+	fileReader, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return nil, err
+	}
+	mounts, err := mount.GetMountsFromReader(fileReader, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -110,13 +114,13 @@ func NewFsInfo(context Context) (FsInfo, error) {
 	fsInfo := &RealFsInfo{
 		partitions:         processMounts(mounts, excluded),
 		labels:             make(map[string]string),
-		mounts:             make(map[string]mount.MountInfo),
+		mounts:             make(map[string]mount.Info),
 		dmsetup:            devicemapper.NewDmsetupClient(),
 		fsUUIDToDeviceName: fsUUIDToDeviceName,
 	}
 
-	for _, mount := range mounts {
-		fsInfo.mounts[mount.MountPoint] = mount
+	for _, mnt := range mounts {
+		fsInfo.mounts[mnt.Mountpoint] = *mnt
 	}
 
 	// need to call this before the log line below printing out the partitions, as this function may
@@ -147,10 +151,10 @@ func getFsUUIDToDeviceNameMap() (map[string]string, error) {
 
 	fsUUIDToDeviceName := make(map[string]string)
 	for _, file := range files {
-		path := filepath.Join(dir, file.Name())
-		target, err := os.Readlink(path)
+		fpath := filepath.Join(dir, file.Name())
+		target, err := os.Readlink(fpath)
 		if err != nil {
-			klog.Warningf("Failed to resolve symlink for %q", path)
+			klog.Warningf("Failed to resolve symlink for %q", fpath)
 			continue
 		}
 		device, err := filepath.Abs(filepath.Join(dir, target))
@@ -162,7 +166,7 @@ func getFsUUIDToDeviceNameMap() (map[string]string, error) {
 	return fsUUIDToDeviceName, nil
 }
 
-func processMounts(mounts []mount.MountInfo, excludedMountpointPrefixes []string) map[string]partition {
+func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) map[string]partition {
 	partitions := make(map[string]partition)
 
 	supportedFsType := map[string]bool{
@@ -174,20 +178,20 @@ func processMounts(mounts []mount.MountInfo, excludedMountpointPrefixes []string
 		"zfs":     true,
 	}
 
-	for _, mount := range mounts {
-		if !strings.HasPrefix(mount.FsType, "ext") && !supportedFsType[mount.FsType] {
+	for _, mnt := range mounts {
+		if !strings.HasPrefix(mnt.Fstype, "ext") && !supportedFsType[mnt.Fstype] {
 			continue
 		}
 		// Avoid bind mounts, exclude tmpfs.
-		if _, ok := partitions[mount.Source]; ok {
-			if mount.FsType != "tmpfs" {
+		if _, ok := partitions[mnt.Source]; ok {
+			if mnt.Fstype != "tmpfs" {
 				continue
 			}
 		}
 
 		hasPrefix := false
 		for _, prefix := range excludedMountpointPrefixes {
-			if strings.HasPrefix(mount.MountPoint, prefix) {
+			if strings.HasPrefix(mnt.Mountpoint, prefix) {
 				hasPrefix = true
 				break
 			}
@@ -197,31 +201,31 @@ func processMounts(mounts []mount.MountInfo, excludedMountpointPrefixes []string
 		}
 
 		// using mountpoint to replace device once fstype it tmpfs
-		if mount.FsType == "tmpfs" {
-			mount.Source = mount.MountPoint
+		if mnt.Fstype == "tmpfs" {
+			mnt.Source = mnt.Mountpoint
 		}
 		// btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
 		// instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point
-		if mount.FsType == "btrfs" && mount.Major == 0 && strings.HasPrefix(mount.Source, "/dev/") {
-			major, minor, err := getBtrfsMajorMinorIds(&mount)
+		if mnt.Fstype == "btrfs" && mnt.Major == 0 && strings.HasPrefix(mnt.Source, "/dev/") {
+			major, minor, err := getBtrfsMajorMinorIds(mnt)
 			if err != nil {
 				klog.Warningf("%s", err)
 			} else {
-				mount.Major = major
-				mount.Minor = minor
+				mnt.Major = major
+				mnt.Minor = minor
 			}
 		}
 
 		// overlay fix: Making mount source unique for all overlay mounts, using the mount's major and minor ids.
-		if mount.FsType == "overlay" {
-			mount.Source = fmt.Sprintf("%s_%d-%d", mount.Source, mount.Major, mount.Minor)
+		if mnt.Fstype == "overlay" {
+			mnt.Source = fmt.Sprintf("%s_%d-%d", mnt.Source, mnt.Major, mnt.Minor)
 		}
 
-		partitions[mount.Source] = partition{
-			fsType:     mount.FsType,
-			mountpoint: mount.MountPoint,
-			major:      uint(mount.Major),
-			minor:      uint(mount.Minor),
+		partitions[mnt.Source] = partition{
+			fsType:     mnt.Fstype,
+			mountpoint: mnt.Mountpoint,
+			major:      uint(mnt.Major),
+			minor:      uint(mnt.Minor),
 		}
 	}
 
@@ -256,12 +260,12 @@ func (i *RealFsInfo) getDockerDeviceMapperInfo(context DockerContext) (string, *
 }
 
 // addSystemRootLabel attempts to determine which device contains the mount for /.
-func (i *RealFsInfo) addSystemRootLabel(mounts []mount.MountInfo) {
+func (i *RealFsInfo) addSystemRootLabel(mounts []*mount.Info) {
 	for _, m := range mounts {
-		if m.MountPoint == "/" {
+		if m.Mountpoint == "/" {
 			i.partitions[m.Source] = partition{
-				fsType:     m.FsType,
-				mountpoint: m.MountPoint,
+				fsType:     m.Fstype,
+				mountpoint: m.Mountpoint,
 				major:      uint(m.Major),
 				minor:      uint(m.Minor),
 			}
@@ -272,7 +276,7 @@ func (i *RealFsInfo) addSystemRootLabel(mounts []mount.MountInfo) {
 }
 
 // addDockerImagesLabel attempts to determine which device contains the mount for docker images.
-func (i *RealFsInfo) addDockerImagesLabel(context Context, mounts []mount.MountInfo) {
+func (i *RealFsInfo) addDockerImagesLabel(context Context, mounts []*mount.Info) {
 	dockerDev, dockerPartition, err := i.getDockerDeviceMapperInfo(context.Docker)
 	if err != nil {
 		klog.Warningf("Could not get Docker devicemapper device: %v", err)
@@ -285,7 +289,7 @@ func (i *RealFsInfo) addDockerImagesLabel(context Context, mounts []mount.MountI
 	}
 }
 
-func (i *RealFsInfo) addCrioImagesLabel(context Context, mounts []mount.MountInfo) {
+func (i *RealFsInfo) addCrioImagesLabel(context Context, mounts []*mount.Info) {
 	if context.Crio.Root != "" {
 		crioPath := context.Crio.Root
 		crioImagePaths := map[string]struct{}{
@@ -324,20 +328,19 @@ func getDockerImagePaths(context Context) map[string]struct{} {
 
 // This method compares the mountpoints with possible container image mount points. If a match is found,
 // the label is added to the partition.
-func (i *RealFsInfo) updateContainerImagesPath(label string, mounts []mount.MountInfo, containerImagePaths map[string]struct{}) {
-	var useMount *mount.MountInfo
+func (i *RealFsInfo) updateContainerImagesPath(label string, mounts []*mount.Info, containerImagePaths map[string]struct{}) {
+	var useMount *mount.Info
 	for _, m := range mounts {
-		if _, ok := containerImagePaths[m.MountPoint]; ok {
-			if useMount == nil || (len(useMount.MountPoint) < len(m.MountPoint)) {
-				useMount = new(mount.MountInfo)
-				*useMount = m
+		if _, ok := containerImagePaths[m.Mountpoint]; ok {
+			if useMount == nil || (len(useMount.Mountpoint) < len(m.Mountpoint)) {
+				useMount = m
 			}
 		}
 	}
 	if useMount != nil {
 		i.partitions[useMount.Source] = partition{
-			fsType:     useMount.FsType,
-			mountpoint: useMount.MountPoint,
+			fsType:     useMount.Fstype,
+			mountpoint: useMount.Mountpoint,
 			major:      uint(useMount.Major),
 			minor:      uint(useMount.Minor),
 		}
@@ -354,7 +357,7 @@ func (i *RealFsInfo) GetDeviceForLabel(label string) (string, error) {
 }
 
 func (i *RealFsInfo) GetLabelsForDevice(device string) ([]string, error) {
-	labels := []string{}
+	var labels []string
 	for label, dev := range i.labels {
 		if dev == device {
 			labels = append(labels, label)
@@ -462,12 +465,12 @@ func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
 		// 8      50 sdd2 40 0 280 223 7 0 22 108 0 330 330
 		deviceName := path.Join("/dev", words[2])
 
-		var error error
+		var err error
 		devInfo := make([]uint64, 2)
 		for i := 0; i < len(devInfo); i++ {
-			devInfo[i], error = strconv.ParseUint(words[i], 10, 64)
-			if error != nil {
-				return nil, error
+			devInfo[i], err = strconv.ParseUint(words[i], 10, 64)
+			if err != nil {
+				return nil, err
 			}
 		}
 
@@ -478,9 +481,9 @@ func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
 			return nil, fmt.Errorf("could not parse all 11 columns of /proc/diskstats")
 		}
 		for i := offset; i < wordLength; i++ {
-			stats[i-offset], error = strconv.ParseUint(words[i], 10, 64)
-			if error != nil {
-				return nil, error
+			stats[i-offset], err = strconv.ParseUint(words[i], 10, 64)
+			if err != nil {
+				return nil, err
 			}
 		}
 		diskStats := DiskStats{
@@ -527,8 +530,8 @@ func (i *RealFsInfo) GetDeviceInfoByFsUUID(uuid string) (*DeviceInfo, error) {
 	return &DeviceInfo{deviceName, p.major, p.minor}, nil
 }
 
-func (i *RealFsInfo) mountInfoFromDir(dir string) (*mount.MountInfo, bool) {
-	mount, found := i.mounts[dir]
+func (i *RealFsInfo) mountInfoFromDir(dir string) (*mount.Info, bool) {
+	mnt, found := i.mounts[dir]
 	// try the parent dir if not found until we reach the root dir
 	// this is an issue on btrfs systems where the directory is not
 	// the subvolume
@@ -536,15 +539,15 @@ func (i *RealFsInfo) mountInfoFromDir(dir string) (*mount.MountInfo, bool) {
 		pathdir, _ := filepath.Split(dir)
 		// break when we reach root
 		if pathdir == "/" {
-			mount, found = i.mounts["/"]
+			mnt, found = i.mounts["/"]
 			break
 		}
 		// trim "/" from the new parent path otherwise the next possible
 		// filepath.Split in the loop will not split the string any further
 		dir = strings.TrimSuffix(pathdir, "/")
-		mount, found = i.mounts[dir]
+		mnt, found = i.mounts[dir]
 	}
-	return &mount, found
+	return &mnt, found
 }
 
 func (i *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
@@ -563,13 +566,13 @@ func (i *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
 		}
 	}
 
-	mount, found := i.mountInfoFromDir(dir)
-	if found && mount.FsType == "btrfs" && mount.Major == 0 && strings.HasPrefix(mount.Source, "/dev/") {
-		major, minor, err := getBtrfsMajorMinorIds(mount)
+	mnt, found := i.mountInfoFromDir(dir)
+	if found && mnt.Fstype == "btrfs" && mnt.Major == 0 && strings.HasPrefix(mnt.Source, "/dev/") {
+		major, minor, err := getBtrfsMajorMinorIds(mnt)
 		if err != nil {
 			klog.Warningf("%s", err)
 		} else {
-			return &DeviceInfo{mount.Source, uint(major), uint(minor)}, nil
+			return &DeviceInfo{mnt.Source, uint(major), uint(minor)}, nil
 		}
 	}
 	return nil, fmt.Errorf("could not find device with major: %d, minor: %d in cached partitions map", major, minor)
@@ -755,7 +758,7 @@ func getZfstats(poolName string) (uint64, uint64, uint64, error) {
 }
 
 // Get major and minor Ids for a mount point using btrfs as filesystem.
-func getBtrfsMajorMinorIds(mount *mount.MountInfo) (int, int, error) {
+func getBtrfsMajorMinorIds(mount *mount.Info) (int, int, error) {
 	// btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
 	// instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point
 
@@ -768,9 +771,9 @@ func getBtrfsMajorMinorIds(mount *mount.MountInfo) (int, int, error) {
 
 	klog.V(4).Infof("btrfs mount %#v", mount)
 	if buf.Mode&syscall.S_IFMT == syscall.S_IFBLK {
-		err := syscall.Stat(mount.MountPoint, buf)
+		err := syscall.Stat(mount.Mountpoint, buf)
 		if err != nil {
-			err = fmt.Errorf("stat failed on %s with error: %s", mount.MountPoint, err)
+			err = fmt.Errorf("stat failed on %s with error: %s", mount.Mountpoint, err)
 			return 0, 0, err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
+	github.com/moby/sys/mountinfo v0.1.3
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect


### PR DESCRIPTION
CAdvisor is vendored into kubernetes/kubernetes, so it cannot use staging
repositories as dependencies. The k8s utils/mount is a staging repository.
This commit switches cAdvisor to use moby/sys/mountinfo instead to avoid
dependency issues.