### PR TITLE
Move `ErrDeviceNotInPartitionsMap` outside of the build constraints

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -20,7 +20,6 @@ package fs
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -58,9 +57,6 @@ const (
 
 // A pool for restricting the number of consecutive `du` and `find` tasks running.
 var pool = make(chan struct{}, maxConcurrentOps)
-
-// ErrDeviceNotInPartitionsMap is the error resulting if a device could not be found in the partitions map.
-var ErrDeviceNotInPartitionsMap = errors.New("could not find device in cached partitions map")
 
 func init() {
 	for i := 0; i < maxConcurrentOps; i++ {

--- a/fs/types.go
+++ b/fs/types.go
@@ -86,8 +86,13 @@ type UsageInfo struct {
 	Inodes uint64
 }
 
-// ErrNoSuchDevice is the error indicating the requested device does not exist.
-var ErrNoSuchDevice = errors.New("cadvisor: no such device")
+var (
+	// ErrNoSuchDevice is the error indicating the requested device does not exist.
+	ErrNoSuchDevice = errors.New("cadvisor: no such device")
+
+	// ErrDeviceNotInPartitionsMap is the error resulting if a device could not be found in the partitions map.
+	ErrDeviceNotInPartitionsMap = errors.New("could not find device in cached partitions map")
+)
 
 type FsInfo interface {
 	// Returns capacity and free space, in bytes, of all the ext2, ext3, ext4 filesystems on the host.


### PR DESCRIPTION
This allows using the error type on non Linux systems as well.
