### PR TITLE
Sort metric names in options for readability

### DIFF
--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -124,10 +125,11 @@ type metricSetValue struct {
 }
 
 func (ml *metricSetValue) String() string {
-	var values []string
+	values := make([]string, 0, len(ml.MetricSet))
 	for metric := range ml.MetricSet {
 		values = append(values, string(metric))
 	}
+	sort.Strings(values)
 	return strings.Join(values, ",")
 }
 
@@ -147,7 +149,12 @@ func (ml *metricSetValue) Set(value string) error {
 }
 
 func init() {
-	flag.Var(&ignoreMetrics, "disable_metrics", "comma-separated list of `metrics` to be disabled. Options are 'accelerator', 'cpu_topology','disk', 'diskIO', 'memory_numa', 'network', 'tcp', 'udp', 'percpu', 'sched', 'process', 'hugetlb', 'referenced_memory', 'resctrl', 'cpuset'.")
+	opts := make([]string, 0, len(ignoreWhitelist))
+	for key := range ignoreWhitelist {
+		opts = append(opts, string(key))
+	}
+	sort.Strings(opts)
+	flag.Var(&ignoreMetrics, "disable_metrics", fmt.Sprintf("comma-separated list of `metrics` to be disabled. Options are '%s'.", strings.Join(opts, "', '")))
 
 	// Default logging verbosity to V(2)
 	flag.Set("v", "2")


### PR DESCRIPTION
List of metric names being generated automatically also avoids it accidentally getting out of date.

PS. Eventually I would like metrics to be sorted in all the lists based on their metric names for coder convenience too. It's harder to verify whether a metric is missing from some place in the cAdvisor code when metrics are not listed in same order, and they need to be added to so places.
