### PR TITLE
Use "kubectl kustomize" instead of "kustomize build"

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -6,22 +6,22 @@ cAdvisor uses [Kustomize](https://github.com/kubernetes-sigs/kustomize) to manag
 
 From the cadvisor/ directory, to generate the base daemonset:
 ```
-kustomize build deploy/kubernetes/base
+kubectl kustomize deploy/kubernetes/base
 ```
 
 To apply the base daemonset to your cluster:
 ```
-kustomize build deploy/kubernetes/base | kubectl apply -f -
+kubectl kustomize deploy/kubernetes/base | kubectl apply -f -
 ```
 
 To generate the daemonset with example patches applied:
 ```
-kustomize build deploy/kubernetes/overlays/examples
+kubectl kustomize deploy/kubernetes/overlays/examples
 ```
 
 To apply the daemonset to your cluster with example patches applied:
 ```
-kustomize build deploy/kubernetes/overlays/examples | kubectl apply -f -
+kubectl kustomize deploy/kubernetes/overlays/examples | kubectl apply -f -
 ```
 
 ### cAdvisor with perf support on Kubernetes
@@ -30,7 +30,7 @@ Example of modifications needed to deploy cAdvisor with perf support is provided
 
 To generate and apply the daemonset with patches for cAdvisor with perf support:
 ```
-kustomize build deploy/kubernetes/overlays/examples_perf | kubectl apply -f -
+kubectl kustomize deploy/kubernetes/overlays/examples_perf | kubectl apply -f -
 ```
 
 ## Kustomization
@@ -39,7 +39,7 @@ On your own fork of cAdvisor, create your own overlay directoy with your patches
 
 To run the daemonset with your patches applied:
 ```
-kustomize build deploy/kubernetes/overlays/<my_custom_overlays> | kubectl apply -f -
+kubectl kustomize deploy/kubernetes/overlays/<my_custom_overlays> | kubectl apply -f -
 ```
 
 To get changes made to the upstream cAdvisor daemonset, simply rebase your fork of cAdvisor on top of upstream.  Since you didn't make changes to the originals, you won't have any conflicts.


### PR DESCRIPTION
There is not anymore need to use a separate "kustomize" tool, one can use "kubectl".

It has supported "kustomize" command since v1.14 (released in March 2019).
