### PR TITLE
Remove docker-isms from manager package

### DIFF
--- a/cmd/internal/pages/docker.go
+++ b/cmd/internal/pages/docker.go
@@ -78,7 +78,7 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 		}
 
 		// Get Docker status
-		status, err := m.DockerInfo()
+		status, err := docker.Status()
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to get docker info: %v", err), http.StatusInternalServerError)
 			return
@@ -86,7 +86,7 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 
 		dockerStatus, driverStatus := toStatusKV(status)
 		// Get Docker Images
-		images, err := m.DockerImages()
+		images, err := docker.Images()
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to get docker images: %v", err), http.StatusInternalServerError)
 			return

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/cadvisor/cache/memory"
 	"github.com/google/cadvisor/collector"
 	"github.com/google/cadvisor/container"
-	"github.com/google/cadvisor/container/docker"
 	"github.com/google/cadvisor/container/raw"
 	"github.com/google/cadvisor/events"
 	"github.com/google/cadvisor/fs"
@@ -60,6 +59,9 @@ var logCadvisorUsage = flag.Bool("log_cadvisor_usage", false, "Whether to log th
 var eventStorageAgeLimit = flag.String("event_storage_age_limit", "default=24h", "Max length of time for which to store events (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or \"default\" and the value is a duration. Default is applied to all non-specified event types")
 var eventStorageEventLimit = flag.String("event_storage_event_limit", "default=100000", "Max number of events to store (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or \"default\" and the value is an integer. Default is applied to all non-specified event types")
 var applicationMetricsCountLimit = flag.Int("application_metrics_count_limit", 100, "Max number of application metrics to store (per container)")
+
+// The namespace under which Docker aliases are unique.
+const DockerNamespace = "docker"
 
 var HousekeepingConfigFlags = HouskeepingConfig{
 	flag.Duration("max_housekeeping_interval", 60*time.Second, "Largest interval to allow between container housekeepings"),
@@ -593,7 +595,7 @@ func (m *manager) getAllDockerContainers() map[string]*containerData {
 
 	// Get containers in the Docker namespace.
 	for name, cont := range m.containers {
-		if name.Namespace == docker.DockerNamespace {
+		if name.Namespace == DockerNamespace {
 			containers[cont.info.Name] = cont
 		}
 	}
@@ -625,14 +627,14 @@ func (m *manager) getDockerContainer(containerName string) (*containerData, erro
 
 	// Check for the container in the Docker container namespace.
 	cont, ok := m.containers[namespacedContainerName{
-		Namespace: docker.DockerNamespace,
+		Namespace: DockerNamespace,
 		Name:      containerName,
 	}]
 
 	// Look for container by short prefix name if no exact match found.
 	if !ok {
 		for contName, c := range m.containers {
-			if contName.Namespace == docker.DockerNamespace && strings.HasPrefix(contName.Name, containerName) {
+			if contName.Namespace == DockerNamespace && strings.HasPrefix(contName.Name, containerName) {
 				if cont == nil {
 					cont = c
 				} else {
@@ -1385,20 +1387,10 @@ func getVersionInfo() (*info.VersionInfo, error) {
 
 	kernelVersion := machine.KernelVersion()
 	osVersion := machine.ContainerOsVersion()
-	dockerVersion, err := docker.VersionString()
-	if err != nil {
-		return nil, err
-	}
-	dockerAPIVersion, err := docker.APIVersionString()
-	if err != nil {
-		return nil, err
-	}
 
 	return &info.VersionInfo{
 		KernelVersion:      kernelVersion,
 		ContainerOsVersion: osVersion,
-		DockerVersion:      dockerVersion,
-		DockerAPIVersion:   dockerAPIVersion,
 		CadvisorVersion:    version.Info["version"],
 		CadvisorRevision:   version.Info["revision"],
 	}, nil

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -134,12 +134,6 @@ type Manager interface {
 
 	CloseEventChannel(watchID int)
 
-	// Get status information about docker.
-	DockerInfo() (info.DockerStatus, error)
-
-	// Get details about interesting docker images.
-	DockerImages() ([]info.DockerImage, error)
-
 	// Returns debugging information. Map of lines per category.
 	DebugInfo() map[string][]string
 }
@@ -1333,14 +1327,6 @@ func parseEventsStoragePolicy() events.StoragePolicy {
 	}
 
 	return policy
-}
-
-func (m *manager) DockerImages() ([]info.DockerImage, error) {
-	return docker.Images()
-}
-
-func (m *manager) DockerInfo() (info.DockerStatus, error) {
-	return docker.Status()
 }
 
 func (m *manager) DebugInfo() map[string][]string {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/cadvisor/cache/memory"
 	"github.com/google/cadvisor/collector"
 	"github.com/google/cadvisor/container"
-	"github.com/google/cadvisor/container/docker"
 	containertest "github.com/google/cadvisor/container/testing"
 	info "github.com/google/cadvisor/info/v1"
 	itest "github.com/google/cadvisor/info/v1/test"
@@ -76,7 +75,7 @@ func createManagerAndAddContainers(
 		// Add Docker containers under their namespace.
 		if strings.HasPrefix(name, "/docker") {
 			mif.containers[namespacedContainerName{
-				Namespace: docker.DockerNamespace,
+				Namespace: DockerNamespace,
 				Name:      strings.TrimPrefix(name, "/docker/"),
 			}] = cont
 		}
@@ -139,7 +138,7 @@ func createManagerAndAddSubContainers(
 		// Add Docker containers under their namespace.
 		if strings.HasPrefix(name, "/docker") {
 			mif.containers[namespacedContainerName{
-				Namespace: docker.DockerNamespace,
+				Namespace: DockerNamespace,
 				Name:      strings.TrimPrefix(name, "/docker/"),
 			}] = cont
 		}


### PR DESCRIPTION
`manager` package should not depend on `container/docker` (or any other specific container runtime) in principle.

doing so will drag in unnecessary dependencies into kubelet. (example when dockershim is removed, this dependency will drag in docker/docker transitively into kubernetes vendor/ directories)