### PR TITLE
Fix process metrics collection in cgroup v2

### DIFF
--- a/container/common/helpers.go
+++ b/container/common/helpers.go
@@ -105,7 +105,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	// CPU.
-	cpuRoot, ok := getControllerPath(cgroupPaths, "cpu", cgroup2UnifiedMode)
+	cpuRoot, ok := GetControllerPath(cgroupPaths, "cpu", cgroup2UnifiedMode)
 	if ok {
 		if utils.FileExists(cpuRoot) {
 			if cgroup2UnifiedMode {
@@ -152,7 +152,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 
 	// Cpu Mask.
 	// This will fail for non-unified hierarchies. We'll return the whole machine mask in that case.
-	cpusetRoot, ok := getControllerPath(cgroupPaths, "cpuset", cgroup2UnifiedMode)
+	cpusetRoot, ok := GetControllerPath(cgroupPaths, "cpuset", cgroup2UnifiedMode)
 	if ok {
 		if utils.FileExists(cpusetRoot) {
 			spec.HasCpu = true
@@ -167,7 +167,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	// Memory
-	memoryRoot, ok := getControllerPath(cgroupPaths, "memory", cgroup2UnifiedMode)
+	memoryRoot, ok := GetControllerPath(cgroupPaths, "memory", cgroup2UnifiedMode)
 	if ok {
 		if cgroup2UnifiedMode {
 			if utils.FileExists(path.Join(memoryRoot, "memory.max")) {
@@ -195,7 +195,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	}
 
 	// Processes, read it's value from pids path directly
-	pidsRoot, ok := getControllerPath(cgroupPaths, "pids", cgroup2UnifiedMode)
+	pidsRoot, ok := GetControllerPath(cgroupPaths, "pids", cgroup2UnifiedMode)
 	if ok {
 		if utils.FileExists(pidsRoot) {
 			spec.HasProcesses = true
@@ -217,7 +217,7 @@ func getSpecInternal(cgroupPaths map[string]string, machineInfoFactory info.Mach
 	return spec, nil
 }
 
-func getControllerPath(cgroupPaths map[string]string, controllerName string, cgroup2UnifiedMode bool) (string, bool) {
+func GetControllerPath(cgroupPaths map[string]string, controllerName string, cgroup2UnifiedMode bool) (string, bool) {
 
 	ok := false
 	path := ""

--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/container/common"
 	info "github.com/google/cadvisor/info/v1"
 )
 
@@ -169,8 +170,7 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 	// file descriptors etc.) and not required a proper container's
 	// root PID (systemd services don't have the root PID atm)
 	if h.includedMetrics.Has(container.ProcessMetrics) {
-		paths := h.cgroupManager.GetPaths()
-		path, ok := paths["cpu"]
+		path, ok := common.GetControllerPath(h.cgroupManager.GetPaths(), "cpu", cgroups.IsCgroup2UnifiedMode())
 		if !ok {
 			klog.V(4).Infof("Could not find cgroups CPU for container %d", h.pid)
 		} else {


### PR DESCRIPTION
This PR fixes #3026 to use a unified root path to collect process stats from procs if cadvisor is running in cgroup v2.

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>