### PR TITLE
Refactor disk usage code in containerd handler

### DIFF
--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -27,6 +27,7 @@ type containerdClientMock struct {
 	cntrs     map[string]*containers.Container
 	status    *criapi.ContainerStatus
 	stats     *criapi.ContainerStats
+	mounts    []*types.Mount
 	returnErr error
 }
 
@@ -58,14 +59,15 @@ func (c *containerdClientMock) ContainerStats(ctx context.Context, id string) (*
 }
 
 func (c *containerdClientMock) SnapshotMounts(ctx context.Context, snapshotter, key string) ([]*types.Mount, error) {
-	return nil, nil
+	return c.mounts, nil
 }
 
-func mockcontainerdClient(cntrs map[string]*containers.Container, status *criapi.ContainerStatus, stats *criapi.ContainerStats, returnErr error) ContainerdClient {
+func mockcontainerdClient(cntrs map[string]*containers.Container, status *criapi.ContainerStatus, stats *criapi.ContainerStats, mounts []*types.Mount, returnErr error) ContainerdClient {
 	return &containerdClientMock{
 		cntrs:     cntrs,
 		status:    status,
 		stats:     stats,
+		mounts:    mounts,
 		returnErr: returnErr,
 	}
 }

--- a/container/containerd/factory_test.go
+++ b/container/containerd/factory_test.go
@@ -58,7 +58,7 @@ func TestCanHandleAndAccept(t *testing.T) {
 	testContainers["40af7cdcbe507acad47a5a62025743ad3ddc6ab93b77b21363aa1c1d641047c9"] = testContainer
 
 	f := &containerdFactory{
-		client:             mockcontainerdClient(testContainers, nil, nil, nil),
+		client:             mockcontainerdClient(testContainers, nil, nil, nil, nil),
 		cgroupSubsystems:   containerlibcontainer.CgroupSubsystems{},
 		fsInfo:             nil,
 		machineInfoFactory: nil,

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -176,7 +176,7 @@ func newContainerdContainerHandler(
 	handler.image = cntr.Image
 
 	if includedMetrics.Has(container.DiskUsageMetrics) && cntr.Labels["io.cri-containerd.kind"] != "sandbox" {
-		err = handler.fillDiskUsageInfo(client, machineInfoFactory, fsInfo, ctx, cntr.Snapshotter, cntr.SnapshotKey, rootfs, status.LogPath)
+		err = handler.fillDiskUsageInfo(ctx, client, machineInfoFactory, fsInfo, cntr.Snapshotter, cntr.SnapshotKey, rootfs, status.LogPath)
 		if err != nil {
 			klog.Errorf("error occured while filling disk usage info for container %s: %s", name, err)
 		}
@@ -202,10 +202,10 @@ func newContainerdContainerHandler(
 }
 
 func (h *containerdContainerHandler) fillDiskUsageInfo(
+	ctx context.Context,
 	client ContainerdClient,
 	machineInfoFactory info.MachineInfoFactory,
 	fsInfo fs.FsInfo,
-	ctx context.Context,
 	snapshotter, snapshotKey, rootfs, logPath string) error {
 	mounts, err := client.SnapshotMounts(ctx, snapshotter, snapshotKey)
 	if err != nil {


### PR DESCRIPTION
1. Refactor disk usage collection code so that any error will not fail the handler creation `newContainerdContainerHandler`.
2. Add more unit tests