### PR TITLE
Depend only on containerd API and avoid vendoring unnecessary things from containerd

### DIFF
--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -24,10 +24,10 @@ import (
 	containersapi "github.com/containerd/containerd/api/services/containers/v1"
 	tasksapi "github.com/containerd/containerd/api/services/tasks/v1"
 	versionapi "github.com/containerd/containerd/api/services/version/v1"
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/pkg/dialer"
 	ptypes "github.com/gogo/protobuf/types"
+	"github.com/google/cadvisor/container/containerd/containers"
+	"github.com/google/cadvisor/container/containerd/errdefs"
+	"github.com/google/cadvisor/container/containerd/pkg/dialer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 )

--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containerd/containerd/containers"
+	"github.com/google/cadvisor/container/containerd/containers"
 )
 
 type containerdClientMock struct {

--- a/container/containerd/containers/containers.go
+++ b/container/containerd/containers/containers.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containers
+
+import (
+	"context"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+)
+
+// Container represents the set of data pinned by a container. Unless otherwise
+// noted, the resources here are considered in use by the container.
+//
+// The resources specified in this object are used to create tasks from the container.
+type Container struct {
+	// ID uniquely identifies the container in a namespace.
+	//
+	// This property is required and cannot be changed after creation.
+	ID string
+
+	// Labels provide metadata extension for a container.
+	//
+	// These are optional and fully mutable.
+	Labels map[string]string
+
+	// Image specifies the image reference used for a container.
+	//
+	// This property is optional and mutable.
+	Image string
+
+	// Runtime specifies which runtime should be used when launching container
+	// tasks.
+	//
+	// This property is required and immutable.
+	Runtime RuntimeInfo
+
+	// Spec should carry the runtime specification used to implement the
+	// container.
+	//
+	// This field is required but mutable.
+	Spec *types.Any
+
+	// SnapshotKey specifies the snapshot key to use for the container's root
+	// filesystem. When starting a task from this container, a caller should
+	// look up the mounts from the snapshot service and include those on the
+	// task create request.
+	//
+	// This field is not required but mutable.
+	SnapshotKey string
+
+	// Snapshotter specifies the snapshotter name used for rootfs
+	//
+	// This field is not required but immutable.
+	Snapshotter string
+
+	// CreatedAt is the time at which the container was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is the time at which the container was updated.
+	UpdatedAt time.Time
+
+	// Extensions stores client-specified metadata
+	Extensions map[string]types.Any
+}
+
+// RuntimeInfo holds runtime specific information
+type RuntimeInfo struct {
+	Name    string
+	Options *types.Any
+}
+
+// Store interacts with the underlying container storage
+type Store interface {
+	// Get a container using the id.
+	//
+	// Container object is returned on success. If the id is not known to the
+	// store, an error will be returned.
+	Get(ctx context.Context, id string) (Container, error)
+
+	// List returns containers that match one or more of the provided filters.
+	List(ctx context.Context, filters ...string) ([]Container, error)
+
+	// Create a container in the store from the provided container.
+	Create(ctx context.Context, container Container) (Container, error)
+
+	// Update the container with the provided container object. ID must be set.
+	//
+	// If one or more fieldpaths are provided, only the field corresponding to
+	// the fieldpaths will be mutated.
+	Update(ctx context.Context, container Container, fieldpaths ...string) (Container, error)
+
+	// Delete a container using the id.
+	//
+	// nil will be returned on success. If the container is not known to the
+	// store, ErrNotFound will be returned.
+	Delete(ctx context.Context, id string) error
+}

--- a/container/containerd/errdefs/errors.go
+++ b/container/containerd/errdefs/errors.go
@@ -1,0 +1,106 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package errdefs defines the common errors used throughout containerd
+// packages.
+//
+// Use with errors.Wrap and error.Wrapf to add context to an error.
+//
+// To detect an error class, use the IsXXX functions to tell whether an error
+// is of a certain type.
+//
+// The functions ToGRPC and FromGRPC can be used to map server-side and
+// client-side errors to the correct types.
+package errdefs
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// Definitions of common error types used throughout containerd. All containerd
+// errors returned by most packages will map into one of these errors classes.
+// Packages should return errors of these types when they want to instruct a
+// client to take a particular action.
+//
+// For the most part, we just try to provide local grpc errors. Most conditions
+// map very well to those defined by grpc.
+var (
+	ErrUnknown            = errors.New("unknown") // used internally to represent a missed mapping.
+	ErrInvalidArgument    = errors.New("invalid argument")
+	ErrNotFound           = errors.New("not found")
+	ErrAlreadyExists      = errors.New("already exists")
+	ErrFailedPrecondition = errors.New("failed precondition")
+	ErrUnavailable        = errors.New("unavailable")
+	ErrNotImplemented     = errors.New("not implemented") // represents not supported and unimplemented
+)
+
+// IsInvalidArgument returns true if the error is due to an invalid argument
+func IsInvalidArgument(err error) bool {
+	return errors.Is(err, ErrInvalidArgument)
+}
+
+// IsNotFound returns true if the error is due to a missing object
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound)
+}
+
+// IsAlreadyExists returns true if the error is due to an already existing
+// metadata item
+func IsAlreadyExists(err error) bool {
+	return errors.Is(err, ErrAlreadyExists)
+}
+
+// IsFailedPrecondition returns true if an operation could not proceed to the
+// lack of a particular condition
+func IsFailedPrecondition(err error) bool {
+	return errors.Is(err, ErrFailedPrecondition)
+}
+
+// IsUnavailable returns true if the error is due to a resource being unavailable
+func IsUnavailable(err error) bool {
+	return errors.Is(err, ErrUnavailable)
+}
+
+// IsNotImplemented returns true if the error is due to not being implemented
+func IsNotImplemented(err error) bool {
+	return errors.Is(err, ErrNotImplemented)
+}
+
+// IsCanceled returns true if the error is due to `context.Canceled`.
+func IsCanceled(err error) bool {
+	return errors.Is(err, context.Canceled)
+}
+
+// IsDeadlineExceeded returns true if the error is due to
+// `context.DeadlineExceeded`.
+func IsDeadlineExceeded(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded)
+}

