### PR TITLE
Fix the first alias of container reference

### DIFF
--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -48,7 +48,7 @@ func (c *containerdClientMock) TaskPid(ctx context.Context, id string) (uint32, 
 }
 
 func (c *containerdClientMock) ContainerStatus(ctx context.Context, id string) (*criapi.ContainerStatus, error) {
-	return &criapi.ContainerStatus{}, nil
+	return c.status, nil
 }
 
 func mockcontainerdClient(cntrs map[string]*containers.Container, status *criapi.ContainerStatus, returnErr error) ContainerdClient {

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -112,7 +112,10 @@ func newContainerdContainerHandler(
 		rootfs = "/rootfs"
 	}
 
+	// For sandbox container (pause), the restart is hardcoded to "0"
 	var restart uint32 = 0
+	// Special container name for sandbox(pause)
+	// It is defined in https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/naming.go#L50-L52
 	containerName := "POD"
 	if cntr.Labels["io.cri-containerd.kind"] != "sandbox" {
 		status, err := client.ContainerStatus(ctx, id)

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -112,11 +112,31 @@ func newContainerdContainerHandler(
 		rootfs = "/rootfs"
 	}
 
+	var restart uint32 = 0
+	containerName := "POD"
+	if cntr.Labels["io.cri-containerd.kind"] != "sandbox" {
+		status, err := client.ContainerStatus(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		restart = status.Metadata.Attempt
+		containerName = cntr.Labels["io.kubernetes.container.name"]
+	}
+
+	// The "io.kubernetes" labels are defined in https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/types/labels.go
+	containerNameConcat := strings.Join([]string{
+		"k8s",
+		containerName,
+		cntr.Labels["io.kubernetes.pod.name"],
+		cntr.Labels["io.kubernetes.pod.namespace"],
+		cntr.Labels["io.kubernetes.pod.uid"],
+		fmt.Sprint(restart)}, "_")
+
 	containerReference := info.ContainerReference{
 		Id:        id,
 		Name:      name,
 		Namespace: k8sContainerdNamespace,
-		Aliases:   []string{id, name},
+		Aliases:   []string{containerNameConcat, id, name},
 	}
 
 	libcontainerHandler := containerlibcontainer.NewHandler(cgroupManager, rootfs, int(taskPid), includedMetrics)

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -26,6 +26,7 @@ import (
 	info "github.com/google/cadvisor/info/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	criapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 func init() {
@@ -60,13 +61,31 @@ func TestHandler(t *testing.T) {
 		checkEnvVars   map[string]string
 	}
 	testContainers := make(map[string]*containers.Container)
+	testContainerSandbox := &containers.Container{
+		ID: "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
+		Labels: map[string]string{
+			"io.cri-containerd.kind":       "sandbox",
+			"io.kubernetes.container.name": "pause",
+			"io.kubernetes.pod.name":       "some-pod",
+			"io.kubernetes.pod.namespace":  "some-ns",
+			"io.kubernetes.pod.uid":        "some-uid"},
+	}
 	testContainer := &containers.Container{
-		ID:     "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
-		Labels: map[string]string{"io.cri-containerd.kind": "sandbox"},
+		ID: "c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086",
+		Labels: map[string]string{
+			"io.cri-containerd.kind":       "container",
+			"io.kubernetes.container.name": "some-container",
+			"io.kubernetes.pod.name":       "some-pod",
+			"io.kubernetes.pod.namespace":  "some-ns",
+			"io.kubernetes.pod.uid":        "some-uid"},
 	}
 	spec := &specs.Spec{Root: &specs.Root{Path: "/test/"}, Process: &specs.Process{Env: []string{"TEST_REGION=FRA", "TEST_ZONE=A", "HELLO=WORLD"}}}
+	testContainerSandbox.Spec, _ = typeurl.MarshalAny(spec)
 	testContainer.Spec, _ = typeurl.MarshalAny(spec)
-	testContainers["40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"] = testContainer
+	testContainers["40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"] = testContainerSandbox
+	testContainers["c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086"] = testContainer
+	status := &criapi.ContainerStatus{Metadata: &criapi.ContainerMetadata{Attempt: 2}}
+
 	for _, ts := range []testCase{
 		{
 			mockcontainerdClient(nil, nil, nil),
@@ -96,7 +115,7 @@ func TestHandler(t *testing.T) {
 			&info.ContainerReference{
 				Id:        "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
 				Name:      "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
-				Aliases:   []string{"40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"},
+				Aliases:   []string{"k8s_POD_some-pod_some-ns_some-uid_0", "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"},
 				Namespace: k8sContainerdNamespace,
 			},
 			map[string]string{},
@@ -115,10 +134,29 @@ func TestHandler(t *testing.T) {
 			&info.ContainerReference{
 				Id:        "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
 				Name:      "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
-				Aliases:   []string{"40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"},
+				Aliases:   []string{"k8s_POD_some-pod_some-ns_some-uid_0", "40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"},
 				Namespace: k8sContainerdNamespace,
 			},
 			map[string]string{"TEST_REGION": "FRA", "TEST_ZONE": "A"},
+		},
+		{
+			mockcontainerdClient(testContainers, status, nil),
+			"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086",
+			&mockedMachineInfo{},
+			nil,
+			&containerlibcontainer.CgroupSubsystems{},
+			false,
+			nil,
+			nil,
+			false,
+			"",
+			&info.ContainerReference{
+				Id:        "c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086",
+				Name:      "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086",
+				Aliases:   []string{"k8s_some-container_some-pod_some-ns_some-uid_2", "c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086", "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086"},
+				Namespace: k8sContainerdNamespace,
+			},
+			map[string]string{},
 		},
 	} {
 		handler, err := newContainerdContainerHandler(ts.client, ts.name, ts.machineInfoFactory, ts.fsInfo, ts.cgroupSubsystems, ts.inHostNamespace, ts.metadataEnvs, ts.includedMetrics)


### PR DESCRIPTION
Signed-off-by: Qiutong Song <songqt01@gmail.com>

## Overview

Previous PR: https://github.com/google/cadvisor/pull/2919

In Prometheus and Statsd, they use the first container alias as the "container name" in the output metrics. However, docker handler and containerd handler have different logics for the alias.

In docker, it is `k8s_<container-name>_<pod-name>_<namespace>_<pod-uid>_<restart-count>` but it is <container id> in containerd.

This PR is to make containerd behave the same way as docker.

## Notes

- For sandbox container (pause), the restart is hardcoded to "0"

## Testing

```
$ go test github.com/google/cadvisor/container/containerd
$ make test
```
Query Prometheus endpont: `localhost:8080/metrics`

```
name="k8s_nginx-pod_nginx-pod_default_3842c335-15cc-4b1a-8aa2-112a1eac3f82_0"
name="k8s_POD_coredns-755cd654d4-pg5wm_kube-system_5fc14a57-9ca9-4237-9e05-38802c229dbd_0"
```

Kill the container process (to force restarted) and re-query

```
name="k8s_nginx-pod_nginx-pod_default_3842c335-15cc-4b1a-8aa2-112a1eac3f82_1"
name="k8s_POD_coredns-755cd654d4-pg5wm_kube-system_5fc14a57-9ca9-4237-9e05-38802c229dbd_0"
```
