### PR TITLE
cmd: enable linter, fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ lint:
 	fi
 	@echo ">> running golangci-lint using configuration at .golangci.yml"
 	@golangci-lint run
+	@cd cmd && golangci-lint run
 
 clean:
 	@rm -f *.test cadvisor

--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var argIp = flag.String("listen_ip", "", "IP to listen on, defaults to all IPs")
+var argIP = flag.String("listen_ip", "", "IP to listen on, defaults to all IPs")
 var argPort = flag.Int("port", 8080, "port to listen")
 var maxProcs = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores).")
 
@@ -131,9 +131,9 @@ func main() {
 
 	sysFs := sysfs.NewRealSysFs()
 
-	collectorHttpClient := createCollectorHttpClient(*collectorCert, *collectorKey)
+	collectorHTTPClient := createCollectorHTTPClient(*collectorCert, *collectorKey)
 
-	resourceManager, err := manager.New(memoryStorage, sysFs, manager.HousekeepingConfigFlags, includedMetrics, &collectorHttpClient, strings.Split(*rawCgroupPrefixWhiteList, ","), strings.Split(*envMetadataWhiteList, ","), *perfEvents, *resctrlInterval)
+	resourceManager, err := manager.New(memoryStorage, sysFs, manager.HousekeepingConfigFlags, includedMetrics, &collectorHTTPClient, strings.Split(*rawCgroupPrefixWhiteList, ","), strings.Split(*envMetadataWhiteList, ","), *perfEvents, *resctrlInterval)
 	if err != nil {
 		klog.Fatalf("Failed to create a manager: %s", err)
 	}
@@ -175,7 +175,7 @@ func main() {
 	rootMux := http.NewServeMux()
 	rootMux.Handle(*urlBasePrefix+"/", http.StripPrefix(*urlBasePrefix, mux))
 
-	addr := fmt.Sprintf("%s:%d", *argIp, *argPort)
+	addr := fmt.Sprintf("%s:%d", *argIP, *argPort)
 	klog.Fatal(http.ListenAndServe(addr, rootMux))
 }
 
@@ -212,7 +212,7 @@ func installSignalHandler(containerManager manager.Manager) {
 	}()
 }
 
