### PR TITLE
Fix oomparser regex for kernels 5.0 and higher

### DIFF
--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -28,7 +28,7 @@ import (
 var (
 	legacyContainerRegexp = regexp.MustCompile(`Task in (.*) killed as a result of limit of (.*)`)
 	// Starting in 5.0 linux kernels, the OOM message changed
-	containerRegexp = regexp.MustCompile(`oom-kill:constraint=(.*),nodemask=(.*),cpuset=(.*),mems_allowed=(.*),oom_memcg=(.*) (.*),task_memcg=(.*),task=(.*),pid=(.*),uid=(.*)`)
+	containerRegexp = regexp.MustCompile(`oom-kill:constraint=(.*),nodemask=(.*),cpuset=(.*),mems_allowed=(.*),oom_memcg=(.*),task_memcg=(.*),task=(.*),pid=(.*),uid=(.*)`)
 	lastLineRegexp  = regexp.MustCompile(`Killed process ([0-9]+) \((.+)\)`)
 	firstLineRegexp = regexp.MustCompile(`invoked oom-killer:`)
 )
@@ -76,15 +76,15 @@ func getContainerName(line string, currentOomInstance *OomInstance) (bool, error
 		// Fall back to the legacy format if it isn't found here.
 		return false, getLegacyContainerName(line, currentOomInstance)
 	}
-	currentOomInstance.ContainerName = parsedLine[7]
+	currentOomInstance.ContainerName = parsedLine[6]
 	currentOomInstance.VictimContainerName = parsedLine[5]
 	currentOomInstance.Constraint = parsedLine[1]
-	pid, err := strconv.Atoi(parsedLine[9])
+	pid, err := strconv.Atoi(parsedLine[8])
 	if err != nil {
 		return false, err
 	}
 	currentOomInstance.Pid = pid
-	currentOomInstance.ProcessName = parsedLine[8]
+	currentOomInstance.ProcessName = parsedLine[7]
 	return true, nil
 }
 

--- a/utils/oomparser/oomparser_test.go
+++ b/utils/oomparser/oomparser_test.go
@@ -27,7 +27,7 @@ const (
 	startLine           = "ruby invoked oom-killer: gfp_mask=0x201da, order=0, oom_score_adj=0"
 	endLine             = "Killed process 19667 (evil-program2) total-vm:1460016kB, anon-rss:1414008kB, file-rss:4kB"
 	legacyContainerLine = "Task in /mem2 killed as a result of limit of /mem3"
-	containerLine       = "oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=ef807430361e6e82b45db92e2e9b6fbec98f419b12c591e655c1a725565e73a8,mems_allowed=0,oom_memcg=/kubepods/burstable/podfbdfe8e3-1c87-4ff2-907 c-b2ec8e25d012,task_memcg=/kubepods/burstable/podfbdfe8e3-1c87-4ff2-907c-b2ec8e25d012/ef807430361e6e82b45db92e2e9b6fbec98f419b12c591e655c1a725565e73a8,task=manager,pid=966,uid=0"
+	containerLine       = "oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=ef807430361e6e82b45db92e2e9b6fbec98f419b12c591e655c1a725565e73a8,mems_allowed=0,oom_memcg=/kubepods/burstable/podfbdfe8e3-1c87-4ff2-907c-b2ec8e25d012,task_memcg=/kubepods/burstable/podfbdfe8e3-1c87-4ff2-907c-b2ec8e25d012/ef807430361e6e82b45db92e2e9b6fbec98f419b12c591e655c1a725565e73a8,task=manager,pid=966,uid=0"
 )
 
 func TestGetLegacyContainerName(t *testing.T) {
@@ -81,8 +81,8 @@ func TestGetContainerName(t *testing.T) {
 	if currentOomInstance.ContainerName != "/kubepods/burstable/podfbdfe8e3-1c87-4ff2-907c-b2ec8e25d012/ef807430361e6e82b45db92e2e9b6fbec98f419b12c591e655c1a725565e73a8" {
 		t.Errorf("getContainerName should have set containerName to /kubepods/burstable/podfbdfe8e3-1c87-4ff2-907c-b2ec8e25d012/ef807430361e6e82b45db92e2e9b6fbec98f419b12c591e655c1a725565e73a8, not %s", currentOomInstance.ContainerName)
 	}
-	if currentOomInstance.VictimContainerName != "/kubepods/burstable/podfbdfe8e3-1c87-4ff2-907" {
-		t.Errorf("getContainerName should have set victimContainerName to /kubepods/burstable/podfbdfe8e3-1c87-4ff2-907, not %s", currentOomInstance.VictimContainerName)
+	if currentOomInstance.VictimContainerName != "/kubepods/burstable/podfbdfe8e3-1c87-4ff2-907c-b2ec8e25d012" {
+		t.Errorf("getContainerName should have set victimContainerName to /kubepods/burstable/podfbdfe8e3-1c87-4ff2-907c-b2ec8e25d012, not %s", currentOomInstance.VictimContainerName)
 	}
 	if currentOomInstance.Pid != 966 {
 		t.Errorf("getContainerName should have set Pid to 966, not %d", currentOomInstance.Pid)


### PR DESCRIPTION
#2418 introduced new regex for 5.0 kernels and higher, the regex had a typo and wasn't resolving the correct container names.

Fixes: https://github.com/google/cadvisor/issues/2813