### PR TITLE
Enable multiple Uncore PMUs for a single group in a configuration file.

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -842,6 +842,9 @@ type PerfStat struct {
 
 	// CPU that perf event was measured on.
 	Cpu int `json:"cpu"`
+
+	// Group_id that perf event was measured on.
+	GroupID string `json:"group_id"`
 }
 
 type PerfValue struct {
@@ -898,6 +901,9 @@ type PerfUncoreStat struct {
 
 	// PMU is Performance Monitoring Unit which collected these stats.
 	PMU string `json:"pmu"`
+
+	// Group_id that perf event was measured on.
+	GroupID string `json:"group_id"`
 }
 
 type UlimitSpec struct {

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -655,7 +655,8 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Value:        123,
 								Name:         "instructions",
 							},
-							Cpu: 0,
+							Cpu:     0,
+							GroupID: "1",
 						},
 						{
 							PerfValue: info.PerfValue{
@@ -663,7 +664,8 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Value:        456,
 								Name:         "instructions",
 							},
-							Cpu: 1,
+							Cpu:     1,
+							GroupID: "1",
 						},
 						{
 							PerfValue: info.PerfValue{
@@ -671,7 +673,8 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Value:        321,
 								Name:         "instructions_retired",
 							},
-							Cpu: 0,
+							Cpu:     0,
+							GroupID: "2",
 						},
 						{
 							PerfValue: info.PerfValue{
@@ -679,7 +682,8 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Value:        789,
 								Name:         "instructions_retired",
 							},
-							Cpu: 1,
+							Cpu:     1,
+							GroupID: "2",
 						},
 					},
 					PerfUncoreStats: []info.PerfUncoreStat{
@@ -689,8 +693,9 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Value:        1231231512.0,
 								Name:         "cas_count_read",
 							},