--- a/container/containerd/errdefs/grpc.go
+++ b/container/containerd/errdefs/grpc.go
@@ -1,0 +1,160 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package errdefs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ToGRPC will attempt to map the backend containerd error into a grpc error,
+// using the original error message as a description.
+//
+// Further information may be extracted from certain errors depending on their
+// type.
+//
+// If the error is unmapped, the original error will be returned to be handled
+// by the regular grpc error handling stack.
+func ToGRPC(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if isGRPCError(err) {
+		// error has already been mapped to grpc
+		return err
+	}
+
+	switch {
+	case IsInvalidArgument(err):
+		return status.Errorf(codes.InvalidArgument, err.Error())
+	case IsNotFound(err):
+		return status.Errorf(codes.NotFound, err.Error())
+	case IsAlreadyExists(err):
+		return status.Errorf(codes.AlreadyExists, err.Error())
+	case IsFailedPrecondition(err):
+		return status.Errorf(codes.FailedPrecondition, err.Error())
+	case IsUnavailable(err):
+		return status.Errorf(codes.Unavailable, err.Error())
+	case IsNotImplemented(err):
+		return status.Errorf(codes.Unimplemented, err.Error())
+	case IsCanceled(err):
+		return status.Errorf(codes.Canceled, err.Error())
+	case IsDeadlineExceeded(err):
+		return status.Errorf(codes.DeadlineExceeded, err.Error())
+	}
+
+	return err
+}
+
+// ToGRPCf maps the error to grpc error codes, assembling the formatting string
+// and combining it with the target error string.
+//
+// This is equivalent to errors.ToGRPC(errors.Wrapf(err, format, args...))
+func ToGRPCf(err error, format string, args ...interface{}) error {
+	return ToGRPC(errors.Wrapf(err, format, args...))
+}
+
+// FromGRPC returns the underlying error from a grpc service based on the grpc error code
+func FromGRPC(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var cls error // divide these into error classes, becomes the cause
+
+	switch code(err) {
+	case codes.InvalidArgument:
+		cls = ErrInvalidArgument
+	case codes.AlreadyExists:
+		cls = ErrAlreadyExists
+	case codes.NotFound:
+		cls = ErrNotFound
+	case codes.Unavailable:
+		cls = ErrUnavailable
+	case codes.FailedPrecondition:
+		cls = ErrFailedPrecondition
+	case codes.Unimplemented:
+		cls = ErrNotImplemented
+	case codes.Canceled:
+		cls = context.Canceled
+	case codes.DeadlineExceeded:
+		cls = context.DeadlineExceeded
+	default:
+		cls = ErrUnknown
+	}
+
+	msg := rebaseMessage(cls, err)
+	if msg != "" {
+		err = errors.Wrap(cls, msg)
+	} else {
+		err = errors.WithStack(cls)
+	}
+
+	return err
+}
+
+// rebaseMessage removes the repeats for an error at the end of an error
+// string. This will happen when taking an error over grpc then remapping it.
+//
+// Effectively, we just remove the string of cls from the end of err if it
+// appears there.
+func rebaseMessage(cls error, err error) string {
+	desc := errDesc(err)
+	clss := cls.Error()
+	if desc == clss {
+		return ""
+	}
+
+	return strings.TrimSuffix(desc, ": "+clss)
+}
+
+func isGRPCError(err error) bool {
+	_, ok := status.FromError(err)
+	return ok
+}
+
+func code(err error) codes.Code {
+	if s, ok := status.FromError(err); ok {
+		return s.Code()
+	}
+	return codes.Unknown
+}
+
+func errDesc(err error) string {
+	if s, ok := status.FromError(err); ok {
+		return s.Message()
+	}
+	return err.Error()
+}

