### PR TITLE
fix when rootfs is empty, TotalUsageBytes will add extraUsage.Bytes on every update, lead to TotalUsageBytes keep increasing

### DIFF
--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -96,7 +96,12 @@ func (fh *realFsHandler) update() error {
 		fh.usage.TotalUsageBytes = rootUsage.Bytes
 	}
 	if fh.extraDir != "" && extraErr == nil {
-		fh.usage.TotalUsageBytes += extraUsage.Bytes
+		if fh.rootfs != "" {
+			fh.usage.TotalUsageBytes += extraUsage.Bytes
+		} else {
+			// rootfs is empty, totalUsageBytes use extra usage bytes
+			fh.usage.TotalUsageBytes = extraUsage.Bytes
+		}
 	}
 
 	// Combine errors into a single error to return


### PR DESCRIPTION
fix when rootfs is empty, TotalUsageBytes will add extraUsage.Bytes on every update, lead to TotalUsageBytes keep increasing. 
this may cause kubelet to evict pods