-							Socket: 0,
-							PMU:    "uncore_imc_0",
+							Socket:  0,
+							PMU:     "uncore_imc_0",
+							GroupID: "1",
 						},
 						{
 							PerfValue: info.PerfValue{
@@ -698,8 +703,9 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Value:        1111231331.0,
 								Name:         "cas_count_read",
 							},
-							Socket: 1,
-							PMU:    "uncore_imc_0",
+							Socket:  1,
+							PMU:     "uncore_imc_0",
+							GroupID: "1",
 						},
 					},
 					ReferencedMemory: 1234,

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -363,24 +363,24 @@ container_network_udp_usage_total{container_env_foo_env="prod",container_label_f
 container_oom_events_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0 1395066363000
 # HELP container_perf_events_total Perf event metric.
 # TYPE container_perf_events_total counter
-container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 123 1395066363000
-container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions_retired",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 321 1395066363000
-container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 456 1395066363000
-container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions_retired",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 789 1395066363000
+container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions",group_id="1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 123 1395066363000
+container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions_retired",group_id="2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 321 1395066363000
+container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions",group_id="1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 456 1395066363000
+container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions_retired",group_id="2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 789 1395066363000
 # HELP container_perf_events_scaling_ratio Perf event metric scaling ratio.
 # TYPE container_perf_events_scaling_ratio gauge
-container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1 1395066363000
-container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions_retired",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.66666666666 1395066363000
-container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.5 1395066363000
-container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions_retired",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.33333333333 1395066363000
+container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions",group_id="1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1 1395066363000
+container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="0",event="instructions_retired",group_id="2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.66666666666 1395066363000
+container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions",group_id="1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.5 1395066363000
+container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="1",event="instructions_retired",group_id="2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.33333333333 1395066363000
 # HELP container_perf_uncore_events_total Perf uncore event metric.
 # TYPE container_perf_uncore_events_total counter
-container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1.231231512e+09 1395066363000
-container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1.111231331e+09 1395066363000
+container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1.231231512e+09 1395066363000
+container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1.111231331e+09 1395066363000
 # HELP container_perf_uncore_events_scaling_ratio Perf uncore event metric scaling ratio.
 # TYPE container_perf_uncore_events_scaling_ratio gauge
-container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1 1395066363000
-container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1 1395066363000
+container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1 1395066363000
+container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1 1395066363000
 # HELP container_processes Number of processes running inside the container.
 # TYPE container_processes gauge
 container_processes{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1 1395066363000

--- a/metrics/testdata/prometheus_metrics_perf_aggregated
+++ b/metrics/testdata/prometheus_metrics_perf_aggregated
@@ -6,20 +6,20 @@ cadvisor_version_info{cadvisorRevision="abcdef",cadvisorVersion="0.16.0",dockerV
 container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.395066363e+09 1395066363000
 # HELP container_perf_events_scaling_ratio Perf event metric scaling ratio.
 # TYPE container_perf_events_scaling_ratio gauge
-container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.5 1395066363000
-container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions_retired",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.33333333333 1395066363000
+container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions",group_id="1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.5 1395066363000
+container_perf_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions_retired",group_id="2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0.33333333333 1395066363000
 # HELP container_perf_events_total Perf event metric.
 # TYPE container_perf_events_total counter
-container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 579 1395066363000
-container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions_retired",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1110 1395066363000
+container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions",group_id="1",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 579 1395066363000
+container_perf_events_total{container_env_foo_env="prod",container_label_foo_label="bar",cpu="",event="instructions_retired",group_id="2",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1110 1395066363000
 # HELP container_perf_uncore_events_scaling_ratio Perf uncore event metric scaling ratio.
 # TYPE container_perf_uncore_events_scaling_ratio gauge
-container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1 1395066363000
-container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1 1395066363000
+container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1 1395066363000
+container_perf_uncore_events_scaling_ratio{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1 1395066363000
 # HELP container_perf_uncore_events_total Perf uncore event metric.
 # TYPE container_perf_uncore_events_total counter
-container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1.231231512e+09 1395066363000
-container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1.111231331e+09 1395066363000
+container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="0",zone_name="hello"} 1.231231512e+09 1395066363000
+container_perf_uncore_events_total{container_env_foo_env="prod",container_label_foo_label="bar",event="cas_count_read",group_id="1",id="testcontainer",image="test",name="testcontaineralias",pmu="uncore_imc_0",socket="1",zone_name="hello"} 1.111231331e+09 1395066363000
 # HELP container_scrape_error 1 if there was an error while getting container metrics, 0 otherwise
 # TYPE container_scrape_error gauge
 container_scrape_error 0

--- a/perf/collector_libpfm_test.go
+++ b/perf/collector_libpfm_test.go
@@ -85,22 +85,22 @@ func TestCollector_UpdateStats(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	collector.cpuFiles = map[int]group{
-		1: {
+	collector.cpuFiles = map[string]group{
+		"1": {
 			cpuFiles: map[string]map[int]readerCloser{
 				"instructions": {0: notScaledBuffer},
 			},
 			names:      []string{"instructions"},
 			leaderName: "instructions",
 		},
-		2: {
+		"2": {
 			cpuFiles: map[string]map[int]readerCloser{
 				"cycles": {11: scaledBuffer},
 			},
 			names:      []string{"cycles"},
 			leaderName: "cycles",
 		},
-		3: {
+		"3": {
 			cpuFiles: map[string]map[int]readerCloser{
 				"cache-misses": {
 					0: groupedBuffer,
@@ -123,7 +123,8 @@ func TestCollector_UpdateStats(t *testing.T) {
 			Value:        999999999,
 			Name:         "cycles",
 		},
-		Cpu: 11,
+		Cpu:     11,
+		GroupID: "2",
 	})
 	assert.Contains(t, stats.PerfStats, info.PerfStat{
 		PerfValue: info.PerfValue{
@@ -131,7 +132,8 @@ func TestCollector_UpdateStats(t *testing.T) {
 			Value:        123456789,
 			Name:         "instructions",
 		},
-		Cpu: 0,
+		Cpu:     0,
+		GroupID: "1",
 	})
 	assert.Contains(t, stats.PerfStats, info.PerfStat{
 		PerfValue: info.PerfValue{
@@ -139,7 +141,8 @@ func TestCollector_UpdateStats(t *testing.T) {
 			Value:        123456,
 			Name:         "cache-misses",
 		},
-		Cpu: 0,
+		Cpu:     0,
+		GroupID: "3",
 	})
 	assert.Contains(t, stats.PerfStats, info.PerfStat{
 		PerfValue: info.PerfValue{
@@ -147,7 +150,8 @@ func TestCollector_UpdateStats(t *testing.T) {
 			Value:        654321,
 			Name:         "cache-references",
 		},
-		Cpu: 0,
+		Cpu:     0,
+		GroupID: "3",
 	})
 }
 
@@ -189,7 +193,7 @@ func TestSetGroupAttributes(t *testing.T) {
 func TestNewCollector(t *testing.T) {
 	perfCollector := newCollector("cgroup", PerfEvents{
 		Core: Events{
-			Events: []Group{{[]Event{"event_1"}, false}, {[]Event{"event_2"}, false}},
+			Events: []Group{{[]Event{"event_1"}, false, "1"}, {[]Event{"event_2"}, false, "2"}},
 			CustomEvents: []CustomEvent{{
 				Type:   0,
 				Config: []uint64{1, 2, 3},
@@ -212,8 +216,8 @@ func TestCollectorSetup(t *testing.T) {
 	events := PerfEvents{
 		Core: Events{
 			Events: []Group{
-				{[]Event{"cache-misses"}, false},
-				{[]Event{"non-existing-event"}, false},
+				{[]Event{"cache-misses"}, false, "1"},
+				{[]Event{"non-existing-event"}, false, "2"},
 			},
 		},
 	}
@@ -227,7 +231,7 @@ func TestCollectorSetup(t *testing.T) {
 	err = c.setup()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(c.cpuFiles))
-	assert.Equal(t, []string{"cache-misses"}, c.cpuFiles[0].names)
+	assert.Equal(t, []string{"cache-misses"}, c.cpuFiles["1"].names)
 }
 
 var readGroupPerfStatCases = []struct {
@@ -258,7 +262,8 @@ var readGroupPerfStatCases = []struct {
 				Value:        5,
 				Name:         "some metric",
 			},
-			Cpu: 1,
+			Cpu:     1,
+			GroupID: "1",
 		}},
 		err: nil,
 	},
@@ -281,7 +286,8 @@ var readGroupPerfStatCases = []struct {
 				Value:        5,
 				Name:         "some metric",
 			},
-			Cpu: 1,
+			Cpu:     1,
+			GroupID: "1",
 		}},
 		err: nil,
 	},
@@ -304,7 +310,8 @@ var readGroupPerfStatCases = []struct {
 				Value:        8,
 				Name:         "some metric",
 			},
-			Cpu: 2,
+			Cpu:     2,
+			GroupID: "1",
 		}},
 		err: nil,
 	},
@@ -327,7 +334,8 @@ var readGroupPerfStatCases = []struct {
 				Value:        4,
 				Name:         "some metric",
 			},
-			Cpu: 3,
+			Cpu:     3,
+			GroupID: "1",
 		}},
 		err: nil,
 	},
@@ -350,7 +358,8 @@ var readGroupPerfStatCases = []struct {
 				Value:        4,
 				Name:         "some metric",
 			},
-			Cpu: 3,
+			Cpu:     3,
+			GroupID: "1",
 		}},
 		err: nil,
 	},
@@ -373,7 +382,8 @@ var readGroupPerfStatCases = []struct {
 				Value:        0,
 				Name:         "some metric",
 			},
-			Cpu: 4,
+			Cpu:     4,
+			GroupID: "1",
 		}},
 		err: nil,
 	},
@@ -396,7 +406,8 @@ var readGroupPerfStatCases = []struct {
 				Value:        0,
 				Name:         "some metric",
 			},
-			Cpu: 4,
+			Cpu:     4,
+			GroupID: "1",
 		}},
 		err: nil,
 	},
