### PR TITLE
Add missing file system metrics in containerd handler

### DIFF
--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -37,15 +37,21 @@ type FsUsage struct {
 	InodeUsage      uint64
 }
 
+type FsUsageProvider interface {
+	// Usage returns the fs usage
+	Usage() (*FsUsage, error)
+	// Targets returns where the fs usage metric is collected,it maybe a directory ,a file or some
+	// information about the snapshotter(for containerd)
+	Targets() []string
+}
+
 type realFsHandler struct {
 	sync.RWMutex
-	lastUpdate time.Time
-	usage      FsUsage
-	period     time.Duration
-	minPeriod  time.Duration
-	rootfs     string
-	extraDir   string
-	fsInfo     fs.FsInfo
+	lastUpdate    time.Time
+	usage         FsUsage
+	period        time.Duration
+	minPeriod     time.Duration
+	usageProvider FsUsageProvider
 	// Tells the container to stop.
 	stopChan chan struct{}
 }
@@ -58,56 +64,33 @@ const DefaultPeriod = time.Minute
 
 var _ FsHandler = &realFsHandler{}
 
-func NewFsHandler(period time.Duration, rootfs, extraDir string, fsInfo fs.FsInfo) FsHandler {
+func NewFsHandler(period time.Duration, provider FsUsageProvider) FsHandler {
 	return &realFsHandler{
-		lastUpdate: time.Time{},
-		usage:      FsUsage{},
-		period:     period,
-		minPeriod:  period,
-		rootfs:     rootfs,
-		extraDir:   extraDir,
-		fsInfo:     fsInfo,
-		stopChan:   make(chan struct{}, 1),
+		lastUpdate:    time.Time{},
+		usage:         FsUsage{},
+		period:        period,
+		minPeriod:     period,
+		usageProvider: provider,
+		stopChan:      make(chan struct{}, 1),
 	}
 }
 
 func (fh *realFsHandler) update() error {
-	var (
-		rootUsage, extraUsage fs.UsageInfo
-		rootErr, extraErr     error
-	)
-	// TODO(vishh): Add support for external mounts.
-	if fh.rootfs != "" {
-		rootUsage, rootErr = fh.fsInfo.GetDirUsage(fh.rootfs)
+
+	usage, err := fh.usageProvider.Usage()
+
+	if err != nil {
+		return err
 	}
 
-	if fh.extraDir != "" {
-		extraUsage, extraErr = fh.fsInfo.GetDirUsage(fh.extraDir)
-	}
-
-	// Wait to handle errors until after all operartions are run.
-	// An error in one will not cause an early return, skipping others
 	fh.Lock()
 	defer fh.Unlock()
 	fh.lastUpdate = time.Now()
-	if fh.rootfs != "" && rootErr == nil {
-		fh.usage.InodeUsage = rootUsage.Inodes
-		fh.usage.BaseUsageBytes = rootUsage.Bytes
-		fh.usage.TotalUsageBytes = rootUsage.Bytes
-	}
-	if fh.extraDir != "" && extraErr == nil {
-		if fh.rootfs != "" {
-			fh.usage.TotalUsageBytes += extraUsage.Bytes
-		} else {
-			// rootfs is empty, totalUsageBytes use extra usage bytes
-			fh.usage.TotalUsageBytes = extraUsage.Bytes
-		}
-	}
 
-	// Combine errors into a single error to return
-	if rootErr != nil || extraErr != nil {
-		return fmt.Errorf("rootDiskErr: %v, extraDiskErr: %v", rootErr, extraErr)
-	}
+	fh.usage.InodeUsage = usage.InodeUsage
+	fh.usage.BaseUsageBytes = usage.BaseUsageBytes
+	fh.usage.TotalUsageBytes = usage.TotalUsageBytes
+
 	return nil
 }
 
@@ -130,7 +113,8 @@ func (fh *realFsHandler) trackUsage() {
 			// if the long duration is persistent either because of slow
 			// disk or lots of containers.
 			longOp = longOp + time.Second
-			klog.V(2).Infof("fs: disk usage and inodes count on following dirs took %v: %v; will not log again for this container unless duration exceeds %v", duration, []string{fh.rootfs, fh.extraDir}, longOp)
+			klog.V(2).Infof(`fs: disk usage and inodes count on targets took %v: %v; `+
+				`will not log again for this container unless duration exceeds %v`, duration, fh.usageProvider.Targets(), longOp)
 		}
 		select {
 		case <-fh.stopChan:
@@ -152,4 +136,56 @@ func (fh *realFsHandler) Usage() FsUsage {
 	fh.RLock()
 	defer fh.RUnlock()
 	return fh.usage
+}
+
+type fsUsageProvider struct {
+	fsInfo   fs.FsInfo
+	rootFs   string
+	extraDir string
+}
+
+func NewGeneralFsUsageProvider(fsInfo fs.FsInfo, rootFs, extraDir string) FsUsageProvider {
+	return &fsUsageProvider{
+		fsInfo:   fsInfo,
+		rootFs:   rootFs,
+		extraDir: extraDir,
+	}
+}
+
+func (f *fsUsageProvider) Targets() []string {
+	return []string{f.rootFs, f.extraDir}
+}
+
+func (f *fsUsageProvider) Usage() (*FsUsage, error) {
+	var (
+		rootUsage, extraUsage fs.UsageInfo
+		rootErr, extraErr     error
+	)
+
+	if f.rootFs != "" {
+		rootUsage, rootErr = f.fsInfo.GetDirUsage(f.rootFs)
+	}
+
+	if f.extraDir != "" {
+		extraUsage, extraErr = f.fsInfo.GetDirUsage(f.extraDir)
+	}
+
+	usage := &FsUsage{}
+
+	if f.rootFs != "" && rootErr == nil {
+		usage.InodeUsage = rootUsage.Inodes
+		usage.BaseUsageBytes = rootUsage.Bytes
+		usage.TotalUsageBytes = rootUsage.Bytes
+	}
+
+	if f.extraDir != "" && extraErr == nil {
+		usage.TotalUsageBytes += extraUsage.Bytes
+	}
+
+	// Combine errors into a single error to return
+	if rootErr != nil || extraErr != nil {
+		return nil, fmt.Errorf("rootDiskErr: %v, extraDiskErr: %v", rootErr, extraErr)
+	}
+
+	return usage, nil
 }

--- a/container/common/fsHandler.go
+++ b/container/common/fsHandler.go
@@ -40,7 +40,7 @@ type FsUsage struct {
 type FsUsageProvider interface {
 	// Usage returns the fs usage
 	Usage() (*FsUsage, error)
-	// Targets returns where the fs usage metric is collected,it maybe a directory ,a file or some
+	// Targets returns where the fs usage metric is collected,it maybe a directory, a file or some
 	// information about the snapshotter(for containerd)
 	Targets() []string
 }
@@ -139,8 +139,9 @@ func (fh *realFsHandler) Usage() FsUsage {
 }
 
 type fsUsageProvider struct {
-	fsInfo   fs.FsInfo
-	rootFs   string
+	fsInfo fs.FsInfo
+	rootFs string
+	// The directory consumed by the container but outside rootFs, e.g. directory of saving logs
 	extraDir string
 }
 
@@ -184,7 +185,7 @@ func (f *fsUsageProvider) Usage() (*FsUsage, error) {
 
 	// Combine errors into a single error to return
 	if rootErr != nil || extraErr != nil {
-		return nil, fmt.Errorf("rootDiskErr: %v, extraDiskErr: %v", rootErr, extraErr)
+		return nil, fmt.Errorf("failed to obtain filesystem usage; rootDiskErr: %v, extraDiskErr: %v", rootErr, extraErr)
 	}
 
 	return usage, nil

--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -45,6 +45,7 @@ type ContainerdClient interface {
 	TaskPid(ctx context.Context, id string) (uint32, error)
 	Version(ctx context.Context) (string, error)
 	ContainerStatus(ctx context.Context, id string) (*criapi.ContainerStatus, error)
+	ContainerStats(ctx context.Context, id string) (*criapi.ContainerStats, error)
 }
 
 var once sync.Once
@@ -138,6 +139,16 @@ func (c *client) ContainerStatus(ctx context.Context, id string) (*criapi.Contai
 		return nil, err
 	}
 	return response.Status, nil
+}
+
+func (c *client) ContainerStats(ctx context.Context, id string) (*criapi.ContainerStats, error) {
+	response, err := c.criService.ContainerStats(ctx, &criapi.ContainerStatsRequest{
+		ContainerId: id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response.Stats, nil
 }
 
 func containerFromProto(containerpb containersapi.Container) *containers.Container {

--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -25,6 +25,7 @@ import (
 type containerdClientMock struct {
 	cntrs     map[string]*containers.Container
 	status    *criapi.ContainerStatus
+	stats     *criapi.ContainerStats
 	returnErr error
 }
 
@@ -51,10 +52,15 @@ func (c *containerdClientMock) ContainerStatus(ctx context.Context, id string) (
 	return c.status, nil
 }
 
-func mockcontainerdClient(cntrs map[string]*containers.Container, status *criapi.ContainerStatus, returnErr error) ContainerdClient {
+func (c *containerdClientMock) ContainerStats(ctx context.Context, id string) (*criapi.ContainerStats, error) {
+	return c.stats, nil
+}
+
+func mockcontainerdClient(cntrs map[string]*containers.Container, status *criapi.ContainerStatus, stats *criapi.ContainerStats, returnErr error) ContainerdClient {
 	return &containerdClientMock{
 		cntrs:     cntrs,
 		status:    status,
+		stats:     stats,
 		returnErr: returnErr,
 	}
 }

--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	types "github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
 	criapi "github.com/google/cadvisor/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -54,6 +55,10 @@ func (c *containerdClientMock) ContainerStatus(ctx context.Context, id string) (
 
 func (c *containerdClientMock) ContainerStats(ctx context.Context, id string) (*criapi.ContainerStats, error) {
 	return c.stats, nil
+}
+
+func (c *containerdClientMock) SnapshotMounts(ctx context.Context, snapshotter, key string) ([]*types.Mount, error) {
+	return nil, nil
 }
 
 func mockcontainerdClient(cntrs map[string]*containers.Container, status *criapi.ContainerStatus, stats *criapi.ContainerStats, returnErr error) ContainerdClient {

--- a/container/containerd/factory_test.go
+++ b/container/containerd/factory_test.go
@@ -58,7 +58,7 @@ func TestCanHandleAndAccept(t *testing.T) {
 	testContainers["40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"] = testContainer
 
 	f := &containerdFactory{
-		client:             mockcontainerdClient(testContainers, nil, nil),
+		client:             mockcontainerdClient(testContainers, nil, nil, nil),
 		cgroupSubsystems:   containerlibcontainer.CgroupSubsystems{},
 		fsInfo:             nil,
 		machineInfoFactory: nil,

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -34,7 +34,7 @@ import (
 
 type fsUsageProvider struct {
 	ctx         context.Context
-	containerId string
+	containerID string
 	client      ContainerdClient
 }
 
@@ -168,7 +168,7 @@ func newContainerdContainerHandler(
 		handler.fsHandler = common.NewFsHandler(common.DefaultPeriod, &fsUsageProvider{
 			ctx:         ctx,
 			client:      client,
-			containerId: id,
+			containerID: id,
 		})
 	}
 
@@ -308,7 +308,7 @@ func (h *containerdContainerHandler) GetContainerIPAddress() string {
 }
 
 func (f *fsUsageProvider) Usage() (*common.FsUsage, error) {
-	stats, err := f.client.ContainerStats(f.ctx, f.containerId)
+	stats, err := f.client.ContainerStats(f.ctx, f.containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -320,5 +320,5 @@ func (f *fsUsageProvider) Usage() (*common.FsUsage, error) {
 }
 
 func (f *fsUsageProvider) Targets() []string {
-	return []string{f.containerId}
+	return []string{f.containerID}
 }

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -164,7 +164,7 @@ func newContainerdContainerHandler(
 	// Add the name and bare ID as aliases of the container.
 	handler.image = cntr.Image
 
-	if includedMetrics.Has(container.DiskUsageMetrics) {
+	if includedMetrics.Has(container.DiskUsageMetrics) && cntr.Labels["io.cri-containerd.kind"] != "sandbox" {
 		handler.fsHandler = common.NewFsHandler(common.DefaultPeriod, &fsUsageProvider{
 			ctx:         ctx,
 			client:      client,
@@ -228,7 +228,7 @@ func (h *containerdContainerHandler) getFsStats(stats *info.ContainerStats) erro
 		common.AssignDeviceNamesToDiskStats((*common.MachineInfoNamer)(mi), &stats.DiskIo)
 	}
 
-	if !h.includedMetrics.Has(container.DiskUsageMetrics) {
+	if !h.includedMetrics.Has(container.DiskUsageMetrics) || h.labels["io.cri-containerd.kind"] == "sandbox" {
 		return nil
 	}
 

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -88,7 +88,7 @@ func TestHandler(t *testing.T) {
 
 	for _, ts := range []testCase{
 		{
-			mockcontainerdClient(nil, nil, nil),
+			mockcontainerdClient(nil, nil, nil, nil),
 			"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
 			nil,
 			nil,
@@ -102,7 +102,7 @@ func TestHandler(t *testing.T) {
 			nil,
 		},
 		{
-			mockcontainerdClient(testContainers, nil, nil),
+			mockcontainerdClient(testContainers, nil, nil, nil),
 			"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
 			&mockedMachineInfo{},
 			nil,
@@ -121,7 +121,7 @@ func TestHandler(t *testing.T) {
 			map[string]string{},
 		},
 		{
-			mockcontainerdClient(testContainers, nil, nil),
+			mockcontainerdClient(testContainers, nil, nil, nil),
 			"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9",
 			&mockedMachineInfo{},
 			nil,
@@ -140,7 +140,7 @@ func TestHandler(t *testing.T) {
 			map[string]string{"TEST_REGION": "FRA", "TEST_ZONE": "A"},
 		},
 		{
-			mockcontainerdClient(testContainers, status, nil),
+			mockcontainerdClient(testContainers, status, nil, nil),
 			"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/c6a1aa99f14d3e57417e145b897e34961145f6b6f14216a176a34bfabbf79086",
 			&mockedMachineInfo{},
 			nil,

--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -183,7 +183,8 @@ func newCrioContainerHandler(
 
 	// we optionally collect disk usage metrics
 	if includedMetrics.Has(container.DiskUsageMetrics) {
-		handler.fsHandler = common.NewFsHandler(common.DefaultPeriod, rootfsStorageDir, storageLogDir, fsInfo)
+		handler.fsHandler = common.NewFsHandler(common.DefaultPeriod, common.NewGeneralFsUsageProvider(
+			fsInfo, rootfsStorageDir, storageLogDir))
 	}
 	// TODO for env vars we wanted to show from container.Config.Env from whitelist
 	//for _, exposedEnv := range metadataEnvAllowList {

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -240,7 +240,8 @@ func newDockerContainerHandler(
 
 	if includedMetrics.Has(container.DiskUsageMetrics) {
 		handler.fsHandler = &dockerFsHandler{
-			fsHandler:       common.NewFsHandler(common.DefaultPeriod, rootfsStorageDir, otherStorageDir, fsInfo),
+			fsHandler: common.NewFsHandler(common.DefaultPeriod, common.NewGeneralFsUsageProvider(
+				fsInfo, rootfsStorageDir, otherStorageDir)),
 			thinPoolWatcher: thinPoolWatcher,
 			zfsWatcher:      zfsWatcher,
 			deviceID:        ctnr.GraphDriver.Data["DeviceId"],


### PR DESCRIPTION
Signed-off-by: Qiutong Song <songqt01@gmail.com>

## Overview

File system metrics are not supported in cadvisor-containerd. This PR attempts to fix it. 

The majority of code is copied from https://github.com/google/cadvisor/pull/2872

Fixed:
```
fs_inodes_free
fs_inodes_total
fs_usage_bytes
fs_limit_bytes
```

## Testing

```
$ make test
```

Query prometheus endpoint
```
$ curl localhost:8080/metrics 2>/dev/null | grep fs_usage_bytes | grep nginx
container_fs_usage_bytes{container_label_io_cri_containerd_kind="container",container_label_io_kubernetes_container_name="nginx-pod",container_label_io_kubernetes_pod_name="nginx-pod",container_label_io_kubernetes_pod_namespace="default",container_label_io_kubernetes_pod_uid="9de12299-f7c6-4404-8483-b40636023b5e",container_label_k8s_app="",container_label_pod_template_hash="",container_label_run="",device="",id="/kubepods/besteffort/pod9de12299-f7c6-4404-8483-b40636023b5e/7c6e000abee310fc05bab29ef9ef58cf27a51e8652197dffcfa8c84656270a38",image="docker.io/library/nginx:latest",name="k8s_nginx-pod_nginx-pod_default_9de12299-f7c6-4404-8483-b40636023b5e_0"} 94208 1631309422620
```

Find the upperdir(writable layer)
```
$ mount | grep overlay | grep 7c6e000abee310fc05bab29ef9ef58cf27a51e8652197dffcfa8c84656270a38
overlay on /run/containerd/io.containerd.runtime.v2.task/k8s.io/7c6e000abee310fc05bab29ef9ef58cf27a51e8652197dffcfa8c84656270a38/rootfs type overlay (rw,relatime,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4802/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4801/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4800/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4799/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4797/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4451/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5001/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5001/work)

$ sudo du -hs /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5001/fs
92K     /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5001/fs
```

`94208` and 92k are close.

After counting the size of logs, the reported number of `fs_usage_bytes` is 98304. The log is roughly 4KB.

```
$ du -sh /var/log/pods/default_nginx-pod_9de12299-f7c6-4404-8483-b40636023b5e/nginx-pod/0.log 
4.0K    /var/log/pods/default_nginx-pod_9de12299-f7c6-4404-8483-b40636023b5e/nginx-pod/0.log
```

`fs_limit_bytes` is reported 
```
container_fs_limit_bytes{container_label_io_cri_containerd_kind="container",container_label_io_kubernetes_container_name="nginx-pod",container_label_io_kubernetes_pod_name="nginx-pod",container_label_io_kubernetes_pod_namespace="default",container_label_io_kubernetes_pod_uid="9de12299-f7c6-4404-8483-b40636023b5e",container_label_k8s_app="",container_label_pod_template_hash="",container_label_run="",device="/dev/sda5",id="/kubepods/besteffort/pod9de12299-f7c6-4404-8483-b40636023b5e/7c6e000abee310fc05bab29ef9ef58cf27a51e8652197dffcfa8c84656270a38",image="docker.io/library/nginx:latest",name="k8s_nginx-pod_nginx-pod_default_9de12299-f7c6-4404-8483-b40636023b5e_0"} 4.1610903552e+10 1631657309819
```

```
(dlv) p snapshotDir
"/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5001/fs"
(dlv) p deviceInfo
*github.com/google/cadvisor/fs.DeviceInfo {
        Device: "/dev/sda5",
        Major: 8,
        Minor: 5,}
```

## Open Questions

~~1. Should we count the log file as https://github.com/google/cadvisor/pull/2872#discussion_r704691997?  e.g. `/var/log/pods/default_nginx-pod_9de12299-f7c6-4404-8483-b40636023b5e/nginx-pod/0.log`~~
~~2. Can we manually construct the rootfs path so that we can get the device name - `/run/containerd/io.containerd.runtime.v2.task/k8s.io/7c6e000abee310fc05bab29ef9ef58cf27a51e8652197dffcfa8c84656270a38/rootfs`? With the device name, we can calculate `fs_limit_bytes`.~~

## Appendix

```
(dlv) p mounts
[]*github.com/containerd/containerd/api/types.Mount len: 1, cap: 1, [
        *{
                Type: "overlay",
                Source: "overlay",
                Target: "",
                Options: []string len: 4, cap: 4, [
                        "index=off",
                        "workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5001/work",
                        "upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/5001/fs",
                        "lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4802/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4801/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4800/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4799/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4797/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4451/fs",
                ],
                XXX_NoUnkeyedLiteral: struct {} {},
                XXX_unrecognized: []uint8 len: 0, cap: 0, nil,
                XXX_sizecache: 0,},
]
```