### PR TITLE
Always evaluate Raw Factory last

### DIFF
--- a/container/factory.go
+++ b/container/factory.go
@@ -242,7 +242,10 @@ func NewContainerHandler(name string, watchType watcher.ContainerWatchSource, me
 	defer factoriesLock.RUnlock()
 
 	// Create the ContainerHandler with the first factory that supports it.
-	for _, factory := range factories[watchType] {
+	// Note that since RawContainerHandler can support a wide range of paths,
+	// it's evaluated last just to make sure if any other ContainerHandler
+	// can support it.
+	for _, factory := range GetReorderedFactoryList(watchType) {
 		canHandle, canAccept, err := factory.CanHandleAndAccept(name)
 		if err != nil {
 			klog.V(4).Infof("Error trying to work out if we can handle %s: %v", name, err)
@@ -284,4 +287,27 @@ func DebugInfo() map[string][]string {
 		}
 	}
 	return out
+}
+
+// GetReorderedFactoryList returns the list of ContainerHandlerFactory where the
+// RawContainerHandler is always the last element.
+func GetReorderedFactoryList(watchType watcher.ContainerWatchSource) []ContainerHandlerFactory {
+	ContainerHandlerFactoryList := make([]ContainerHandlerFactory, 0, len(factories))
+
+	var rawFactory ContainerHandlerFactory
+	for _, v := range factories[watchType] {
+		if v != nil {
+			if v.String() == "raw" {
+				rawFactory = v
+				continue
+			}
+			ContainerHandlerFactoryList = append(ContainerHandlerFactoryList, v)
+		}
+	}
+
+	if rawFactory != nil {
+		ContainerHandlerFactoryList = append(ContainerHandlerFactoryList, rawFactory)
+	}
+
+	return ContainerHandlerFactoryList
 }

--- a/container/factory_test.go
+++ b/container/factory_test.go
@@ -162,3 +162,25 @@ func TestNewContainerHandler_Accept(t *testing.T) {
 		t.Error("Expected NewContainerHandler to ignore the container.")
 	}
 }
+
+func TestRawContainerHandler_Last(t *testing.T) {
+	chf1 := &mockContainerHandlerFactory{
+		Name: "raw",
+	}
+	container.RegisterContainerHandlerFactory(chf1, []watcher.ContainerWatchSource{watcher.Raw})
+	cfh2 := &mockContainerHandlerFactory{
+		Name: "crio",
+	}
+	container.RegisterContainerHandlerFactory(cfh2, []watcher.ContainerWatchSource{watcher.Raw})
+
+	cfh3 := &mockContainerHandlerFactory{
+		Name: "containerd",
+	}
+	container.RegisterContainerHandlerFactory(cfh3, []watcher.ContainerWatchSource{watcher.Raw})
+
+	list := container.GetReorderedFactoryList(watcher.Raw)
+
+	if list[len(list)-1].String() != "raw" {
+		t.Error("Expected raw container handler to be last in the list.")
+	}
+}


### PR DESCRIPTION
This is related to https://github.com/google/cadvisor/pull/2957#issuecomment-947375225. 

Since the `raw` factory can handle pretty much everything, the issue addressed in https://github.com/google/cadvisor/pull/2957 cannot be handled only by that PR. Once we make sure that `raw` is evaluated in the end always, then the fix in https://github.com/google/cadvisor/pull/2957 should work without any issues. 


Signed-off-by: Harshal Patil <harpatil@redhat.com>