### PR TITLE
Remove trailing \0 from values read from ppc64le device-tree.

### DIFF
--- a/utils/sysfs/sysfs.go
+++ b/utils/sysfs/sysfs.go
@@ -325,9 +325,9 @@ func (fs *realSysFs) GetSystemUUID() (string, error) {
 	if id, err := ioutil.ReadFile(path.Join(dmiDir, "id", "product_uuid")); err == nil {
 		return strings.TrimSpace(string(id)), nil
 	} else if id, err = ioutil.ReadFile(path.Join(ppcDevTree, "system-id")); err == nil {
-		return strings.TrimSpace(string(id)), nil
+		return strings.TrimSpace(strings.TrimRight(string(id), "\000")), nil
 	} else if id, err = ioutil.ReadFile(path.Join(ppcDevTree, "vm,uuid")); err == nil {
-		return strings.TrimSpace(string(id)), nil
+		return strings.TrimSpace(strings.TrimRight(string(id), "\000")), nil
 	} else if id, err = ioutil.ReadFile(path.Join(s390xDevTree, "machine-id")); err == nil {
 		return strings.TrimSpace(string(id)), nil
 	} else {


### PR DESCRIPTION
Values in Power OF device-tree are null-terminated. For example:

```
$ sudo od -t cx1 /proc/device-tree/system-id
0000000   I   B   M   ,   0   6   7   8   B   2   3   0   0  \0
         49  42  4d  2c  30  36  37  38  42  32  33  30  30  00
```

The null character needs to be trimmed or otherwise it will be part of the Go string.
This is causing problems with node attribute `systemUUID` in Kubernetes/OpenShift clusters for ppc64le nodes:
```
# kubectl get node master-0 -o yaml
 ...
  nodeInfo:
    architecture: ppc64le
    bootID: dab6f6ac-7d18-4411-9b87-9bd990752071
    containerRuntimeVersion: cri-o://1.19.1-7.rhaos4.6.git6377f68.el8
    kernelVersion: 4.18.0-193.41.1.el8_2.ppc64le
    kubeProxyVersion: v1.19.0+1833054
    kubeletVersion: v1.19.0+1833054
    machineID: 5884c39c43a843d78f6051c8485e376a
    operatingSystem: linux
    osImage: Red Hat Enterprise Linux CoreOS 46.82.202101270839-0 (Ootpa)
    systemUUID: "IBM,0678B22C0\0"
```