### PR TITLE
Fix missing metrics on cgroups v2

### DIFF
--- a/container/common/helpers.go
+++ b/container/common/helpers.go
@@ -195,7 +195,6 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	// Processes, read it's value from pids path directly
-	//pidsRoot, ok := cgroupPaths["pids"]
 	pidsRoot, ok := getControllerPath(cgroupPaths, "pids", cgroup2UnifiedMode)
 	if ok {
 		if utils.FileExists(pidsRoot) {

--- a/container/common/helpers.go
+++ b/container/common/helpers.go
@@ -105,7 +105,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	// CPU.
-	cpuRoot, ok := cgroupPaths["cpu"]
+	cpuRoot, ok := getControllerPath(cgroupPaths, "cpu", cgroup2UnifiedMode)
 	if ok {
 		if utils.FileExists(cpuRoot) {
 			if cgroup2UnifiedMode {
@@ -152,7 +152,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 
 	// Cpu Mask.
 	// This will fail for non-unified hierarchies. We'll return the whole machine mask in that case.
-	cpusetRoot, ok := cgroupPaths["cpuset"]
+	cpusetRoot, ok := getControllerPath(cgroupPaths, "cpuset", cgroup2UnifiedMode)
 	if ok {
 		if utils.FileExists(cpusetRoot) {
 			spec.HasCpu = true
@@ -167,7 +167,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	// Memory
-	memoryRoot, ok := cgroupPaths["memory"]
+	memoryRoot, ok := getControllerPath(cgroupPaths, "memory", cgroup2UnifiedMode)
 	if ok {
 		if cgroup2UnifiedMode {
 			if utils.FileExists(path.Join(memoryRoot, "memory.max")) {
@@ -195,7 +195,8 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	// Processes, read it's value from pids path directly
-	pidsRoot, ok := cgroupPaths["pids"]
+	//pidsRoot, ok := cgroupPaths["pids"]
+	pidsRoot, ok := getControllerPath(cgroupPaths, "pids", cgroup2UnifiedMode)
 	if ok {
 		if utils.FileExists(pidsRoot) {
 			spec.HasProcesses = true
@@ -215,6 +216,19 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	return spec, nil
+}
+
+func getControllerPath(cgroupPaths map[string]string, controllerName string, cgroup2UnifiedMode bool) (string, bool) {
+
+	ok := false
+	path := ""
+
+	if cgroup2UnifiedMode {
+		path, ok = cgroupPaths[""]
+	} else {
+		path, ok = cgroupPaths[controllerName]
+	}
+	return path, ok
 }
 
 func readString(dirpath string, file string) string {

--- a/container/common/helpers_test.go
+++ b/container/common/helpers_test.go
@@ -143,10 +143,7 @@ func TestGetSpecCgroupV2(t *testing.T) {
 	}
 
 	cgroupPaths := map[string]string{
-		"memory": filepath.Join(root, "test_resources/cgroup_v2/test1"),
-		"cpu":    filepath.Join(root, "test_resources/cgroup_v2/test1"),
-		"cpuset": filepath.Join(root, "test_resources/cgroup_v2/test1"),
-		"pids":   filepath.Join(root, "test_resources/cgroup_v2/test1"),
+		"": filepath.Join(root, "test_resources/cgroup_v2/test1"),
 	}
 
 	spec, err := getSpecInternal(cgroupPaths, &mockInfoProvider{}, false, false, true)
@@ -176,9 +173,7 @@ func TestGetSpecCgroupV2Max(t *testing.T) {
 	assert.Nil(t, err)
 
 	cgroupPaths := map[string]string{
-		"memory": filepath.Join(root, "test_resources/cgroup_v2/test2"),
-		"cpu":    filepath.Join(root, "test_resources/cgroup_v2/test2"),
-		"pids":   filepath.Join(root, "test_resources/cgroup_v2/test2"),
+		"": filepath.Join(root, "test_resources/cgroup_v2/test2"),
 	}
 
 	spec, err := getSpecInternal(cgroupPaths, &mockInfoProvider{}, false, false, true)


### PR DESCRIPTION
Path lookups fail in the cgroups v2 cgroupPaths map (common/helpers.go, getSpecInternal) that only has key "" and some metrics are missing (cpu cfs related ones, for instance).