### PR TITLE
fix: atomic operations on 32-byte device

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -64,6 +64,7 @@ type containerInfo struct {
 }
 
 type containerData struct {
+	oomEvents                uint64
 	handler                  container.ContainerHandler
 	info                     containerInfo
 	memoryCache              *memory.InMemoryCache
@@ -103,8 +104,6 @@ type containerData struct {
 
 	// resctrlCollector updates stats for resctrl controller.
 	resctrlCollector stats.Collector
-
-	oomEvents uint64
 }
 
 // jitter returns a time.Duration between duration and duration + maxFactor * duration,


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/106977

prevent panic on atomic operations 