-func createCollectorHttpClient(collectorCert, collectorKey string) http.Client {
+func createCollectorHTTPClient(collectorCert, collectorKey string) http.Client {
 	//Enable accessing insecure endpoints. We should be able to access metrics from any endpoint
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,

--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -102,7 +102,7 @@ func init() {
 	flag.Var(&enableMetrics, "enable_metrics", fmt.Sprintf("comma-separated list of `metrics` to be enabled. If set, overrides 'disable_metrics'. Options are %s.", optstr))
 
 	// Default logging verbosity to V(2)
-	flag.Set("v", "2")
+	_ = flag.Set("v", "2")
 }
 
 func main() {

--- a/cmd/internal/api/handler.go
+++ b/cmd/internal/api/handler.go
@@ -135,10 +135,6 @@ func writeResult(res interface{}, w http.ResponseWriter) error {
 }
 
 func streamResults(eventChannel *events.EventChannel, w http.ResponseWriter, r *http.Request, m manager.Manager) error {
-	cn, ok := w.(http.CloseNotifier)
-	if !ok {
-		return errors.New("could not access http.CloseNotifier")
-	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		return errors.New("could not access http.Flusher")
@@ -151,7 +147,7 @@ func streamResults(eventChannel *events.EventChannel, w http.ResponseWriter, r *
 	enc := json.NewEncoder(w)
 	for {
 		select {
-		case <-cn.CloseNotify():
+		case <-r.Context().Done():
 			m.CloseEventChannel(eventChannel.GetWatchId())
 			return nil
 		case ev := <-eventChannel.GetChannel():

--- a/cmd/internal/api/handler.go
+++ b/cmd/internal/api/handler.go
@@ -129,8 +129,8 @@ func writeResult(res interface{}, w http.ResponseWriter) error {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(out)
-	return nil
+	_, err = w.Write(out)
+	return err
 
 }
 

--- a/cmd/internal/api/handler.go
+++ b/cmd/internal/api/handler.go
@@ -41,14 +41,14 @@ const (
 )
 
 func RegisterHandlers(mux httpmux.Mux, m manager.Manager) error {
-	apiVersions := getApiVersions()
-	supportedApiVersions := make(map[string]ApiVersion, len(apiVersions))
+	apiVersions := getAPIVersions()
+	supportedAPIVersions := make(map[string]ApiVersion, len(apiVersions))
 	for _, v := range apiVersions {
-		supportedApiVersions[v.Version()] = v
+		supportedAPIVersions[v.Version()] = v
 	}
 
 	mux.HandleFunc(apiResource, func(w http.ResponseWriter, r *http.Request) {
-		err := handleRequest(supportedApiVersions, m, w, r)
+		err := handleRequest(supportedAPIVersions, m, w, r)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 		}
@@ -65,7 +65,7 @@ const (
 	apiRequestArgs
 )
 
-func handleRequest(supportedApiVersions map[string]ApiVersion, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
+func handleRequest(supportedAPIVersions map[string]ApiVersion, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
 	start := time.Now()
 	defer func() {
 		klog.V(4).Infof("Request took %s", time.Since(start))
@@ -80,8 +80,8 @@ func handleRequest(supportedApiVersions map[string]ApiVersion, m manager.Manager
 
 	// If the request doesn't have an API version, list those.
 	if request == apiPrefix || request == apiResource {
-		versions := make([]string, 0, len(supportedApiVersions))
-		for v := range supportedApiVersions {
+		versions := make([]string, 0, len(supportedAPIVersions))
+		for v := range supportedAPIVersions {
 			versions = append(versions, v)
 		}
 		sort.Strings(versions)
@@ -100,7 +100,7 @@ func handleRequest(supportedApiVersions map[string]ApiVersion, m manager.Manager
 	requestArgs := strings.Split(requestElements[apiRequestArgs], "/")
 
 	// Check supported versions.
-	versionHandler, ok := supportedApiVersions[version]
+	versionHandler, ok := supportedAPIVersions[version]
 	if !ok {
 		return fmt.Errorf("unsupported API version %q", version)
 	}

--- a/cmd/internal/api/versions.go
+++ b/cmd/internal/api/versions.go
@@ -367,7 +367,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 			}
 			klog.Errorf("Error calling GetRequestedContainersInfo: %v", err)
 		}
-		contStats := make(map[string][]v2.DeprecatedContainerStats, 0)
+		contStats := make(map[string][]v2.DeprecatedContainerStats)
 		for name, cinfo := range infos {
 			contStats[name] = v2.DeprecatedStatsFromV1(cinfo)
 		}
@@ -379,15 +379,15 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 		if err != nil {
 			return err
 		}
-		contMetrics := make(map[string]map[string]map[string][]info.MetricValBasic, 0)
+		contMetrics := make(map[string]map[string]map[string][]info.MetricValBasic)
 		for _, cinfo := range infos {
-			metrics := make(map[string]map[string][]info.MetricValBasic, 0)
+			metrics := make(map[string]map[string][]info.MetricValBasic)
 			for _, contStat := range cinfo.Stats {
 				if len(contStat.CustomMetrics) == 0 {
 					continue
 				}
 				for name, allLabels := range contStat.CustomMetrics {
-					metricLabels := make(map[string][]info.MetricValBasic, 0)
+					metricLabels := make(map[string][]info.MetricValBasic)
 					for _, metric := range allLabels {
 						if !metric.Timestamp.IsZero() {
 							metVal := info.MetricValBasic{

--- a/cmd/internal/api/versions.go
+++ b/cmd/internal/api/versions.go
@@ -29,20 +29,20 @@ import (
 )
 
 const (
-	containersApi    = "containers"
-	subcontainersApi = "subcontainers"
-	machineApi       = "machine"
-	machineStatsApi  = "machinestats"
-	dockerApi        = "docker"
-	summaryApi       = "summary"
-	statsApi         = "stats"
-	specApi          = "spec"
-	eventsApi        = "events"
-	storageApi       = "storage"
-	attributesApi    = "attributes"
-	versionApi       = "version"
-	psApi            = "ps"
-	customMetricsApi = "appmetrics"
+	containersAPI    = "containers"
+	subcontainersAPI = "subcontainers"
+	machineAPI       = "machine"
+	machineStatsAPI  = "machinestats"
+	dockerAPI        = "docker"
+	summaryAPI       = "summary"
+	statsAPI         = "stats"
+	specAPI          = "spec"
+	eventsAPI        = "events"
+	storageAPI       = "storage"
+	attributesAPI    = "attributes"
+	versionAPI       = "version"
+	psAPI            = "ps"
+	customMetricsAPI = "appmetrics"
 )
 
 // Interface for a cAdvisor API version
@@ -58,7 +58,7 @@ type ApiVersion interface {
 }
 
 // Gets all supported API versions.
-func getApiVersions() []ApiVersion {
+func getAPIVersions() []ApiVersion {
 	v1_0 := &version1_0{}
 	v1_1 := newVersion1_1(v1_0)
 	v1_2 := newVersion1_2(v1_1)
@@ -80,12 +80,12 @@ func (api *version1_0) Version() string {
 }
 
 func (api *version1_0) SupportedRequestTypes() []string {
-	return []string{containersApi, machineApi}
+	return []string{containersAPI, machineAPI}
 }
 
 func (api *version1_0) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
 	switch requestType {
-	case machineApi:
+	case machineAPI:
 		klog.V(4).Infof("Api - Machine")
 
 		// Get the MachineInfo
@@ -98,7 +98,7 @@ func (api *version1_0) HandleRequest(requestType string, request []string, m man
 		if err != nil {
 			return err
 		}
-	case containersApi:
+	case containersAPI:
 		containerName := getContainerName(request)
 		klog.V(4).Infof("Api - Container(%s)", containerName)
 
@@ -143,12 +143,12 @@ func (api *version1_1) Version() string {
 }
 
 func (api *version1_1) SupportedRequestTypes() []string {
-	return append(api.baseVersion.SupportedRequestTypes(), subcontainersApi)
+	return append(api.baseVersion.SupportedRequestTypes(), subcontainersAPI)
 }
 
 func (api *version1_1) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
 	switch requestType {
-	case subcontainersApi:
+	case subcontainersAPI:
 		containerName := getContainerName(request)
 		klog.V(4).Infof("Api - Subcontainers(%s)", containerName)
 
@@ -193,12 +193,12 @@ func (api *version1_2) Version() string {
 }
 
 func (api *version1_2) SupportedRequestTypes() []string {
-	return append(api.baseVersion.SupportedRequestTypes(), dockerApi)
+	return append(api.baseVersion.SupportedRequestTypes(), dockerAPI)
 }
 
 func (api *version1_2) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
 	switch requestType {
-	case dockerApi:
+	case dockerAPI:
 		klog.V(4).Infof("Api - Docker(%v)", request)
 
 		// Get the query request.
@@ -262,12 +262,12 @@ func (api *version1_3) Version() string {
 }
 
 func (api *version1_3) SupportedRequestTypes() []string {
-	return append(api.baseVersion.SupportedRequestTypes(), eventsApi)
+	return append(api.baseVersion.SupportedRequestTypes(), eventsAPI)
 }
 
 func (api *version1_3) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
 	switch requestType {
-	case eventsApi:
+	case eventsAPI:
 		return handleEventRequest(request, m, w, r)
 	default:
 		return api.baseVersion.HandleRequest(requestType, request, m, w, r)
@@ -310,7 +310,7 @@ func (api *version2_0) Version() string {
 }
 
 func (api *version2_0) SupportedRequestTypes() []string {
-	return []string{versionApi, attributesApi, eventsApi, machineApi, summaryApi, statsApi, specApi, storageApi, psApi, customMetricsApi}
+	return []string{versionAPI, attributesAPI, eventsAPI, machineAPI, summaryAPI, statsAPI, specAPI, storageAPI, psAPI, customMetricsAPI}
 }
 
 func (api *version2_0) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
@@ -319,14 +319,14 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 		return err
 	}
 	switch requestType {
-	case versionApi:
+	case versionAPI:
 		klog.V(4).Infof("Api - Version")
 		versionInfo, err := m.GetVersionInfo()
 		if err != nil {
 			return err
 		}
 		return writeResult(versionInfo.CadvisorVersion, w)
-	case attributesApi:
+	case attributesAPI:
 		klog.V(4).Info("Api - Attributes")
 
 		machineInfo, err := m.GetMachineInfo()
@@ -339,7 +339,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 		}
 		info := v2.GetAttributes(machineInfo, versionInfo)
 		return writeResult(info, w)
-	case machineApi:
+	case machineAPI:
 		klog.V(4).Info("Api - Machine")
 
 		// TODO(rjnagal): Move machineInfo from v1.
@@ -348,7 +348,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 			return err
 		}
 		return writeResult(machineInfo, w)
-	case summaryApi:
+	case summaryAPI:
 		containerName := getContainerName(request)
 		klog.V(4).Infof("Api - Summary for container %q, options %+v", containerName, opt)
 
@@ -357,7 +357,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 			return err
 		}
 		return writeResult(stats, w)
-	case statsApi:
+	case statsAPI:
 		name := getContainerName(request)
 		klog.V(4).Infof("Api - Stats: Looking for stats for container %q, options %+v", name, opt)
 		infos, err := m.GetRequestedContainersInfo(name, opt)
@@ -372,7 +372,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 			contStats[name] = v2.DeprecatedStatsFromV1(cinfo)
 		}
 		return writeResult(contStats, w)
-	case customMetricsApi:
+	case customMetricsAPI:
 		containerName := getContainerName(request)
 		klog.V(4).Infof("Api - Custom Metrics: Looking for metrics for container %q, options %+v", containerName, opt)
 		infos, err := m.GetContainerInfoV2(containerName, opt)
@@ -412,7 +412,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 			contMetrics[containerName] = metrics
 		}
 		return writeResult(contMetrics, w)
-	case specApi:
+	case specAPI:
 		containerName := getContainerName(request)
 		klog.V(4).Infof("Api - Spec for container %q, options %+v", containerName, opt)
 		specs, err := m.GetContainerSpec(containerName, opt)
@@ -420,7 +420,7 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 			return err
 		}
 		return writeResult(specs, w)
-	case storageApi:
+	case storageAPI:
 		label := r.URL.Query().Get("label")
 		uuid := r.URL.Query().Get("uuid")
 		switch {
@@ -445,9 +445,9 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 			}
 			return writeResult(fi, w)
 		}
-	case eventsApi:
+	case eventsAPI:
 		return handleEventRequest(request, m, w, r)
-	case psApi:
+	case psAPI:
 		// reuse container type from request.
 		// ignore recursive.
 		// TODO(rjnagal): consider count to limit ps output.
@@ -478,7 +478,7 @@ func (api *version2_1) Version() string {
 }
 
 func (api *version2_1) SupportedRequestTypes() []string {
-	return append([]string{machineStatsApi}, api.baseVersion.SupportedRequestTypes()...)
+	return append([]string{machineStatsAPI}, api.baseVersion.SupportedRequestTypes()...)
 }
 
 func (api *version2_1) HandleRequest(requestType string, request []string, m manager.Manager, w http.ResponseWriter, r *http.Request) error {
@@ -489,7 +489,7 @@ func (api *version2_1) HandleRequest(requestType string, request []string, m man
 	}
 
 	switch requestType {
-	case machineStatsApi:
+	case machineStatsAPI:
 		klog.V(4).Infof("Api - MachineStats(%v)", request)
 		cont, err := m.GetRequestedContainersInfo("/", opt)
 		if err != nil {
@@ -499,7 +499,7 @@ func (api *version2_1) HandleRequest(requestType string, request []string, m man
 			klog.Errorf("Error calling GetRequestedContainersInfo: %v", err)
 		}
 		return writeResult(v2.MachineStatsFromV1(cont["/"]), w)
-	case statsApi:
+	case statsAPI:
 		name := getContainerName(request)
 		klog.V(4).Infof("Api - Stats: Looking for stats for container %q, options %+v", name, opt)
 		conts, err := m.GetRequestedContainersInfo(name, opt)

--- a/cmd/internal/container/install/install.go
+++ b/cmd/internal/container/install/install.go
@@ -16,6 +16,7 @@
 package install
 
 import (
+	// Register all included container providers.
 	_ "github.com/google/cadvisor/cmd/internal/container/mesos/install"
 	_ "github.com/google/cadvisor/container/containerd/install"
 	_ "github.com/google/cadvisor/container/crio/install"

--- a/cmd/internal/container/mesos/client.go
+++ b/cmd/internal/container/mesos/client.go
@@ -44,8 +44,8 @@ type client struct {
 }
 
 type mesosAgentClient interface {
-	ContainerInfo(id string) (*containerInfo, error)
-	ContainerPid(id string) (int, error)
+	containerInfo(id string) (*containerInfo, error)
+	containerPID(id string) (int, error)
 }
 
 type containerInfo struct {
@@ -53,8 +53,8 @@ type containerInfo struct {
 	labels map[string]string
 }
 
-// Client is an interface to query mesos agent http endpoints
-func Client() (mesosAgentClient, error) {
+// newClient is an interface to query mesos agent http endpoints
+func newClient() (mesosAgentClient, error) {
 	mesosClientOnce.Do(func() {
 		// Start Client
 		apiURL := url.URL{
@@ -79,8 +79,8 @@ func Client() (mesosAgentClient, error) {
 	return mesosClient, nil
 }
 
-// ContainerInfo returns the container information of the given container id
-func (c *client) ContainerInfo(id string) (*containerInfo, error) {
+// containerInfo returns the container information of the given container id
+func (c *client) containerInfo(id string) (*containerInfo, error) {
 	container, err := c.getContainer(id)
 	if err != nil {
 		return nil, err
@@ -99,11 +99,11 @@ func (c *client) ContainerInfo(id string) (*containerInfo, error) {
 }
 
 // Get the Pid of the container
-func (c *client) ContainerPid(id string) (int, error) {
+func (c *client) containerPID(id string) (int, error) {
 	var pid int
 	err := retry.Retry(
 		func(attempt uint) error {
-			c, err := c.ContainerInfo(id)
+			c, err := c.containerInfo(id)
 			if err != nil {
 				return err
 			}

--- a/cmd/internal/container/mesos/client.go
+++ b/cmd/internal/container/mesos/client.go
@@ -101,8 +101,7 @@ func (c *client) ContainerInfo(id string) (*containerInfo, error) {
 // Get the Pid of the container
 func (c *client) ContainerPid(id string) (int, error) {
 	var pid int
-	var err error
-	err = retry.Retry(
+	err := retry.Retry(
 		func(attempt uint) error {
 			c, err := c.ContainerInfo(id)
 			if err != nil {

--- a/cmd/internal/container/mesos/client_test.go
+++ b/cmd/internal/container/mesos/client_test.go
@@ -21,7 +21,7 @@ type FakeMesosAgentClient struct {
 	err      error
 }
 
-func (c *FakeMesosAgentClient) ContainerInfo(id string) (*containerInfo, error) {
+func (c *FakeMesosAgentClient) containerInfo(id string) (*containerInfo, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -32,7 +32,7 @@ func (c *FakeMesosAgentClient) ContainerInfo(id string) (*containerInfo, error) 
 	return cInfo, nil
 }
 
-func (c *FakeMesosAgentClient) ContainerPid(id string) (int, error) {
+func (c *FakeMesosAgentClient) containerPID(id string) (int, error) {
 	if c.err != nil {
 		return invalidPID, c.err
 	}

--- a/cmd/internal/container/mesos/factory.go
+++ b/cmd/internal/container/mesos/factory.go
@@ -61,7 +61,7 @@ func (f *mesosFactory) String() string {
 }
 
 func (f *mesosFactory) NewContainerHandler(name string, metadataEnvAllowList []string, inHostNamespace bool) (container.ContainerHandler, error) {
-	client, err := Client()
+	client, err := newClient()
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (f *mesosFactory) CanHandleAndAccept(name string) (handle bool, accept bool
 	// Check if the container is known to mesos and it is active.
 	id := ContainerNameToMesosId(name)
 
-	_, err = f.client.ContainerInfo(id)
+	_, err = f.client.containerInfo(id)
 	if err != nil {
 		return false, true, fmt.Errorf("error getting running container: %v", err)
 	}
@@ -126,7 +126,7 @@ func Register(
 	fsInfo fs.FsInfo,
 	includedMetrics container.MetricSet,
 ) error {
-	client, err := Client()
+	client, err := newClient()
 
 	if err != nil {
 		return fmt.Errorf("unable to create mesos agent client: %v", err)

--- a/cmd/internal/container/mesos/handler.go
+++ b/cmd/internal/container/mesos/handler.go
@@ -170,7 +170,7 @@ func (h *mesosContainerHandler) GetStats() (*info.ContainerStats, error) {
 func (h *mesosContainerHandler) GetCgroupPath(resource string) (string, error) {
 	path, ok := h.cgroupPaths[resource]
 	if !ok {
-		return "", fmt.Errorf("could not find path for resource %q for container %q\n", resource, h.name)
+		return "", fmt.Errorf("could not find path for resource %q for container %q", resource, h.name)
 	}
 	return path, nil
 }

--- a/cmd/internal/container/mesos/handler.go
+++ b/cmd/internal/container/mesos/handler.go
@@ -75,14 +75,14 @@ func newMesosContainerHandler(
 
 	id := ContainerNameToMesosId(name)
 
-	cinfo, err := client.ContainerInfo(id)
+	cinfo, err := client.containerInfo(id)
 
 	if err != nil {
 		return nil, err
 	}
 
 	labels := cinfo.labels
-	pid, err := client.ContainerPid(id)
+	pid, err := client.containerPID(id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/internal/healthz/healthz.go
+++ b/cmd/internal/healthz/healthz.go
@@ -22,7 +22,7 @@ import (
 
 func handleHealthz(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok"))
+	_, _ = w.Write([]byte("ok"))
 }
 
 // Register simple HTTP /healthz handler to return "ok".

--- a/cmd/internal/pages/docker.go
+++ b/cmd/internal/pages/docker.go
@@ -158,5 +158,4 @@ func serveDockerPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
 	}
 
 	klog.V(5).Infof("Request took %s", time.Since(start))
-	return
 }

--- a/cmd/internal/pages/pages.go
+++ b/cmd/internal/pages/pages.go
@@ -67,9 +67,9 @@ type pageData struct {
 }
 
 func init() {
-	containersHtmlTemplate, _ := Asset("cmd/internal/pages/assets/html/containers.html")
+	containersHTMLTemplate, _ := Asset("cmd/internal/pages/assets/html/containers.html")
 	pageTemplate = template.New("containersTemplate").Funcs(funcMap)
-	_, err := pageTemplate.Parse(string(containersHtmlTemplate))
+	_, err := pageTemplate.Parse(string(containersHTMLTemplate))
 	if err != nil {
 		klog.Fatalf("Failed to parse template: %s", err)
 	}

--- a/cmd/internal/pages/static/static.go
+++ b/cmd/internal/pages/static/static.go
@@ -29,24 +29,24 @@ import (
 const StaticResource = "/static/"
 
 var popper, _ = Asset("cmd/internal/pages/assets/js/popper.min.js")
-var bootstrapJs, _ = Asset("cmd/internal/pages/assets/js/bootstrap-4.0.0-beta.2.min.js")
-var containersJs, _ = Asset("cmd/internal/pages/assets/js/containers.js")
-var loaderJs, _ = Asset("cmd/internal/pages/assets/js/loader.js")
-var jqueryJs, _ = Asset("cmd/internal/pages/assets/js/jquery-3.5.1.min.js")
+var bootstrapJS, _ = Asset("cmd/internal/pages/assets/js/bootstrap-4.0.0-beta.2.min.js")
+var containersJS, _ = Asset("cmd/internal/pages/assets/js/containers.js")
+var loaderJS, _ = Asset("cmd/internal/pages/assets/js/loader.js")
+var jqueryJS, _ = Asset("cmd/internal/pages/assets/js/jquery-3.5.1.min.js")
 
-var bootstrapCss, _ = Asset("cmd/internal/pages/assets/styles/bootstrap-4.0.0-beta.2.min.css")
-var bootstrapThemeCss, _ = Asset("cmd/internal/pages/assets/styles/bootstrap-theme-3.1.1.min.css")
-var containersCss, _ = Asset("cmd/internal/pages/assets/styles/containers.css")
+var bootstrapCSS, _ = Asset("cmd/internal/pages/assets/styles/bootstrap-4.0.0-beta.2.min.css")
+var bootstrapThemeCSS, _ = Asset("cmd/internal/pages/assets/styles/bootstrap-theme-3.1.1.min.css")
+var containersCSS, _ = Asset("cmd/internal/pages/assets/styles/containers.css")
 
 var staticFiles = map[string][]byte{
 	"popper.min.js":                  popper,
-	"bootstrap-4.0.0-beta.2.min.css": bootstrapCss,
-	"bootstrap-4.0.0-beta.2.min.js":  bootstrapJs,
-	"bootstrap-theme-3.1.1.min.css":  bootstrapThemeCss,
-	"containers.css":                 containersCss,
-	"containers.js":                  containersJs,
-	"loader.js":                      loaderJs,
-	"jquery-3.5.1.min.js":            jqueryJs,
+	"bootstrap-4.0.0-beta.2.min.css": bootstrapCSS,
+	"bootstrap-4.0.0-beta.2.min.js":  bootstrapJS,
+	"bootstrap-theme-3.1.1.min.css":  bootstrapThemeCSS,
+	"containers.css":                 containersCSS,
+	"containers.js":                  containersJS,
+	"loader.js":                      loaderJS,
+	"jquery-3.5.1.min.js":            jqueryJS,
 }
 
 func HandleRequest(w http.ResponseWriter, u *url.URL) {

--- a/cmd/internal/storage/bigquery/bigquery.go
+++ b/cmd/internal/storage/bigquery/bigquery.go
@@ -254,7 +254,7 @@ func (s *bigqueryStorage) containerFilesystemStatsToRows(
 	stats *info.ContainerStats,
 ) (rows []map[string]interface{}) {
 	for _, fsStat := range stats.Filesystem {
-		row := make(map[string]interface{}, 0)
+		row := make(map[string]interface{})
 		row[colFsDevice] = fsStat.Device
 		row[colFsLimit] = fsStat.Limit
 		row[colFsUsage] = fsStat.Usage

--- a/cmd/internal/storage/bigquery/bigquery.go
+++ b/cmd/internal/storage/bigquery/bigquery.go
@@ -42,10 +42,10 @@ const (
 	colTimestamp          string = "timestamp"
 	colMachineName        string = "machine"
 	colContainerName      string = "container_name"
-	colCpuCumulativeUsage string = "cpu_cumulative_usage"
-	// Cumulative Cpu usage in system and user mode
-	colCpuCumulativeUsageSystem string = "cpu_cumulative_usage_system"
-	colCpuCumulativeUsageUser   string = "cpu_cumulative_usage_user"
+	colCPUCumulativeUsage string = "cpu_cumulative_usage"
+	// Cumulative CPU usage in system and user mode
+	colCPUCumulativeUsageSystem string = "cpu_cumulative_usage_system"
+	colCPUCumulativeUsageUser   string = "cpu_cumulative_usage_user"
 	// Memory usage
 	colMemoryUsage string = "memory_usage"
 	// Working set size
@@ -110,17 +110,17 @@ func (s *bigqueryStorage) GetSchema() *bigquery.TableSchema {
 	i++
 	fields[i] = &bigquery.TableFieldSchema{
 		Type: typeInteger,
-		Name: colCpuCumulativeUsage,
+		Name: colCPUCumulativeUsage,
 	}
 	i++
 	fields[i] = &bigquery.TableFieldSchema{
 		Type: typeInteger,
-		Name: colCpuCumulativeUsageSystem,
+		Name: colCPUCumulativeUsageSystem,
 	}
 	i++
 	fields[i] = &bigquery.TableFieldSchema{
 		Type: typeInteger,
-		Name: colCpuCumulativeUsageUser,
+		Name: colCPUCumulativeUsageUser,
 	}
 	i++
 	fields[i] = &bigquery.TableFieldSchema{
@@ -212,13 +212,13 @@ func (s *bigqueryStorage) containerStatsToRows(
 	row[colContainerName] = name
 
 	// Cumulative Cpu Usage
-	row[colCpuCumulativeUsage] = stats.Cpu.Usage.Total
+	row[colCPUCumulativeUsage] = stats.Cpu.Usage.Total
 
 	// Cumulative Cpu Usage in system mode
-	row[colCpuCumulativeUsageSystem] = stats.Cpu.Usage.System
+	row[colCPUCumulativeUsageSystem] = stats.Cpu.Usage.System
 
 	// Cumulative Cpu Usage in user mode
-	row[colCpuCumulativeUsageUser] = stats.Cpu.Usage.User
+	row[colCPUCumulativeUsageUser] = stats.Cpu.Usage.User
 
 	// Memory Usage
 	row[colMemoryUsage] = stats.Memory.Usage
@@ -289,12 +289,12 @@ func (s *bigqueryStorage) Close() error {
 // machineName: A unique identifier to identify the host that current cAdvisor
 // instance is running on.
 // tableName: BigQuery table used for storing stats.
-func newStorage(machineName, datasetId, tableName string) (storage.StorageDriver, error) {
+func newStorage(machineName, datasetID, tableName string) (storage.StorageDriver, error) {
 	bqClient, err := client.NewClient()
 	if err != nil {
 		return nil, err
 	}
-	err = bqClient.CreateDataset(datasetId)
+	err = bqClient.CreateDataset(datasetID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/internal/storage/bigquery/client/client.go
+++ b/cmd/internal/storage/bigquery/client/client.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -23,6 +24,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/jwt"
 	bigquery "google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/option"
 )
 
 var (
@@ -71,7 +73,7 @@ func connect() (*oauth2.Token, *bigquery.Service, error) {
 		PrivateKey: pemBytes,
 		TokenURL:   "https://accounts.google.com/o/oauth2/token",
 	}
-	token, err := jwtConfig.TokenSource(oauth2.NoContext).Token()
+	token, err := jwtConfig.TokenSource(context.Background()).Token()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,9 +90,9 @@ func connect() (*oauth2.Token, *bigquery.Service, error) {
 			TokenURL: "https://accounts.google.com/o/oauth2/token",
 		},
 	}
-	client := config.Client(oauth2.NoContext, token)
+	client := config.Client(context.Background(), token)
 
-	service, err := bigquery.New(client)
+	service, err := bigquery.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		fmt.Printf("Failed to create new service: %v\n", err)
 		return nil, nil, err

--- a/cmd/internal/storage/bigquery/client/client.go
+++ b/cmd/internal/storage/bigquery/client/client.go
@@ -144,9 +144,8 @@ func (c *Client) PrintDatasets() error {
 	if err != nil {
 		fmt.Printf("Failed to get list of datasets\n")
 		return err
-	} else {
-		fmt.Printf("Successfully retrieved datasets. Retrieved: %d\n", len(datasetList.Datasets))
 	}
+	fmt.Printf("Successfully retrieved datasets. Retrieved: %d\n", len(datasetList.Datasets))
 
 	for _, d := range datasetList.Datasets {
 		fmt.Printf("%s %s\n", d.Id, d.FriendlyName)

--- a/cmd/internal/storage/bigquery/client/example/example.go
+++ b/cmd/internal/storage/bigquery/client/example/example.go
@@ -40,7 +40,10 @@ func main() {
 		panic(err)
 	}
 
-	c.PrintDatasets()
+	err = c.PrintDatasets()
+	if err != nil {
+		panic(err)
+	}
 
 	// Create a new dataset.
 	err = c.CreateDataset("sampledataset")

--- a/cmd/internal/storage/influxdb/influxdb.go
+++ b/cmd/internal/storage/influxdb/influxdb.go
@@ -50,10 +50,10 @@ type influxdbStorage struct {
 // Series names
 const (
 	// Cumulative CPU usage
-	serCpuUsageTotal  string = "cpu_usage_total"
-	serCpuUsageSystem string = "cpu_usage_system"
-	serCpuUsageUser   string = "cpu_usage_user"
-	serCpuUsagePerCpu string = "cpu_usage_per_cpu"
+	serCPUUsageTotal  string = "cpu_usage_total"
+	serCPUUsageSystem string = "cpu_usage_system"
+	serCPUUsageUser   string = "cpu_usage_user"
+	serCPUUsagePerCPU string = "cpu_usage_per_cpu"
 	// Smoothed average of number of runnable threads x 1000.
 	serLoadAverage string = "load_average"
 	// Memory Usage
@@ -204,17 +204,17 @@ func (s *influxdbStorage) containerStatsToPoints(
 	stats *info.ContainerStats,
 ) (points []*influxdb.Point) {
 	// CPU usage: Total usage in nanoseconds
-	points = append(points, makePoint(serCpuUsageTotal, stats.Cpu.Usage.Total))
+	points = append(points, makePoint(serCPUUsageTotal, stats.Cpu.Usage.Total))
 
 	// CPU usage: Time spend in system space (in nanoseconds)
-	points = append(points, makePoint(serCpuUsageSystem, stats.Cpu.Usage.System))
+	points = append(points, makePoint(serCPUUsageSystem, stats.Cpu.Usage.System))
 
 	// CPU usage: Time spent in user space (in nanoseconds)
-	points = append(points, makePoint(serCpuUsageUser, stats.Cpu.Usage.User))
+	points = append(points, makePoint(serCPUUsageUser, stats.Cpu.Usage.User))
 
 	// CPU usage per CPU
 	for i := 0; i < len(stats.Cpu.Usage.PerCpu); i++ {
-		point := makePoint(serCpuUsagePerCpu, stats.Cpu.Usage.PerCpu[i])
+		point := makePoint(serCPUUsagePerCPU, stats.Cpu.Usage.PerCpu[i])
 		tags := map[string]string{"instance": fmt.Sprintf("%v", i)}
 		addTagsToPoint(point, tags)
 

--- a/cmd/internal/storage/redis/redis.go
+++ b/cmd/internal/storage/redis/redis.go
@@ -101,11 +101,11 @@ func (s *redisStorage) AddStats(cInfo *info.ContainerInfo, stats *info.Container
 			s.lastWrite = time.Now()
 		}
 	}()
-	if len(seriesToFlush) > 0 {
-		// We use redis's "LPUSH" to push the data to the redis
-		s.conn.Send("LPUSH", s.redisKey, seriesToFlush)
+	if len(seriesToFlush) == 0 {
+		return nil
 	}
-	return nil
+	// We use redis's "LPUSH" to push the data to the redis
+	return s.conn.Send("LPUSH", s.redisKey, seriesToFlush)
 }
 
 func (s *redisStorage) Close() error {

--- a/cmd/internal/storage/statsd/client/client.go
+++ b/cmd/internal/storage/statsd/client/client.go
@@ -47,7 +47,7 @@ func (c *Client) Close() error {
 func (c *Client) Send(namespace, containerName, key string, value uint64) error {
 	// only send counter value
 	formatted := fmt.Sprintf("%s.%s.%s:%d|g", namespace, containerName, key, value)
-	_, err := fmt.Fprintf(c.conn, formatted)
+	_, err := fmt.Fprint(c.conn, formatted)
 	if err != nil {
 		return fmt.Errorf("failed to send data %q: %v", formatted, err)
 	}

--- a/cmd/internal/storage/statsd/statsd.go
+++ b/cmd/internal/storage/statsd/statsd.go
@@ -35,12 +35,12 @@ const (
 	// Cumulative CPU usage
 	// To be deprecated in 0.39
 	// https://github.com/google/cadvisor/issues/2637
-	colCpuCumulativeUsage string = "cpu_cumulative_usage"
+	colCPUCumulativeUsage string = "cpu_cumulative_usage"
 	// Cumulative CPU usage
-	serCpuUsageTotal  string = "cpu_usage_total"
-	serCpuUsageSystem string = "cpu_usage_system"
-	serCpuUsageUser   string = "cpu_usage_user"
-	serCpuUsagePerCpu string = "cpu_usage_per_cpu"
+	serCPUUsageTotal  string = "cpu_usage_total"
+	serCPUUsageSystem string = "cpu_usage_system"
+	serCPUUsageUser   string = "cpu_usage_user"
+	serCPUUsagePerCPU string = "cpu_usage_per_cpu"
 	// Smoothed average of number of runnable threads x 1000.
 	serLoadAverage string = "cpu_load_average"
 	// Memory Usage
@@ -101,20 +101,20 @@ func (s *statsdStorage) containerStatsToValues(stats *info.ContainerStats) (seri
 	series = make(map[string]uint64)
 
 	// Total usage in nanoseconds
-	series[serCpuUsageTotal] = stats.Cpu.Usage.Total
+	series[serCPUUsageTotal] = stats.Cpu.Usage.Total
 
 	// To be deprecated in 0.39
-	series[colCpuCumulativeUsage] = series[serCpuUsageTotal]
+	series[colCPUCumulativeUsage] = series[serCPUUsageTotal]
 
 	// CPU usage: Time spend in system space (in nanoseconds)
-	series[serCpuUsageSystem] = stats.Cpu.Usage.System
+	series[serCPUUsageSystem] = stats.Cpu.Usage.System
 
 	// CPU usage: Time spent in user space (in nanoseconds)
-	series[serCpuUsageUser] = stats.Cpu.Usage.User
+	series[serCPUUsageUser] = stats.Cpu.Usage.User
 
 	// CPU usage per CPU
 	for i := 0; i < len(stats.Cpu.Usage.PerCpu); i++ {
-		series[serCpuUsagePerCpu+"."+strconv.Itoa(i)] = stats.Cpu.Usage.PerCpu[i]
+		series[serCPUUsagePerCPU+"."+strconv.Itoa(i)] = stats.Cpu.Usage.PerCpu[i]
 	}
 
 	// Load Average

--- a/cmd/internal/storage/stdout/stdout.go
+++ b/cmd/internal/storage/stdout/stdout.go
@@ -37,12 +37,12 @@ const (
 	// Cumulative CPU usage
 	// To be deprecated in 0.39
 	// https://github.com/google/cadvisor/issues/2637
-	colCpuCumulativeUsage string = "cpu_cumulative_usage"
+	colCPUCumulativeUsage string = "cpu_cumulative_usage"
 	// Cumulative CPU usage
-	serCpuUsageTotal  string = "cpu_usage_total"
-	serCpuUsageSystem string = "cpu_usage_system"
-	serCpuUsageUser   string = "cpu_usage_user"
-	serCpuUsagePerCpu string = "cpu_usage_per_cpu"
+	serCPUUsageTotal  string = "cpu_usage_total"
+	serCPUUsageSystem string = "cpu_usage_system"
+	serCPUUsageUser   string = "cpu_usage_user"
+	serCPUUsagePerCPU string = "cpu_usage_per_cpu"
 	// Smoothed average of number of runnable threads x 1000.
 	serLoadAverage string = "load_average"
 	// Memory Usage
@@ -106,20 +106,20 @@ func (driver *stdoutStorage) containerStatsToValues(stats *info.ContainerStats) 
 	series[serTimestamp] = uint64(time.Now().UnixNano())
 
 	// Total usage in nanoseconds
-	series[serCpuUsageTotal] = stats.Cpu.Usage.Total
+	series[serCPUUsageTotal] = stats.Cpu.Usage.Total
 
 	// To be deprecated in 0.39
-	series[colCpuCumulativeUsage] = series[serCpuUsageTotal]
+	series[colCPUCumulativeUsage] = series[serCPUUsageTotal]
 
 	// CPU usage: Time spend in system space (in nanoseconds)
-	series[serCpuUsageSystem] = stats.Cpu.Usage.System
+	series[serCPUUsageSystem] = stats.Cpu.Usage.System
 
 	// CPU usage: Time spent in user space (in nanoseconds)
-	series[serCpuUsageUser] = stats.Cpu.Usage.User
+	series[serCPUUsageUser] = stats.Cpu.Usage.User
 
 	// CPU usage per CPU
 	for i := 0; i < len(stats.Cpu.Usage.PerCpu); i++ {
-		series[serCpuUsagePerCpu+"."+strconv.Itoa(i)] = stats.Cpu.Usage.PerCpu[i]
+		series[serCPUUsagePerCPU+"."+strconv.Itoa(i)] = stats.Cpu.Usage.PerCpu[i]
 	}
 
 	// Load Average

--- a/cmd/internal/storage/test/storagetests.go
+++ b/cmd/internal/storage/test/storagetests.go
@@ -70,10 +70,8 @@ func TimeEq(t1, t2 time.Time, tolerance time.Duration) bool {
 		t1, t2 = t2, t1
 	}
 	diff := t2.Sub(t1)
-	if diff <= tolerance {
-		return true
-	}
-	return false
+
+	return diff <= tolerance
 }
 
 // This function will generate random stats and write


### PR DESCRIPTION
Apparently, golangci-lint (and thus `make lint`, `make presubmit`, and various CI jobs)
was not checking any code in cmd.

Make it do so, and fix found warnings.

**This requires careful review, as some changes are not trivial. Please review commit by commit.** 
