### PR TITLE
Implement containerd environment variables whitelisting

### DIFF
--- a/container/containerd/factory.go
+++ b/container/containerd/factory.go
@@ -41,6 +41,8 @@ const k8sContainerdNamespace = "containerd"
 // --cgroup-parent have another prefix than 'containerd'
 var containerdCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
 
+var containerdEnvWhitelist = flag.String("containerd_env_metadata_whitelist", "", "a comma-separated list of environment variable keys matched with specified prefix that needs to be collected for containerd containers")
+
 type containerdFactory struct {
 	machineInfoFactory info.MachineInfoFactory
 	client             ContainerdClient
@@ -62,7 +64,8 @@ func (f *containerdFactory) NewContainerHandler(name string, inHostNamespace boo
 		return
 	}
 
-	metadataEnvs := []string{}
+	metadataEnvs := strings.Split(*containerdEnvWhitelist, ",")
+
 	return newContainerdContainerHandler(
 		client,
 		name,

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -133,11 +133,19 @@ func newContainerdContainerHandler(
 	}
 	// Add the name and bare ID as aliases of the container.
 	handler.image = cntr.Image
-	for _, envVar := range spec.Process.Env {
-		if envVar != "" {
-			splits := strings.SplitN(envVar, "=", 2)
-			if len(splits) == 2 {
-				handler.envs[splits[0]] = splits[1]
+
+	for _, exposedEnv := range metadataEnvs {
+		if exposedEnv == "" {
+			// if no containerdEnvWhitelist provided, len(metadataEnvs) == 1, metadataEnvs[0] == ""
+			continue
+		}
+
+		for _, envVar := range spec.Process.Env {
+			if envVar != "" {
+				splits := strings.SplitN(envVar, "=", 2)
+				if len(splits) == 2 && strings.HasPrefix(splits[0], exposedEnv) {
+					handler.envs[splits[0]] = splits[1]
+				}
 			}
 		}
 	}

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -32,6 +32,16 @@ func init() {
 	typeurl.Register(&specs.Spec{}, "types.contianerd.io/opencontainers/runtime-spec", "v1", "Spec")
 }
 
+type mockedMachineInfo struct{}
+
+func (m *mockedMachineInfo) GetMachineInfo() (*info.MachineInfo, error) {
+	return &info.MachineInfo{}, nil
+}
+
+func (m *mockedMachineInfo) GetVersionInfo() (*info.VersionInfo, error) {
+	return &info.VersionInfo{}, nil
+}
+
 func TestHandler(t *testing.T) {
 	as := assert.New(t)
 	type testCase struct {
@@ -47,13 +57,14 @@ func TestHandler(t *testing.T) {
 		hasErr         bool
 		errContains    string
 		checkReference *info.ContainerReference
+		checkEnvVars   map[string]string
 	}
 	testContainers := make(map[string]*containers.Container)
 	testContainer := &containers.Container{
 		ID:     "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
 		Labels: map[string]string{"io.cri-containerd.kind": "sandbox"},
 	}
-	spec := &specs.Spec{Root: &specs.Root{Path: "/test/"}, Process: &specs.Process{}}
+	spec := &specs.Spec{Root: &specs.Root{Path: "/test/"}, Process: &specs.Process{Env: []string{"TEST_REGION=FRA", "TEST_ZONE=A", "HELLO=WORLD"}}}
 	testContainer.Spec, _ = typeurl.MarshalAny(spec)
 	testContainers["40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"] = testContainer
 	for _, ts := range []testCase{
@@ -69,11 +80,12 @@ func TestHandler(t *testing.T) {
 			true,
 			"unable to find container \"40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9\"",
 			nil,
+			nil,
 		},
 		{
 			mockcontainerdClient(testContainers, nil),
 			"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
-			nil,
+			&mockedMachineInfo{},
 			nil,
 			&containerlibcontainer.CgroupSubsystems{},
 			false,
@@ -87,6 +99,26 @@ func TestHandler(t *testing.T) {
 				Aliases:   []string{"40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"},
 				Namespace: k8sContainerdNamespace,
 			},
+			map[string]string{},
+		},
+		{
+			mockcontainerdClient(testContainers, nil),
+			"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
+			&mockedMachineInfo{},
+			nil,
+			&containerlibcontainer.CgroupSubsystems{},
+			false,
+			[]string{"TEST"},
+			nil,
+			false,
+			"",
+			&info.ContainerReference{
+				Id:        "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
+				Name:      "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
+				Aliases:   []string{"40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"},
+				Namespace: k8sContainerdNamespace,
+			},
+			map[string]string{"TEST_REGION": "FRA", "TEST_ZONE": "A"},
 		},
 	} {
 		handler, err := newContainerdContainerHandler(ts.client, ts.name, ts.machineInfoFactory, ts.fsInfo, ts.cgroupSubsystems, ts.inHostNamespace, ts.metadataEnvs, ts.includedMetrics)
@@ -100,6 +132,11 @@ func TestHandler(t *testing.T) {
 			cr, err := handler.ContainerReference()
 			as.Nil(err)
 			as.Equal(*ts.checkReference, cr)
+		}
+		if ts.checkEnvVars != nil {
+			sp, err := handler.GetSpec()
+			as.Nil(err)
+			as.Equal(ts.checkEnvVars, sp.Envs)
 		}
 	}
 }


### PR DESCRIPTION
Currently, when using cadvisor with containerd it exposes all the environment variables for every container which can be dangerous (i.e. secret env vars in k8s) and can result in big and slow metrics responses (/metrics endpoint in our environment takes some seconds to reply and gives a >500MB body size) and high memory usage.

This PR adds the whitelisting functionality mimicking the same functionality in the docker module to keep consistency between them.