### PR TITLE
prevent tcp metrics from being dropped when network is disabled

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -344,7 +344,7 @@ func (h *dockerContainerHandler) ContainerReference() (info.ContainerReference, 
 }
 
 func (h *dockerContainerHandler) needNet() bool {
-	if h.includedMetrics.Has(container.NetworkUsageMetrics) {
+	if h.includedMetrics.Has(container.NetworkUsageMetrics) || h.includedMetrics.Has(container.NetworkTcpUsageMetrics) || h.includedMetrics.Has(container.NetworkUdpUsageMetrics) || h.includedMetrics.Has(container.NetworkAdvancedTcpUsageMetrics) {
 		return !h.networkMode.IsContainer()
 	}
 	return false


### PR DESCRIPTION
The network metrics should not be dropped when network metric is disabled. As there are multiple metric set besides network under ContainerStats.Network, like tcp advtcp udp. And I think maybe this include check function should be moved to the prometheus metric side since these metrics are already collected.