@@ -414,7 +425,7 @@ func TestReadPerfStat(t *testing.T) {
 				cpuFiles:   nil,
 				names:      []string{test.name},
 				leaderName: test.name,
-			}, test.cpu, "/")
+			}, test.cpu, "/", "1")
 			assert.Equal(tt, test.perfStat, stat)
 			assert.Equal(tt, test.err, err)
 		})

--- a/perf/config_test.go
+++ b/perf/config_test.go
@@ -45,7 +45,8 @@ func TestConfigParsing(t *testing.T) {
 
 	assert.Len(t, events.Uncore.Events, 3)
 	assert.Equal(t, Event("cas_count_write"), events.Uncore.Events[0].events[0])
-	assert.Equal(t, Event("uncore_imc_0/UNC_M_CAS_COUNT:RD"), events.Uncore.Events[1].events[0])
+	assert.Equal(t, Event("uncore_imc/UNC_M_CAS_COUNT:RD"), events.Uncore.Events[1].events[0])
+	assert.Equal(t, Event("uncore_imc/UNC_M_CAS_COUNT:WR"), events.Uncore.Events[1].events[1])
 	assert.Equal(t, Event("uncore_ubox/UNC_U_EVENT_MSG"), events.Uncore.Events[2].events[0])
 
 	assert.Len(t, events.Uncore.CustomEvents, 1)

--- a/perf/config_test.go
+++ b/perf/config_test.go
@@ -29,7 +29,7 @@ func TestConfigParsing(t *testing.T) {
 	events, err := parseConfig(file)
 
 	assert.Nil(t, err)
-	assert.Len(t, events.Core.Events, 2)
+	assert.Len(t, events.Core.Events, 3)
 	assert.Len(t, events.Core.Events[0].events, 2)
 	assert.Equal(t, true, events.Core.Events[0].array)
 	assert.Equal(t, Event("instructions"), events.Core.Events[0].events[0])
@@ -37,6 +37,11 @@ func TestConfigParsing(t *testing.T) {
 	assert.Len(t, events.Core.Events[1].events, 1)
 	assert.Equal(t, false, events.Core.Events[1].array)
 	assert.Equal(t, Event("cycles"), events.Core.Events[1].events[0])
+	assert.Len(t, events.Core.Events[2].events, 2)
+	assert.Equal(t, true, events.Core.Events[2].array)
+	assert.Equal(t, Event("instructions"), events.Core.Events[2].events[0])
+	assert.Equal(t, Event("cycles"), events.Core.Events[2].events[1])
+	assert.Equal(t, "my_group", events.Core.Events[2].id)
 
 	assert.Len(t, events.Uncore.Events, 3)
 	assert.Equal(t, Event("cas_count_write"), events.Uncore.Events[0].events[0])
@@ -47,5 +52,4 @@ func TestConfigParsing(t *testing.T) {
 	assert.Equal(t, Config{0x5300}, events.Uncore.CustomEvents[0].Config)
 	assert.Equal(t, uint32(0x12), events.Uncore.CustomEvents[0].Type)
 	assert.Equal(t, Event("cas_count_write"), events.Uncore.CustomEvents[0].Name)
-
 }

--- a/perf/testing/perf.json
+++ b/perf/testing/perf.json
@@ -21,7 +21,10 @@
   "uncore": {
     "events": [
       "cas_count_write",
-      "uncore_imc_0/UNC_M_CAS_COUNT:RD",
+      {
+        "group_id": "my_uncore_group",
+        "group_events": ["uncore_imc/UNC_M_CAS_COUNT:RD", "uncore_imc/UNC_M_CAS_COUNT:WR"]
+      },
       "uncore_ubox/UNC_U_EVENT_MSG"
     ],
     "custom_events": [

--- a/perf/testing/perf.json
+++ b/perf/testing/perf.json
@@ -2,7 +2,11 @@
   "core": {
     "events": [
       ["instructions", "instructions_retired"],
-      "cycles"
+      "cycles",
+      {
+        "group_id": "my_group",
+        "group_events": ["instructions", "cycles"]
+      }
     ],
     "custom_events": [
       {

--- a/perf/uncore_libpfm.go
+++ b/perf/uncore_libpfm.go
@@ -242,21 +242,21 @@ func checkGroup(group Group, eventPMUs map[Event]uncorePMUs) error {
 	if group.array {
 		var pmu uncorePMUs
 		for _, event := range group.events {
-			if len(eventPMUs[event]) > 1 {
-				return fmt.Errorf("the events in group usually have to be from single PMU, try reorganizing the \"%v\" group", group.events)
+			if pmu == nil {
+				pmu = eventPMUs[event]
+				continue
 			}
-			if len(eventPMUs[event]) == 1 {
-				if pmu == nil {
-					pmu = eventPMUs[event]
-					continue
-				}
 
-				eq := reflect.DeepEqual(pmu, eventPMUs[event])
-				if !eq {
-					return fmt.Errorf("the events in group usually have to be from the same PMU, try reorganizing the \"%v\" group", group.events)
-				}
+			eq := reflect.DeepEqual(pmu, eventPMUs[event])
+			if !eq {
+				return fmt.Errorf("the events in group usually have to be from the same PMU, try reorganizing the \"%v\" group", group.events)
 			}
 		}
+
+		if len(pmu) > 1 {
+			klog.Warningf("You should be aware that metrics from %v group cannot be counted in the same time from different PMUs.", group.events)
+		}
+
 		return nil
 	}
 	if len(eventPMUs[group.events[0]]) < 1 {

--- a/perf/uncore_libpfm_test.go
+++ b/perf/uncore_libpfm_test.go
@@ -137,7 +137,7 @@ func TestUncoreCollectorSetup(t *testing.T) {
 	assert.Equal(t, []string{"uncore_imc_1/cas_count_read"},
 		getMapKeys(collector.cpuFiles["1"]["uncore_imc_1"].cpuFiles))
 	assert.ElementsMatch(t, []string{"uncore_imc_0/cas_count_write", "uncore_imc_0/cas_count_read"},
-		getMapKeys(collector.cpuFiles["1"]["uncore_imc_0"].cpuFiles))
+		getMapKeys(collector.cpuFiles["3"]["uncore_imc_0"].cpuFiles))
 
 	// There are no errors.
 	assert.Nil(t, err)

--- a/perf/uncore_libpfm_test.go
+++ b/perf/uncore_libpfm_test.go
@@ -218,7 +218,7 @@ func TestCheckGroup(t *testing.T) {
 					"uncore_imc_1": {name: "uncore_imc_1", typeOf: 19, cpus: []uint32{0, 1}},
 				},
 			},
-			"the events in group usually have to be from single PMU, try reorganizing the \"[uncore_imc/cas_count_write uncore_imc/cas_count_read]\" group",
+			"",
 		},
 		{
 			Group{[]Event{"uncore_imc_0/cas_count_write", "uncore_imc_1/cas_count_read"}, true, "1"},


### PR DESCRIPTION
As a cAdvisor user I want to have this configuration working:

``["uncore_imc/cas_count_write", "uncore_imc/cas_count_read"]``