### PR TITLE
Prepend rootfs to the paths in containerd handler

### DIFF
--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -18,6 +18,7 @@ package containerd
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -192,7 +193,7 @@ func newContainerdContainerHandler(
 				}
 			}
 		}
-		deviceInfo, err := fsInfo.GetDirFsDevice(snapshotDir)
+		deviceInfo, err := fsInfo.GetDirFsDevice(path.Join(rootfs, snapshotDir))
 		if err != nil {
 			return nil, err
 		}
@@ -227,7 +228,7 @@ func newContainerdContainerHandler(
 			client:      client,
 			containerID: id,
 			// Path of logs, e.g. /var/log/pods/XXX
-			logPath: status.LogPath,
+			logPath: path.Join(rootfs, status.LogPath),
 			fsInfo:  fsInfo,
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Qiutong Song <songqt01@gmail.com>

## Overview

Previous commit has a bug of checking wrong path. The problem was the path should be prepended with rootfs if cadvisor runs within container.
```
Failed to create existing container: /kubepods/besteffort/pod3fd5ec35-da3b-4174-8cb6-d710b7c483b3/ffd567befc2a43b587af98008130f195fb6f0693e8807e93df085252e3576369: stat failed on /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/177/fs with error: no such file or directory
```

## Testing

```
make build
make test
```

```
make release

VERSION=v0.36.0 # use the latest release version from https://github.com/google/cadvisor/releases
sudo docker run \
  --volume=/:/rootfs:ro \
  --volume=/var/run:/var/run:ro \
  --volume=/sys:/sys:ro \
  --volume=/var/lib/docker/:/var/lib/docker:ro \
  --volume=/dev/disk/:/dev/disk:ro \
  --publish=8080:8080 \
  --detach=true \
  --name=cadvisor \
  --privileged \
  --device=/dev/kmsg \
  gcr.io/cadvisor/cadvisor:$VERSION
```

- Verified FS metrics are properly reported
- Verified no error logs