### PR TITLE
Update Alpine base image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 AS build
+FROM alpine:3.15 AS build
 
 RUN apk --no-cache add libc6-compat device-mapper findutils zfs build-base linux-headers python3 bash git wget cmake pkgconfig ndctl-dev && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
@@ -32,7 +32,7 @@ ENV GO_FLAGS="-tags=libpfm,netgo,libipmctl"
 
 RUN ./build/build.sh
 
-FROM alpine:3.12
+FROM alpine:3.15
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils zfs ndctl && \

--- a/deploy/Dockerfile.ppc64le
+++ b/deploy/Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 FROM ppc64le/alpine:3.15
-5AINTAINER dashpole@google.com lysannef@us.ibm.com
+MAINTAINER dashpole@google.com lysannef@us.ibm.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils zfs && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \

--- a/deploy/Dockerfile.ppc64le
+++ b/deploy/Dockerfile.ppc64le
@@ -1,5 +1,5 @@
-FROM ppc64le/alpine:3.10
-MAINTAINER dashpole@google.com lysannef@us.ibm.com
+FROM ppc64le/alpine:3.15
+5AINTAINER dashpole@google.com lysannef@us.ibm.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils zfs && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \


### PR DESCRIPTION
One of our security tools is reporting that the version of Alpine upon which the `cadvisor` image is built is reaching EOL soon (see [here](https://endoflife.date/alpine) for details). This PR just bumps the minor version. Unfortunately Alpine doesn't follow SemVer so there's no guarantees around minor version bumps but nothing in the subsequent release notes seems to indicate any issue with how `cadvisor` runs so it ought to be fine.