### PR TITLE
api/v2: document and consume count=-1

### DIFF
--- a/cmd/internal/api/versions.go
+++ b/cmd/internal/api/versions.go
@@ -547,11 +547,14 @@ func GetRequestOptions(r *http.Request) (v2.RequestOptions, error) {
 	}
 	count := r.URL.Query().Get("count")
 	if len(count) != 0 {
-		n, err := strconv.ParseUint(count, 10, 32)
+		n, err := strconv.Atoi(count)
 		if err != nil {
 			return opt, fmt.Errorf("failed to parse 'count' option: %v", count)
 		}
-		opt.Count = int(n)
+		if n < -1 {
+			return opt, fmt.Errorf("invalid 'count' option: only -1 and larger values allowed, not %d", n)
+		}
+		opt.Count = n
 	}
 	recursive := r.URL.Query().Get("recursive")
 	if recursive == "true" {

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -265,7 +265,7 @@ type FsInfo struct {
 type RequestOptions struct {
 	// Type of container identifier specified - TypeName (default) or TypeDocker
 	IdType string `json:"type"`
-	// Number of stats to return
+	// Number of stats to return, -1 means no limit.
 	Count int `json:"count"`
 	// Whether to include stats for child subcontainers.
 	Recursive bool `json:"recursive"`


### PR DESCRIPTION
The underlying code already knows how to consume count=-1 when fetching
all data points. This patch allows the server to accept such a value
from the client and pass it through.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

cc @mrunalp 