### PR TITLE
Pinned tag using SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # v2
       with:
         go-version: ${{ matrix.go-versions }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2
     - name: Run presubmit checks
       run: |
         source ${{ matrix.environment-variables }}
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2
       with:
         fetch-depth: 1
         path: go/src/github.com/google/cadvisor
@@ -48,7 +48,7 @@ jobs:
         source ${{ matrix.environment-variables }}
         make docker-test-integration
     - name: Upload cAdvisor log file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 # v1
       if: failure()
       with:
         name: cadvisor.log


### PR DESCRIPTION
Pinned actions by SHA instead of a tag because tags can be moved while SHA can’t.

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies