### PR TITLE
Refactor max_housekeeping_interval to move in manager package

### DIFF
--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -26,7 +26,6 @@ import (
 	"sort"
 	"strings"
 	"syscall"
-	"time"
 
 	cadvisorhttp "github.com/google/cadvisor/cmd/internal/http"
 	"github.com/google/cadvisor/container"
@@ -58,11 +57,6 @@ var httpDigestFile = flag.String("http_digest_file", "", "HTTP digest file for t
 var httpDigestRealm = flag.String("http_digest_realm", "localhost", "HTTP digest file for the web UI")
 
 var prometheusEndpoint = flag.String("prometheus_endpoint", "/metrics", "Endpoint to expose Prometheus metrics on")
-
-var housekeepingConfig = manager.HouskeepingConfig{
-	flag.Duration("max_housekeeping_interval", 60*time.Second, "Largest interval to allow between container housekeepings"),
-	flag.Bool("allow_dynamic_housekeeping", true, "Whether to allow the housekeeping interval to be dynamic"),
-}
 
 var enableProfiling = flag.Bool("profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
 
@@ -195,7 +189,7 @@ func main() {
 
 	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
 
-	resourceManager, err := manager.New(memoryStorage, sysFs, housekeepingConfig, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList, ","), *perfEvents)
+	resourceManager, err := manager.New(memoryStorage, sysFs, manager.HousekeepingConfigFlags, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList, ","), *perfEvents)
 	if err != nil {
 		klog.Fatalf("Failed to create a manager: %s", err)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -62,6 +62,11 @@ var eventStorageAgeLimit = flag.String("event_storage_age_limit", "default=24h",
 var eventStorageEventLimit = flag.String("event_storage_event_limit", "default=100000", "Max number of events to store (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or \"default\" and the value is an integer. Default is applied to all non-specified event types")
 var applicationMetricsCountLimit = flag.Int("application_metrics_count_limit", 100, "Max number of application metrics to store (per container)")
 
+var HousekeepingConfigFlags = HouskeepingConfig{
+	flag.Duration("max_housekeeping_interval", 60*time.Second, "Largest interval to allow between container housekeepings"),
+	flag.Bool("allow_dynamic_housekeeping", true, "Whether to allow the housekeeping interval to be dynamic"),
+}
+
 // The Manager interface defines operations for starting a manager and getting
 // container and machine information.
 type Manager interface {


### PR DESCRIPTION
As per the discussion https://github.com/google/cadvisor/pull/2920#issuecomment-902406524, this PR refactors `max_housekeeping_interval` to move it from `cmd` package to `manager` package so that along with the command line kubelet can also override it. 

Potential users of this refactor - https://github.com/kubernetes/kubernetes/pull/104339 

I have tested this refactoring with cadvisor command, 
```bash
[harshal@localhost cadvisor]$ ./cadvisor -h 
Usage of ./cadvisor:
</snip>
 -max_housekeeping_interval duration
        Largest interval to allow between container housekeepings (default 1m0s)
</snip>
```
So this isn't breaking existing flag. 

Plus it works with kubelet too,
```bash
[harshal@localhost kubernetes]$ _output/bin/kubelet -h | grep max-house
      --max-housekeeping-interval duration                       Largest interval to allow between container housekeepings (default 1m0s)
[harshal@localhost kubernetes]$ 
```

/cc @bobbypage @rphillips @pxaws

Signed-off-by: Harshal Patil <harpatil@redhat.com>