### PR TITLE
Add '-enable_metrics' option to docs / examples

### DIFF
--- a/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
+++ b/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
@@ -17,7 +17,7 @@ spec:
           - --max_housekeeping_interval=15s
           - --event_storage_event_limit=default=0
           - --event_storage_age_limit=default=0
-          - --disable_metrics=percpu,hugetlb,sched,tcp,udp,advtcp # enable only diskIO, cpu, memory, network, disk, process
+          - --enable_metrics=disk,diskIO,memory,network,process   # app & cpu metrics are always enabled
           - --docker_only                                         # only show stats for docker containers
           - --store_container_labels=false
           - --whitelisted_container_labels=io.kubernetes.container.name, io.kubernetes.pod.name,io.kubernetes.pod.namespace

--- a/docs/running.md
+++ b/docs/running.md
@@ -23,7 +23,7 @@ cAdvisor is now running (in the background) on `http://localhost:8080/`. The set
 - If docker daemon is running with [user namespace enabled](https://docs.docker.com/engine/reference/commandline/dockerd/#starting-the-daemon-with-user-namespaces-enabled),
 you need to add `--userns=host` option in order for cAdvisor to monitor Docker containers,
 otherwise cAdvisor can not connect to docker daemon.
-- If cadvisor scrapes `process metrics` by set flag `--disable_metrics`, you need to add `--pid=host` and `--privileged` for `docker run` to get `/proc/pid/fd` path in host.
+- If cadvisor scrapes `process` metrics due to `--disable_metrics` or `--enable_metrics` options, you need to add `--pid=host` and `--privileged` for `docker run` to get `/proc/pid/fd` path in host.
 - If cAdvisor needs to be run in Docker container without `--privileged` option it is possible to add host devices to container using `--dev` and
   specify security options using `--security-opt` with secure computing mode (seccomp).
   For details related to seccomp please [see](https://docs.docker.com/engine/security/seccomp/), the default Docker profile can be found [here](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json).

--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -125,7 +125,8 @@ cAdvisor stores the latest historical data in memory. How long of a history it s
 --application_metrics_count_limit=100: Max number of application metrics to store (per container) (default 100)
 --collector_cert="": Collector's certificate, exposed to endpoints for certificate based authentication.
 --collector_key="": Key for the collector's certificate
---disable_metrics=referenced_memory,cpu_topology,resctrl,udp,advtcp,sched,hugetlb,memory_numa,tcp,process: comma-separated list of metrics to be disabled. Options are 'accelerator', 'cpu_topology','disk', 'diskIO', 'memory_numa', 'network', 'tcp', 'udp', 'percpu', 'sched', 'process', 'hugetlb', 'referenced_memory', 'resctrl', 'cpuset'. (default referenced_memory,cpu_topology,resctrl,udp,advtcp,sched,hugetlb,memory_numa,tcp,process)
+--disable_metrics=<metrics>: comma-separated list of metrics to be disabled. Options are accelerator,advtcp,cpuLoad,cpu_topology,cpuset,disk,diskIO,hugetlb,memory,memory_numa,network,oom_event,percpu,perf_event,process,referenced_memory,resctrl,sched,tcp,udp. (default advtcp,cpu_topology,cpuset,hugetlb,memory_numa,process,referenced_memory,resctrl,sched,tcp,udp)
+--enable_metrics=<metrics>: comma-separated list of metrics to be enabled. If set, overrides 'disable_metrics'. Options are accelerator,advtcp,cpuLoad,cpu_topology,cpuset,disk,diskIO,hugetlb,memory,memory_numa,network,oom_event,percpu,perf_event,process,referenced_memory,resctrl,sched,tcp,udp.
 --prometheus_endpoint="/metrics": Endpoint to expose Prometheus metrics on (default "/metrics")
 --disable_root_cgroup_stats=false: Disable collecting root Cgroup stats
 ```
@@ -149,7 +150,7 @@ cAdvisor stores the latest historical data in memory. How long of a history it s
 --perf_events_config="" Path to a JSON file containing configuration of perf events to measure. Empty value disables perf events measuring.
 ```
 
-Core perf events can be exposed on Prometheus endpoint per CPU or aggregated by event. It is controlled through `--disable_metrics` parameter with option `percpu`, e.g.:
+Core perf events can be exposed on Prometheus endpoint per CPU or aggregated by event. It is controlled through `--disable_metrics` and `--enable_metrics` parameters with option `percpu`, e.g.:
 - `--disable_metrics="percpu"` - core perf events are aggregated
 - `--disable_metrics=""` - core perf events are exposed per CPU.
 

--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -1,6 +1,6 @@
 # Monitoring cAdvisor with Prometheus
 
-cAdvisor exposes container and hardware statistics as [Prometheus](https://prometheus.io) metrics out of the box. By default, these metrics are served under the `/metrics` HTTP endpoint. This endpoint may be customized by setting the `-prometheus_endpoint` and `-disable_metrics` command-line flags.
+cAdvisor exposes container and hardware statistics as [Prometheus](https://prometheus.io) metrics out of the box. By default, these metrics are served under the `/metrics` HTTP endpoint. This endpoint may be customized by setting the `-prometheus_endpoint` and `-disable_metrics` or `-enable_metrics` command-line flags.
 
 To collect some of metrics it is required to build cAdvisor with additional flags, for details see [build instructions](../development/build.md), additional flags are indicated in "additional build flag" column in table below.
 
@@ -14,9 +14,9 @@ To monitor cAdvisor with Prometheus, simply configure one or more jobs in Promet
 
 ## Prometheus container metrics
 
-The table below lists the Prometheus container metrics exposed by cAdvisor (in alphabetical order by metric name):
+The table below lists the Prometheus container metrics exposed by cAdvisor (in alphabetical order by metric name) and corresponding `-disable_metrics` / `-enable_metrics` option parameter:
 
-Metric name | Type | Description | Unit (where applicable) | -disable_metrics parameter | additional build flag |
+Metric name | Type | Description | Unit (where applicable) | option parameter | additional build flag |
 :-----------|:-----|:------------|:------------------------|:---------------------------|:----------------------
 `container_accelerator_duty_cycle` | Gauge | Percent of time over the past sample period during which the accelerator was actively processing | percentage | accelerator |
 `container_accelerator_memory_total_bytes` | Gauge | Total accelerator memory | bytes | accelerator |
@@ -97,9 +97,9 @@ Metric name | Type | Description | Unit (where applicable) | -disable_metrics pa
 
 ## Prometheus hardware metrics
 
-The table below lists the Prometheus hardware metrics exposed by cAdvisor (in alphabetical order by metric name):
+The table below lists the Prometheus hardware metrics exposed by cAdvisor (in alphabetical order by metric name) and corresponding `-disable_metrics` / `-enable_metrics` option parameter:
 
-Metric name | Type | Description | Unit (where applicable) | -disable_metrics parameter | addional build flag |
+Metric name | Type | Description | Unit (where applicable) | option parameter | addional build flag |
 :-----------|:-----|:------------|:------------------------|:---------------------------|:--------------------
 `machine_cpu_cache_capacity_bytes` | Gauge |  Cache size in bytes assigned to NUMA node and CPU core | bytes | cpu_topology |
 `machine_cpu_cores` | Gauge | Number of logical CPU cores | | |


### PR DESCRIPTION
Fixes also -disable_metrics 'process' metric name in running.md, and updates list of '-disable_metrics' option metrics.

Note: I've followed the existing documentation convention of giving cAdvisor option names with two dashes (--enable_metrics) although current cAdvisor uses only one dash (-enable_metrics).