### PR TITLE
Disable polling of CPU & PIDs cgroups when they are not needed

### DIFF
--- a/build/integration.sh
+++ b/build/integration.sh
@@ -26,8 +26,8 @@ printf "" # Refresh sudo credentials if necessary.
 function start {
   set +e  # We want to handle errors if cAdvisor crashes.
   echo ">> starting cAdvisor locally"
-  # This cpuset, percpu, memory, disk, diskIO, network, perf_event metrics should be enabled.
-  GORACE="halt_on_error=1" ./cadvisor --enable_metrics="cpuset,percpu,memory,disk,diskIO,network,perf_event" --env_metadata_whitelist=TEST_VAR --v=6 --logtostderr $CADVISOR_ARGS &> "$log_file"
+  # cpu, cpuset, percpu, memory, disk, diskIO, network, perf_event metrics should be enabled.
+  GORACE="halt_on_error=1" ./cadvisor --enable_metrics="cpu,cpuset,percpu,memory,disk,diskIO,network,perf_event" --env_metadata_whitelist=TEST_VAR --v=6 --logtostderr $CADVISOR_ARGS &> "$log_file"
   if [ $? != 0 ]; then
     echo "!! cAdvisor exited unexpectedly with Exit $?"
     kill $TEST_PID # cAdvisor crashed: abort testing.

--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -53,6 +53,10 @@ func GetCgroupSubsystems(includedMetrics container.MetricSet) (CgroupSubsystems,
 		disableCgroups["io"] = struct{}{}
 	}
 
+	if !includedMetrics.Has(container.CpuUsageMetrics) {
+		disableCgroups["cpu"] = struct{}{}
+	}
+
 	if !includedMetrics.Has(container.CPUSetMetrics) {
 		disableCgroups["cpuset"] = struct{}{}
 	}
@@ -67,6 +71,10 @@ func GetCgroupSubsystems(includedMetrics container.MetricSet) (CgroupSubsystems,
 
 	if !includedMetrics.Has(container.PerfMetrics) {
 		disableCgroups["perf_event"] = struct{}{}
+	}
+
+	if !includedMetrics.Has(container.ProcessMetrics) {
+		disableCgroups["pids"] = struct{}{}
 	}
 
 	return getCgroupSubsystemsHelper(allCgroups, disableCgroups)


### PR DESCRIPTION
https://github.com/google/cadvisor/pull/2910 made CPU usage metrics configurable from CLI, and process metrics were that already earlier.  Prometheus code skips reporting them when they are disabled, and polling should be skipped too.

Fixes: https://github.com/google/cadvisor/issues/2932
