### PR TITLE
if docker can't connect during InitializeFSContext , do not add image dev info to real fs info label cache

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -284,15 +284,17 @@ func (i *RealFsInfo) addSystemRootLabel(mounts []*mount.Info) {
 
 // addDockerImagesLabel attempts to determine which device contains the mount for docker images.
 func (i *RealFsInfo) addDockerImagesLabel(context Context, mounts []*mount.Info) {
-	dockerDev, dockerPartition, err := i.getDockerDeviceMapperInfo(context.Docker)
-	if err != nil {
-		klog.Warningf("Could not get Docker devicemapper device: %v", err)
-	}
-	if len(dockerDev) > 0 && dockerPartition != nil {
-		i.partitions[dockerDev] = *dockerPartition
-		i.labels[LabelDockerImages] = dockerDev
-	} else {
-		i.updateContainerImagesPath(LabelDockerImages, mounts, getDockerImagePaths(context))
+	if context.Docker.Driver != "" {
+		dockerDev, dockerPartition, err := i.getDockerDeviceMapperInfo(context.Docker)
+		if err != nil {
+			klog.Warningf("Could not get Docker devicemapper device: %v", err)
+		}
+		if len(dockerDev) > 0 && dockerPartition != nil {
+			i.partitions[dockerDev] = *dockerPartition
+			i.labels[LabelDockerImages] = dockerDev
+		} else {
+			i.updateContainerImagesPath(LabelDockerImages, mounts, getDockerImagePaths(context))
+		}
 	}
 }
 

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -374,7 +374,8 @@ func TestAddDockerImagesLabel(t *testing.T) {
 		expectedPartition              *partition
 	}{
 		{
-			name: "single partition, no dedicated image fs",
+			name:   "single partition, no dedicated image fs",
+			driver: "overlay2",
 			mounts: []*mount.Info{
 				{
 					Source:     "/dev/root",
@@ -427,7 +428,8 @@ func TestAddDockerImagesLabel(t *testing.T) {
 			expectedDockerDevice: "/dev/sdb1",
 		},
 		{
-			name: "multiple mounts - innermost check",
+			name:   "multiple mounts - innermost check",
+			driver: "overlay2",
 			mounts: []*mount.Info{
 				{
 					Source:     "/dev/sda1",
@@ -448,7 +450,8 @@ func TestAddDockerImagesLabel(t *testing.T) {
 			expectedDockerDevice: "/dev/sdb2",
 		},
 		{
-			name: "root fs inside container, docker-images bindmount",
+			name:   "root fs inside container, docker-images bindmount",
+			driver: "overlay2",
 			mounts: []*mount.Info{
 				{
 					Source:     "overlay",
@@ -464,7 +467,8 @@ func TestAddDockerImagesLabel(t *testing.T) {
 			expectedDockerDevice: "/dev/sda1",
 		},
 		{
-			name: "[overlay2] root fs inside container - /var/lib/docker bindmount",
+			name:   "[overlay2] root fs inside container - /var/lib/docker bindmount",
+			driver: "overlay2",
 			mounts: []*mount.Info{
 				{
 					Source:     "overlay",


### PR DESCRIPTION
when cadvisor Initialize FS Context, docker restart or something wrong happen, context.Dokcer.Driver set to "", now default use /var/lib/docker device usage as image fs usage. if we use device mapper as storage driver,  we may get wrong image fs usage inforamation， so may be lead kubelet image gc manager to get a wrong information。