--- a/container/containerd/errdefs/grpc_test.go
+++ b/container/containerd/errdefs/grpc_test.go
@@ -1,0 +1,118 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package errdefs
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pkg/errors"
+)
+
+func TestGRPCRoundTrip(t *testing.T) {
+	errShouldLeaveAlone := errors.New("unknown to package")
+
+	for _, testcase := range []struct {
+		input error
+		cause error
+		str   string
+	}{
+		{
+			input: ErrAlreadyExists,
+			cause: ErrAlreadyExists,
+		},
+		{
+			input: ErrNotFound,
+			cause: ErrNotFound,
+		},
+		{
+			input: errors.Wrapf(ErrFailedPrecondition, "test test test"),
+			cause: ErrFailedPrecondition,
+			str:   "test test test: failed precondition",
+		},
+		{
+			input: status.Errorf(codes.Unavailable, "should be not available"),
+			cause: ErrUnavailable,
+			str:   "should be not available: unavailable",
+		},
+		{
+			input: errShouldLeaveAlone,
+			cause: ErrUnknown,
+			str:   errShouldLeaveAlone.Error() + ": " + ErrUnknown.Error(),
+		},
+		{
+			input: context.Canceled,
+			cause: context.Canceled,
+			str:   "context canceled",
+		},
+		{
+			input: errors.Wrapf(context.Canceled, "this is a test cancel"),
+			cause: context.Canceled,
+			str:   "this is a test cancel: context canceled",
+		},
+		{
+			input: context.DeadlineExceeded,
+			cause: context.DeadlineExceeded,
+			str:   "context deadline exceeded",
+		},
+		{
+			input: errors.Wrapf(context.DeadlineExceeded, "this is a test deadline exceeded"),
+			cause: context.DeadlineExceeded,
+			str:   "this is a test deadline exceeded: context deadline exceeded",
+		},
+	} {
+		t.Run(testcase.input.Error(), func(t *testing.T) {
+			t.Logf("input: %v", testcase.input)
+			gerr := ToGRPC(testcase.input)
+			t.Logf("grpc: %v", gerr)
+			ferr := FromGRPC(gerr)
+			t.Logf("recovered: %v", ferr)
+
+			if errors.Cause(ferr) != testcase.cause {
+				t.Fatalf("unexpected cause: %v != %v", errors.Cause(ferr), testcase.cause)
+			}
+			if !errors.Is(ferr, testcase.cause) {
+				t.Fatalf("unexpected cause: !errors.Is(%v, %v)", ferr, testcase.cause)
+			}
+
+			expected := testcase.str
+			if expected == "" {
+				expected = testcase.cause.Error()
+			}
+			if ferr.Error() != expected {
+				t.Fatalf("unexpected string: %q != %q", ferr.Error(), expected)
+			}
+		})
+	}
+
+}

--- a/container/containerd/factory_test.go
+++ b/container/containerd/factory_test.go
@@ -17,8 +17,8 @@ package containerd
 import (
 	"testing"
 
-	"github.com/containerd/containerd/containers"
 	"github.com/containerd/typeurl"
+	"github.com/google/cadvisor/container/containerd/containers"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )

