### PR TITLE
dockerfile: Use the same Go version.

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.12 AS build
 
-RUN apk --no-cache add libc6-compat device-mapper findutils zfs build-base linux-headers go python3 bash git wget cmake pkgconfig ndctl-dev && \
+RUN apk --no-cache add libc6-compat device-mapper findutils zfs build-base linux-headers python3 bash git wget cmake pkgconfig ndctl-dev && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
+    apk --no-cache add go==1.16.10-r0 --repository http://dl-3.alpinelinux.org/alpine/v3.14/community/ && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Go version changed in #3046.
It should be also changed in the dockerfile.

This fixes:
```
build github.com/google/cadvisor/cmd: cannot load io/fs: malformed module path "io/fs": missing dot in first path element
The command '/bin/sh -c ./build/build.sh' returned a non-zero code: 1
make: *** [Makefile:79: docker-%] Error 1
```
when building a docker image.

@iwankgb @bobbypage 

Signed-off-by: Paweł Szulik <pawel.szulik@intel.com>