### PR TITLE
Do not return the error when hitting the cache not synced issue

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -693,6 +693,10 @@ func (m *manager) GetRequestedContainersInfo(containerName string, options v2.Re
 	for name, data := range containers {
 		info, err := m.containerDataToContainerInfo(data, &query)
 		if err != nil {
+			if err == memory.ErrDataNotFound {
+				klog.Warningf("Error getting data for container %s because of race condition", name)
+				continue
+			}
 			errs.append(name, "containerDataToContainerInfo", err)
 		}
 		containersMap[name] = info


### PR DESCRIPTION
Fixes: https://github.com/google/cadvisor/issues/2867

Signed-off-by: Harshal Patil <harpatil@redhat.com>