--- a/container/containerd/grpc.go
+++ b/container/containerd/grpc.go
@@ -16,7 +16,7 @@
 package containerd
 
 import (
-	"github.com/containerd/containerd/namespaces"
+	"github.com/google/cadvisor/container/containerd/namespaces"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/errdefs"
+	"github.com/google/cadvisor/container/containerd/errdefs"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"golang.org/x/net/context"
 

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -18,12 +18,12 @@ package containerd
 import (
 	"testing"
 
-	"github.com/containerd/containerd/containers"
 	"github.com/containerd/typeurl"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/container/containerd/containers"
 	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
 )

--- a/container/containerd/identifiers/validate.go
+++ b/container/containerd/identifiers/validate.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package identifiers provides common validation for identifiers and keys
+// across containerd.
+//
+// Identifiers in containerd must be a alphanumeric, allowing limited
+// underscores, dashes and dots.
+//
+// While the character set may be expanded in the future, identifiers
+// are guaranteed to be safely used as filesystem path components.
+package identifiers
+
+import (
+	"regexp"
+
+	"github.com/google/cadvisor/container/containerd/errdefs"
+	"github.com/pkg/errors"
+)
+
+const (
+	maxLength  = 76
+	alphanum   = `[A-Za-z0-9]+`
+	separators = `[._-]`
+)
+
+var (
+	// identifierRe defines the pattern for valid identifiers.
+	identifierRe = regexp.MustCompile(reAnchor(alphanum + reGroup(separators+reGroup(alphanum)) + "*"))
+)
+
+// Validate returns nil if the string s is a valid identifier.
+//
+// identifiers are similar to the domain name rules according to RFC 1035, section 2.3.1. However
+// rules in this package are relaxed to allow numerals to follow period (".") and mixed case is
+// allowed.
+//
+// In general identifiers that pass this validation should be safe for use as filesystem path components.
+func Validate(s string) error {
+	if len(s) == 0 {
+		return errors.Wrapf(errdefs.ErrInvalidArgument, "identifier must not be empty")
+	}
+
+	if len(s) > maxLength {
+		return errors.Wrapf(errdefs.ErrInvalidArgument, "identifier %q greater than maximum length (%d characters)", s, maxLength)
+	}
+
+	if !identifierRe.MatchString(s) {
+		return errors.Wrapf(errdefs.ErrInvalidArgument, "identifier %q must match %v", s, identifierRe)
+	}
+	return nil
+}
+
+func reGroup(s string) string {
+	return `(?:` + s + `)`
+}
+
+func reAnchor(s string) string {
+	return `^` + s + `$`
+}

--- a/container/containerd/identifiers/validate_test.go
+++ b/container/containerd/identifiers/validate_test.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package identifiers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/cadvisor/container/containerd/errdefs"
+)
+
+func TestValidIdentifiers(t *testing.T) {
+	for _, input := range []string{
+		"default",
+		"Default",
+		t.Name(),
+		"default-default",
+		"containerd.io",
+		"foo.boo",
+		"swarmkit.docker.io",
+		"0912341234",
+		"task.0.0123456789",
+		"container.system-75-f19a.00",
+		"underscores_are_allowed",
+		strings.Repeat("a", maxLength),
+	} {
+		t.Run(input, func(t *testing.T) {
+			if err := Validate(input); err != nil {
+				t.Fatalf("unexpected error: %v != nil", err)
+			}
+		})
+	}
+}
+
+func TestInvalidIdentifiers(t *testing.T) {
+	for _, input := range []string{
+		"",
+		".foo..foo",
+		"foo/foo",
+		"foo/..",
+		"foo..foo",
+		"foo.-boo",
+		"-foo.boo",
+		"foo.boo-",
+		"but__only_tasteful_underscores",
+		"zn--e9.org", // or something like it!
+		"default--default",
+		strings.Repeat("a", maxLength+1),
+	} {
+
+		t.Run(input, func(t *testing.T) {
+			if err := Validate(input); err == nil {
+				t.Fatal("expected invalid error")
+			} else if !errdefs.IsInvalidArgument(err) {
+				t.Fatal("error should be an invalid identifier error")
+			}
+		})
+	}
+}

