### PR TITLE
Fix documentation of RequestOptions.IdType

### DIFF
--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -263,7 +263,7 @@ type FsInfo struct {
 }
 
 type RequestOptions struct {
-	// Type of container identifier specified - "name", "dockerid", dockeralias"
+	// Type of container identifier specified - TypeName (default) or TypeDocker
 	IdType string `json:"type"`
 	// Number of stats to return
 	Count int `json:"count"`


### PR DESCRIPTION
The only valid options are "name" (default) or "docker", while "dockerid" and "dockeralias" fail with an 'unknown type' error.

Reference:
https://github.com/google/cadvisor/blob/20e306ab0398f00daaafeda2444b9ec157636f74/cmd/internal/api/versions.go#L531-L540