### PR TITLE
container/libcontainer: nits

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -383,7 +383,7 @@ func getReferencedKBytes(pids []int) (uint64, error) {
 		if err != nil {
 			klog.V(5).Infof("Cannot read %s file, err: %s", smapsFilePath, err)
 			if os.IsNotExist(err) {
-				continue //smaps file does not exists for all PIDs
+				continue // smaps file does not exists for all PIDs
 			}
 			return 0, err
 		}
@@ -426,7 +426,7 @@ func clearReferencedBytes(pids []int, cycles uint64, resetInterval uint64) error
 	if cycles%resetInterval == 0 {
 		for _, pid := range pids {
 			clearRefsFilePath := fmt.Sprintf(clearRefsFilePathPattern, pid)
-			clerRefsFile, err := os.OpenFile(clearRefsFilePath, os.O_WRONLY, 0644)
+			clerRefsFile, err := os.OpenFile(clearRefsFilePath, os.O_WRONLY, 0o644)
 			if err != nil {
 				// clear_refs file may not exist for all PIDs
 				continue
@@ -455,9 +455,7 @@ func networkStatsFromProc(rootFs string, pid int) ([]info.InterfaceStats, error)
 	return ifaceStats, nil
 }
 
-var (
-	ignoredDevicePrefixes = []string{"lo", "veth", "docker"}
-)
+var ignoredDevicePrefixes = []string{"lo", "veth", "docker"}
 
 func isIgnoredDevice(ifName string) bool {
 	for _, prefix := range ignoredDevicePrefixes {
@@ -615,11 +613,9 @@ func scanAdvancedTCPStats(advancedStats *info.TcpAdvancedStat, advancedTCPStatsF
 	}
 
 	return scanner.Err()
-
 }
 
 func scanTCPStats(tcpStatsFile string) (info.TcpStat, error) {
-
 	var stats info.TcpStat
 
 	data, err := ioutil.ReadFile(tcpStatsFile)
@@ -628,17 +624,17 @@ func scanTCPStats(tcpStatsFile string) (info.TcpStat, error) {
 	}
 
 	tcpStateMap := map[string]uint64{
-		"01": 0, //ESTABLISHED
-		"02": 0, //SYN_SENT
-		"03": 0, //SYN_RECV
-		"04": 0, //FIN_WAIT1
-		"05": 0, //FIN_WAIT2
-		"06": 0, //TIME_WAIT
-		"07": 0, //CLOSE
-		"08": 0, //CLOSE_WAIT
-		"09": 0, //LAST_ACK
-		"0A": 0, //LISTEN
-		"0B": 0, //CLOSING
+		"01": 0, // ESTABLISHED
+		"02": 0, // SYN_SENT
+		"03": 0, // SYN_RECV
+		"04": 0, // FIN_WAIT1
+		"05": 0, // FIN_WAIT2
+		"06": 0, // TIME_WAIT
+		"07": 0, // CLOSE
+		"08": 0, // CLOSE_WAIT
+		"09": 0, // LAST_ACK
+		"0A": 0, // LISTEN
+		"0B": 0, // CLOSING
 	}
 
 	reader := strings.NewReader(string(data))
@@ -896,7 +892,6 @@ func setThreadsStats(s *cgroups.Stats, ret *info.ContainerStats) {
 		ret.Processes.ThreadsCurrent = s.PidsStats.Current
 		ret.Processes.ThreadsMax = s.PidsStats.Limit
 	}
-
 }
 
 func newContainerStats(libcontainerStats *libcontainer.Stats, includedMetrics container.MetricSet) *info.ContainerStats {

--- a/container/libcontainer/handler_test.go
+++ b/container/libcontainer/handler_test.go
@@ -30,7 +30,7 @@ func TestScanInterfaceStats(t *testing.T) {
 		t.Error(err)
 	}
 
-	var netdevstats = []info.InterfaceStats{
+	netdevstats := []info.InterfaceStats{
 		{
 			Name:      "wlp4s0",
 			RxBytes:   1,
@@ -78,7 +78,7 @@ func TestScanUDPStats(t *testing.T) {
 		t.Error(err)
 	}
 
-	var udpstats = info.UdpStat{
+	udpstats := info.UdpStat{
 		Listen:   2,
 		Dropped:  4,
 		RxQueued: 10,
@@ -168,11 +168,10 @@ func TestSetProcessesStats(t *testing.T) {
 	if expected.Processes.ThreadsMax != ret.Processes.ThreadsMax {
 		t.Fatalf("expected max threads: %d == %d", ret.Processes.ThreadsMax, expected.Processes.ThreadsMax)
 	}
-
 }
 
 func TestParseLimitsFile(t *testing.T) {
-	var testData = []struct {
+	testData := []struct {
 		limitLine string
 		expected  []info.UlimitSpec
 	}{
@@ -211,7 +210,7 @@ func TestParseLimitsFile(t *testing.T) {
 }
 
 func TestReferencedBytesStat(t *testing.T) {
-	//overwrite package variables
+	// overwrite package variables
 	smapsFilePathPattern = "testdata/smaps%d"
 	clearRefsFilePathPattern = "testdata/clear_refs%d"
 
@@ -223,16 +222,17 @@ func TestReferencedBytesStat(t *testing.T) {
 	clearRefsFiles := []string{
 		"testdata/clear_refs4",
 		"testdata/clear_refs6",
-		"testdata/clear_refs8"}
+		"testdata/clear_refs8",
+	}
 
-	//check if clear_refs files have proper values
+	// check if clear_refs files have proper values
 	assert.Equal(t, "0\n", getFileContent(t, clearRefsFiles[0]))
 	assert.Equal(t, "0\n", getFileContent(t, clearRefsFiles[1]))
 	assert.Equal(t, "0\n", getFileContent(t, clearRefsFiles[2]))
 }
 
 func TestReferencedBytesStatWhenNeverCleared(t *testing.T) {
-	//overwrite package variables
+	// overwrite package variables
 	smapsFilePathPattern = "testdata/smaps%d"
 	clearRefsFilePathPattern = "testdata/clear_refs%d"
 
@@ -244,16 +244,17 @@ func TestReferencedBytesStatWhenNeverCleared(t *testing.T) {
 	clearRefsFiles := []string{
 		"testdata/clear_refs4",
 		"testdata/clear_refs6",
-		"testdata/clear_refs8"}
+		"testdata/clear_refs8",
+	}
 
-	//check if clear_refs files have proper values
+	// check if clear_refs files have proper values
 	assert.Equal(t, "0\n", getFileContent(t, clearRefsFiles[0]))
 	assert.Equal(t, "0\n", getFileContent(t, clearRefsFiles[1]))
 	assert.Equal(t, "0\n", getFileContent(t, clearRefsFiles[2]))
 }
 
 func TestReferencedBytesStatWhenResetIsNeeded(t *testing.T) {
-	//overwrite package variables
+	// overwrite package variables
 	smapsFilePathPattern = "testdata/smaps%d"
 	clearRefsFilePathPattern = "testdata/clear_refs%d"
 
@@ -265,9 +266,10 @@ func TestReferencedBytesStatWhenResetIsNeeded(t *testing.T) {
 	clearRefsFiles := []string{
 		"testdata/clear_refs4",
 		"testdata/clear_refs6",
-		"testdata/clear_refs8"}
+		"testdata/clear_refs8",
+	}
 
-	//check if clear_refs files have proper values
+	// check if clear_refs files have proper values
 	assert.Equal(t, "1\n", getFileContent(t, clearRefsFiles[0]))
 	assert.Equal(t, "1\n", getFileContent(t, clearRefsFiles[1]))
 	assert.Equal(t, "1\n", getFileContent(t, clearRefsFiles[2]))
@@ -276,7 +278,7 @@ func TestReferencedBytesStatWhenResetIsNeeded(t *testing.T) {
 }
 
 func TestGetReferencedKBytesWhenSmapsMissing(t *testing.T) {
-	//overwrite package variable
+	// overwrite package variable
 	smapsFilePathPattern = "testdata/smaps%d"
 
 	pids := []int{10}
@@ -286,7 +288,7 @@ func TestGetReferencedKBytesWhenSmapsMissing(t *testing.T) {
 }
 
 func TestClearReferencedBytesWhenClearRefsMissing(t *testing.T) {
-	//overwrite package variable
+	// overwrite package variable
 	clearRefsFilePathPattern = "testdata/clear_refs%d"
 
 	pids := []int{10}

--- a/container/libcontainer/helpers.go
+++ b/container/libcontainer/helpers.go
@@ -204,5 +204,4 @@ func NewCgroupManager(name string, paths map[string]string) (cgroups.Manager, er
 		Name: name,
 	}
 	return fs.NewManager(&config, paths, false), nil
-
 }

--- a/container/libcontainer/helpers_test.go
+++ b/container/libcontainer/helpers_test.go
@@ -141,7 +141,7 @@ func getFileContent(t *testing.T, filePath string) string {
 
 func clearTestData(t *testing.T, clearRefsPaths []string) {
 	for _, clearRefsPath := range clearRefsPaths {
-		err := ioutil.WriteFile(clearRefsPath, []byte("0\n"), 0644)
+		err := ioutil.WriteFile(clearRefsPath, []byte("0\n"), 0o644)
 		assert.Nil(t, err)
 	}
 }


### PR DESCRIPTION
Please see individual commits for details. In short:

1. Unexport Disk* ids: those are only used within the package and therefore should not be public.
2. Formatting: the result of running `gofumpt` on the code in container/libcontainer.