--- a/container/containerd/namespaces/context.go
+++ b/container/containerd/namespaces/context.go
@@ -1,0 +1,91 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespaces
+
+import (
+	"context"
+	"os"
+
+	"github.com/google/cadvisor/container/containerd/errdefs"
+	"github.com/google/cadvisor/container/containerd/identifiers"
+	"github.com/pkg/errors"
+)
+
+const (
+	// NamespaceEnvVar is the environment variable key name
+	NamespaceEnvVar = "CONTAINERD_NAMESPACE"
+	// Default is the name of the default namespace
+	Default = "default"
+)
+
+type namespaceKey struct{}
+
+// WithNamespace sets a given namespace on the context
+func WithNamespace(ctx context.Context, namespace string) context.Context {
+	ctx = context.WithValue(ctx, namespaceKey{}, namespace) // set our key for namespace
+	// also store on the grpc and ttrpc headers so it gets picked up by any clients that
+	// are using this.
+	return withTTRPCNamespaceHeader(withGRPCNamespaceHeader(ctx, namespace), namespace)
+}
+
+// NamespaceFromEnv uses the namespace defined in CONTAINERD_NAMESPACE or
+// default
+func NamespaceFromEnv(ctx context.Context) context.Context {
+	namespace := os.Getenv(NamespaceEnvVar)
+	if namespace == "" {
+		namespace = Default
+	}
+	return WithNamespace(ctx, namespace)
+}
+
+// Namespace returns the namespace from the context.
+//
+// The namespace is not guaranteed to be valid.
+func Namespace(ctx context.Context) (string, bool) {
+	namespace, ok := ctx.Value(namespaceKey{}).(string)
+	if !ok {
+		if namespace, ok = fromGRPCHeader(ctx); !ok {
+			return fromTTRPCHeader(ctx)
+		}
+	}
+	return namespace, ok
+}
+
+// NamespaceRequired returns the valid namespace from the context or an error.
+func NamespaceRequired(ctx context.Context) (string, error) {
+	namespace, ok := Namespace(ctx)
+	if !ok || namespace == "" {
+		return "", errors.Wrapf(errdefs.ErrFailedPrecondition, "namespace is required")
+	}
+	if err := identifiers.Validate(namespace); err != nil {
+		return "", errors.Wrap(err, "namespace validation")
+	}
+	return namespace, nil
+}

--- a/container/containerd/namespaces/context_test.go
+++ b/container/containerd/namespaces/context_test.go
@@ -1,0 +1,88 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespaces
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestContext(t *testing.T) {
+	ctx := context.Background()
+	namespace, ok := Namespace(ctx)
+	if ok {
+		t.Fatal("namespace should not be present")
+	}
+
+	if namespace != "" {
+		t.Fatalf("namespace should not be defined: got %q", namespace)
+	}
+
+	expected := "test"
+	nctx := WithNamespace(ctx, expected)
+
+	namespace, ok = Namespace(nctx)
+	if !ok {
+		t.Fatal("expected to find a namespace")
+	}
+
+	if namespace != expected {
+		t.Fatalf("unexpected namespace: %q != %q", namespace, expected)
+	}
+}
+
+func TestNamespaceFromEnv(t *testing.T) {
+	oldenv := os.Getenv(NamespaceEnvVar)
+	defer os.Setenv(NamespaceEnvVar, oldenv) // restore old env var
+
+	ctx := context.Background()
+	namespace, ok := Namespace(ctx)
+	if ok {
+		t.Fatal("namespace should not be present")
+	}
+
+	if namespace != "" {
+		t.Fatalf("namespace should not be defined: got %q", namespace)
+	}
+
+	expected := "test-namespace"
+	os.Setenv(NamespaceEnvVar, expected)
+	nctx := NamespaceFromEnv(ctx)
+
+	namespace, ok = Namespace(nctx)
+	if !ok {
+		t.Fatal("expected to find a namespace")
+	}
+
+	if namespace != expected {
+		t.Fatalf("unexpected namespace: %q != %q", namespace, expected)
+	}
+}

