### PR TITLE
Fix typo in test function name

### DIFF
--- a/info/v2/conversion_test.go
+++ b/info/v2/conversion_test.go
@@ -30,7 +30,7 @@ var (
 	envs      = map[string]string{"foo": "bar"}
 )
 
-func TestContanierSpecFromV1(t *testing.T) {
+func TestContainerSpecFromV1(t *testing.T) {
 	v1Spec := v1.ContainerSpec{
 		CreationTime: timestamp,
 		Labels:       labels,


### PR DESCRIPTION
2-letter typo fix is too small change to be copyrightable, so this "contribution" should not require CLA.
