### PR TITLE
deploy: remove blank space of whitelisted_container_labels

### DIFF
--- a/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
+++ b/deploy/kubernetes/overlays/examples/cadvisor-args.yaml
@@ -20,4 +20,4 @@ spec:
           - --enable_metrics=app,cpu,disk,diskIO,memory,network,process
           - --docker_only                                         # only show stats for docker containers
           - --store_container_labels=false
-          - --whitelisted_container_labels=io.kubernetes.container.name, io.kubernetes.pod.name,io.kubernetes.pod.namespace
+          - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace


### PR DESCRIPTION
Can't scrape correct container labels in this config.