### PR TITLE
Revert "Remove unused MetricSet.Append() method"

### DIFF
--- a/container/factory.go
+++ b/container/factory.go
@@ -145,6 +145,16 @@ func (ms MetricSet) Difference(ms1 MetricSet) MetricSet {
 	return result
 }
 
+func (ms MetricSet) Append(ms1 MetricSet) MetricSet {
+	result := ms
+	for kind := range ms1 {
+		if !ms.Has(kind) {
+			result.add(kind)
+		}
+	}
+	return result
+}
+
 // All registered auth provider plugins.
 var pluginsLock sync.Mutex
 var plugins = make(map[string]Plugin)


### PR DESCRIPTION
This reverts commit ded4f2f8758f840d7dbdc2f6fe4a2aa0963ed0ed.

This method is still used in Kubernetes.

from [WIP against k/k](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/97252/pull-kubernetes-typecheck/1451003572912132096) 
```
ERROR(windows/arm64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(darwin/arm64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(windows/386): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(linux/amd64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go:112:140: not enough arguments in call to manager.New
ERROR(linux/amd64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(darwin/amd64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(windows/amd64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go:112:140: not enough arguments in call to manager.New
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(linux/ppc64le): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go:112:140: not enough arguments in call to manager.New
ERROR(linux/ppc64le): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(linux/arm64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go:112:140: not enough arguments in call to manager.New
ERROR(linux/arm64): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(linux/386): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go:112:140: not enough arguments in call to manager.New
ERROR(linux/386): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
ERROR(linux/s390x): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go:112:140: not enough arguments in call to manager.New
ERROR(linux/s390x): /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/server/server.go:376:19: includedMetrics.Add undefined (type "k8s.io/kubernetes/vendor/github.com/google/cadvisor/container".MetricSet has no field or method Add)
exit status 1
!!! Type Check has failed. This may cause cross platform build failures.
!!! Please see https://git.k8s.io/kubernetes/test/typecheck for more information.
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>