### PR TITLE
backport v0.39: fix: atomic operations on 32-byte device

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -63,6 +63,7 @@ type containerInfo struct {
 }
 
 type containerData struct {
+	oomEvents                uint64
 	handler                  container.ContainerHandler
 	info                     containerInfo
 	memoryCache              *memory.InMemoryCache


### PR DESCRIPTION
Backport https://github.com/google/cadvisor/pull/3029 to v0.39 cAdvisor 

xref: kubernetes/kubernetes#106977