### PR TITLE
cgroupv2: fix swap accounting

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -806,7 +806,7 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	if cgroups.IsCgroup2UnifiedMode() {
 		ret.Memory.Cache = s.MemoryStats.Stats["file"]
 		ret.Memory.RSS = s.MemoryStats.Stats["anon"]
-		ret.Memory.Swap = s.MemoryStats.SwapUsage.Usage
+		ret.Memory.Swap = s.MemoryStats.SwapUsage.Usage - s.MemoryStats.Usage.Usage
 		ret.Memory.MappedFile = s.MemoryStats.Stats["file_mapped"]
 	} else if s.MemoryStats.UseHierarchy {
 		ret.Memory.Cache = s.MemoryStats.Stats["total_cache"]


### PR DESCRIPTION
Since runsc v1.0.0-rc94 `stats.MemoryStats.SwapUsage` on cgroupv2 includes memory usage:

* https://github.com/opencontainers/runc/commit/b99ca25ad0f

This results in wrong metrics:

```
container_memory_rss{id="/system.slice/qs-dnsv2.service"} 9.173716992e+09 1635890983582
container_memory_swap{id="/system.slice/qs-dnsv2.service"} 1.249011712e+10 1635890983582
container_memory_usage_bytes{id="/system.slice/qs-dnsv2.service"} 1.249011712e+10 1635890983582
```

Here my service dosn't have any swapped pages, yet it reports all memory as swapped.