--- a/container/containerd/namespaces/grpc.go
+++ b/container/containerd/namespaces/grpc.go
@@ -1,0 +1,74 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespaces
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// GRPCHeader defines the header name for specifying a containerd namespace.
+	GRPCHeader = "containerd-namespace"
+)
+
+// NOTE(stevvooe): We can stub this file out if we don't want a grpc dependency here.
+
+func withGRPCNamespaceHeader(ctx context.Context, namespace string) context.Context {
+	// also store on the grpc headers so it gets picked up by any clients that
+	// are using this.
+	nsheader := metadata.Pairs(GRPCHeader, namespace)
+	md, ok := metadata.FromOutgoingContext(ctx) // merge with outgoing context.
+	if !ok {
+		md = nsheader
+	} else {
+		// order ensures the latest is first in this list.
+		md = metadata.Join(nsheader, md)
+	}
+
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func fromGRPCHeader(ctx context.Context) (string, bool) {
+	// try to extract for use in grpc servers.
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		// TODO(stevvooe): Check outgoing context?
+		return "", false
+	}
+
+	values := md[GRPCHeader]
+	if len(values) == 0 {
+		return "", false
+	}
+
+	return values[0], true
+}

--- a/container/containerd/namespaces/store.go
+++ b/container/containerd/namespaces/store.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespaces
+
+import "context"
+
+// Store provides introspection about namespaces.
+//
+// Note that these are slightly different than other objects, which are record
+// oriented. A namespace is really just a name and a set of labels. Objects
+// that belong to a namespace are returned when the namespace is assigned to a
+// given context.
+//
+//
+type Store interface {
+	Create(ctx context.Context, namespace string, labels map[string]string) error
+	Labels(ctx context.Context, namespace string) (map[string]string, error)
+	SetLabel(ctx context.Context, namespace, key, value string) error
+	List(ctx context.Context) ([]string, error)
+
+	// Delete removes the namespace. The namespace must be empty to be deleted.
+	Delete(ctx context.Context, namespace string, opts ...DeleteOpts) error
+}
+
+// DeleteInfo specifies information for the deletion of a namespace
+type DeleteInfo struct {
+	// Name of the namespace
+	Name string
+}
+
+// DeleteOpts allows the caller to set options for namespace deletion
+type DeleteOpts func(context.Context, *DeleteInfo) error

--- a/container/containerd/namespaces/ttrpc.go
+++ b/container/containerd/namespaces/ttrpc.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespaces
+
+import (
+	"context"
+
+	"github.com/containerd/ttrpc"
+)
+
+const (
+	// TTRPCHeader defines the header name for specifying a containerd namespace
+	TTRPCHeader = "containerd-namespace-ttrpc"
+)
+
+func copyMetadata(src ttrpc.MD) ttrpc.MD {
+	md := ttrpc.MD{}
+	for k, v := range src {
+		md[k] = append(md[k], v...)
+	}
+	return md
+}
+
+func withTTRPCNamespaceHeader(ctx context.Context, namespace string) context.Context {
+	md, ok := ttrpc.GetMetadata(ctx)
+	if !ok {
+		md = ttrpc.MD{}
+	} else {
+		md = copyMetadata(md)
+	}
+	md.Set(TTRPCHeader, namespace)
+	return ttrpc.WithMetadata(ctx, md)
+}
+
+func fromTTRPCHeader(ctx context.Context) (string, bool) {
+	return ttrpc.GetMetadataValue(ctx, TTRPCHeader)
+}

--- a/container/containerd/namespaces/ttrpc_test.go
+++ b/container/containerd/namespaces/ttrpc_test.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespaces
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/containerd/ttrpc"
+)
+
+func TestCopyTTRPCMetadata(t *testing.T) {
+	src := ttrpc.MD{}
+	src.Set("key", "a", "b", "c", "d")
+	md := copyMetadata(src)
+
+	if !reflect.DeepEqual(src, md) {
+		t.Fatalf("metadata is copied incorrectly")
+	}
+
+	slice, _ := src.Get("key")
+	slice[0] = "z"
+	if reflect.DeepEqual(src, md) {
+		t.Fatalf("metadata is copied incorrectly")
+	}
+}
+
+func TestTTRPCNamespaceHeader(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test-namespace"
+	ctx = withTTRPCNamespaceHeader(ctx, namespace)
+
+	header, ok := fromTTRPCHeader(ctx)
+	if !ok || header != namespace {
+		t.Fatalf("ttrp namespace header is set incorrectly")
+	}
+}

