### PR TITLE
Add custom error type if device not found in partitions map

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -19,6 +19,7 @@ package fs
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -55,6 +56,9 @@ const (
 
 // A pool for restricting the number of consecutive `du` and `find` tasks running.
 var pool = make(chan struct{}, maxConcurrentOps)
+
+// ErrDeviceNotInPartitionsMap is the error resulting if a device could not be found in the partitions map.
+var ErrDeviceNotInPartitionsMap = errors.New("could not find device in cached partitions map")
 
 func init() {
 	for i := 0; i < maxConcurrentOps; i++ {
@@ -595,7 +599,7 @@ func (i *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
 		return &DeviceInfo{mnt.Source, uint(major), uint(minor)}, nil
 	}
 
-	return nil, fmt.Errorf("could not find device with major: %d, minor: %d in cached partitions map", major, minor)
+	return nil, fmt.Errorf("with major: %d, minor: %d: %w", major, minor, ErrDeviceNotInPartitionsMap)
 }
 
 func GetDirUsage(dir string) (UsageInfo, error) {


### PR DESCRIPTION
The new error type `ErrDeviceNotInPartisionsMap` can be used by external
consumers like Kubernetes to distinguish certain error paths.

Refers to https://github.com/kubernetes/kubernetes/pull/100448
