### PR TITLE
crio: filter out systemd related components

### DIFF
--- a/container/crio/factory.go
+++ b/container/crio/factory.go
@@ -32,6 +32,9 @@ import (
 // The namespace under which crio aliases are unique.
 const CrioNamespace = "crio"
 
+// The namespace systemd runs components under.
+const SystemdNamespace = "system-systemd"
+
 // Regexp that identifies CRI-O cgroups
 var crioCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
 
@@ -113,6 +116,9 @@ func (f *crioFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	}
 	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
 		return false, false, nil
+	}
+	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
+		return true, false, nil
 	}
 	// if the container is not associated with CRI-O, we can't handle it or accept it.
 	if !isContainerName(name) {


### PR DESCRIPTION
In Openshift we are [seeing](https://bugzilla.redhat.com/show_bug.cgi?id=1978528#c4) systemd components get added to housekeeping within the Kubelet using crio. This patch filters the `system-systemd` namespace for containers.

cc @harche 