### PR TITLE
Cherrypick Add missing python3 in Dockerfile to release-v0.39

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12 AS build
 
-RUN apk --no-cache add libc6-compat device-mapper findutils zfs build-base linux-headers go bash git wget cmake pkgconfig ndctl-dev && \
+RUN apk --no-cache add libc6-compat device-mapper findutils zfs build-base linux-headers go python3 bash git wget cmake pkgconfig ndctl-dev && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Cherrypick https://github.com/google/cadvisor/pull/2832 to v0.39 to ensure `make release` continues to work on v0.39 branch.

Signed-off-by: Paweł Szulik <pawel.szulik@intel.com>