### PR TITLE
Patch to fix issue 2341

### DIFF
--- a/container/raw/factory.go
+++ b/container/raw/factory.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	DockerOnly             = flag.Bool("docker_only", false, "Only report docker containers in addition to root stats")
-	disableRootCgroupStats = flag.Bool("disable_root_cgroup_stats", false, "Disable collecting root Cgroup stats")
+	DisableRootCgroupStats = flag.Bool("disable_root_cgroup_stats", false, "Disable collecting root Cgroup stats")
 )
 
 type rawFactory struct {

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -227,7 +227,7 @@ func (h *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 }
 
 func (h *rawContainerHandler) GetStats() (*info.ContainerStats, error) {
-	if *disableRootCgroupStats && isRootCgroup(h.name) {
+	if *DisableRootCgroupStats && isRootCgroup(h.name) {
 		return nil, nil
 	}
 	stats, err := h.libcontainerHandler.GetStats()

--- a/manager/container.go
+++ b/manager/container.go
@@ -486,7 +486,7 @@ func (cd *containerData) nextHousekeepingInterval() time.Duration {
 		var empty time.Time
 		stats, err := cd.memoryCache.RecentStats(cd.info.Name, empty, empty, 2)
 		if err != nil {
-			if cd.allowErrorLogging() && !(cd.isRoot() && *raw.DisableRootCgroupStats){
+			if cd.allowErrorLogging() && !(cd.isRoot() && *raw.DisableRootCgroupStats) {
 				klog.Warningf("Failed to get RecentStats(%q) while determining the next housekeeping: %v", cd.info.Name, err)
 			}
 		} else if len(stats) == 2 {

--- a/manager/container.go
+++ b/manager/container.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/cadvisor/cache/memory"
 	"github.com/google/cadvisor/collector"
 	"github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/container/raw"
 	info "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/stats"
@@ -485,7 +486,7 @@ func (cd *containerData) nextHousekeepingInterval() time.Duration {
 		var empty time.Time
 		stats, err := cd.memoryCache.RecentStats(cd.info.Name, empty, empty, 2)
 		if err != nil {
-			if cd.allowErrorLogging() {
+			if cd.allowErrorLogging() && !(cd.info.Name=="/" && *raw.DisableRootCgroupStats){
 				klog.Warningf("Failed to get RecentStats(%q) while determining the next housekeeping: %v", cd.info.Name, err)
 			}
 		} else if len(stats) == 2 {

--- a/manager/container.go
+++ b/manager/container.go
@@ -486,7 +486,7 @@ func (cd *containerData) nextHousekeepingInterval() time.Duration {
 		var empty time.Time
 		stats, err := cd.memoryCache.RecentStats(cd.info.Name, empty, empty, 2)
 		if err != nil {
-			if cd.allowErrorLogging() && !(cd.info.Name=="/" && *raw.DisableRootCgroupStats){
+			if cd.allowErrorLogging() && !(cd.isRoot() && *raw.DisableRootCgroupStats){
 				klog.Warningf("Failed to get RecentStats(%q) while determining the next housekeeping: %v", cd.info.Name, err)
 			}
 		} else if len(stats) == 2 {


### PR DESCRIPTION
This patch will ignore the warning 
`Failed to get RecentStats("/") while determining the next housekeeping: unable to find data in memory cache`
for root cgroup when `--disable_root_cgroup_stats` flag is set to true.

Closes #2341