--- a/container/containerd/pkg/dialer/dialer.go
+++ b/container/containerd/pkg/dialer/dialer.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dialer
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type dialResult struct {
+	c   net.Conn
+	err error
+}
+
+// ContextDialer returns a GRPC net.Conn connected to the provided address
+func ContextDialer(ctx context.Context, address string) (net.Conn, error) {
+	if deadline, ok := ctx.Deadline(); ok {
+		return timeoutDialer(address, time.Until(deadline))
+	}
+	return timeoutDialer(address, 0)
+}
+
+// Dialer returns a GRPC net.Conn connected to the provided address
+// Deprecated: use ContextDialer and grpc.WithContextDialer.
+var Dialer = timeoutDialer
+
+func timeoutDialer(address string, timeout time.Duration) (net.Conn, error) {
+	var (
+		stopC = make(chan struct{})
+		synC  = make(chan *dialResult)
+	)
+	go func() {
+		defer close(synC)
+		for {
+			select {
+			case <-stopC:
+				return
+			default:
+				c, err := dialer(address, timeout)
+				if isNoent(err) {
+					<-time.After(10 * time.Millisecond)
+					continue
+				}
+				synC <- &dialResult{c, err}
+				return
+			}
+		}
+	}()
+	select {
+	case dr := <-synC:
+		return dr.c, dr.err
+	case <-time.After(timeout):
+		close(stopC)
+		go func() {
+			dr := <-synC
+			if dr != nil && dr.c != nil {
+				dr.c.Close()
+			}
+		}()
+		return nil, errors.Errorf("dial %s: timeout", address)
+	}
+}

--- a/container/containerd/pkg/dialer/dialer_unix.go
+++ b/container/containerd/pkg/dialer/dialer_unix.go
@@ -1,0 +1,66 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !windows
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dialer
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// DialAddress returns the address with unix:// prepended to the
+// provided address
+func DialAddress(address string) string {
+	return fmt.Sprintf("unix://%s", address)
+}
+
+func isNoent(err error) bool {
+	if err != nil {
+		if nerr, ok := err.(*net.OpError); ok {
+			if serr, ok := nerr.Err.(*os.SyscallError); ok {
+				if serr.Err == syscall.ENOENT {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func dialer(address string, timeout time.Duration) (net.Conn, error) {
+	address = strings.TrimPrefix(address, "unix://")
+	return net.DialTimeout("unix", address, timeout)
+}

--- a/container/containerd/pkg/dialer/dialer_windows.go
+++ b/container/containerd/pkg/dialer/dialer_windows.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dialer
+
+import (
+	"net"
+	"os"
+	"time"
+
+	winio "github.com/Microsoft/go-winio"
+)
+
+func isNoent(err error) bool {
+	return os.IsNotExist(err)
+}
+
+func dialer(address string, timeout time.Duration) (net.Conn, error) {
+	return winio.DialPipe(address, &timeout)
+}
+
+// DialAddress returns the dial address
+func DialAddress(address string) string {
+	return address
+}

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.54.0
-	github.com/Microsoft/go-winio v0.4.15 // indirect
+	github.com/Microsoft/go-winio v0.4.15
 	github.com/aws/aws-sdk-go v1.35.24
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/containerd v1.4.11
-	github.com/containerd/ttrpc v1.0.2 // indirect
+	github.com/containerd/ttrpc v1.0.2
 	github.com/containerd/typeurl v1.0.2
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.7+incompatible


### PR DESCRIPTION
When cadvisor vendors in things from containerd, there is a dependency loop between cadvisor<->containerd<->kubernetes as containerd vendors in cri-api. So we have been unable to move to newer versions of containerd that use go modules. To help with this effort in 1.6, containerd folks will publish `containerd/containerd/api` as a separate go module. To prep for this, we can cleanup our usage of containerd now to depend only on the code under `containerd/containerd/api` by borrowing some code from containerd repository that essentially acts as a containerd client. 

When containerd 1.6 goes GA, we can switch over to the new `containerd/api` go module. Kubernetes also needs https://github.com/moby/moby/pull/42624 from moby/moby to completely eliminate this dependency loop unless/until we get rid of dockershim (WIP for dockershim removal is here - https://github.com/kubernetes/kubernetes/pull/97252). Either way we are in track to get rid of this dependency loop by kubernetes 1.24 🤞🏾 🙏🏾 

Signed-off-by: Davanum Srinivas <davanum@gmail.com>