### PR TITLE
Add 'enable_metrics' option

### DIFF
--- a/cmd/cadvisor_test.go
+++ b/cmd/cadvisor_test.go
@@ -58,7 +58,7 @@ func TestMemoryNumaMetricsAreDisabledByDefault(t *testing.T) {
 	assert.True(t, ignoreMetrics.Has(container.MemoryNumaMetrics))
 }
 
-func TestIgnoreMetrics(t *testing.T) {
+func TestEnableAndIgnoreMetrics(t *testing.T) {
 	tests := []struct {
 		value    string
 		expected []container.MetricKind
@@ -69,11 +69,13 @@ func TestIgnoreMetrics(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.NoError(t, ignoreMetrics.Set(test.value))
+		for _, sets := range []metricSetValue{enableMetrics, ignoreMetrics} {
+			assert.NoError(t, sets.Set(test.value))
 
-		assert.Equal(t, len(test.expected), len(ignoreMetrics.MetricSet))
-		for _, expected := range test.expected {
-			assert.True(t, ignoreMetrics.Has(expected), "Missing %s", expected)
+			assert.Equal(t, len(test.expected), len(sets.MetricSet))
+			for _, expected := range test.expected {
+				assert.True(t, sets.Has(expected), "Missing %s", expected)
+			}
 		}
 	}
 }

--- a/container/factory.go
+++ b/container/factory.go
@@ -118,6 +118,16 @@ func (ms MetricSet) Difference(ms1 MetricSet) MetricSet {
 	return result
 }
 
+func (ms MetricSet) Append(ms1 MetricSet) MetricSet {
+	result := ms
+	for kind := range ms1 {
+		if !ms.Has(kind) {
+			result.Add(kind)
+		}
+	}
+	return result
+}
+
 // All registered auth provider plugins.
 var pluginsLock sync.Mutex
 var plugins = make(map[string]Plugin)


### PR DESCRIPTION
Looking at the cAdvisor issues, it's nowadays often used to get just some specific metrics [1].  Doing that with 'disable_metrics' option is bothersome because there's such a large number of options one needs to disable, and that set can grow on cAdvisor updates.

Doing that by specifying only metrics one wants with 'enable_metrics' is easier & hopefully future-proof.

Btw. Regarding toIncludedMetrics() function, I think it would be clearer just to inline container.AllMetrics.Difference() call instead of having that wrapper function for it.  Any comments on that, and whether such change should be another PR or part of this one?

[1] Eventually it would be nice to be able to disable all cAdvisor metrics, not just the ones on ignoreWhitelist, but that belongs definitely to another PR.