### PR TITLE
manager: fix determining selfContainer name

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -158,7 +158,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, houskeepingConfig
 	if cgroups.IsCgroup2UnifiedMode() {
 		klog.Warningf("Cannot detect current cgroup on cgroup v2")
 	} else {
-		selfContainer, err := cgroups.GetOwnCgroupPath("cpu")
+		selfContainer, err = cgroups.GetOwnCgroup("cpu")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I found that on cgroup v1 `selfContainer` was not being determined correctly, due to two issues, both of which this PR fixes.