### PR TITLE
Add flag to disable machine metrics

### DIFF
--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -87,7 +87,6 @@ var (
 		container.ProcessMetrics:                 struct{}{},
 		container.HugetlbUsageMetrics:            struct{}{},
 		container.ReferencedMemoryMetrics:        struct{}{},
-		container.MachineMetrics:                 struct{}{},
 		container.CPUTopologyMetrics:             struct{}{},
 		container.ResctrlMetrics:                 struct{}{},
 		container.CPUSetMetrics:                  struct{}{},

--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -87,6 +87,7 @@ var (
 		container.ProcessMetrics:                 struct{}{},
 		container.HugetlbUsageMetrics:            struct{}{},
 		container.ReferencedMemoryMetrics:        struct{}{},
+		container.MachineMetrics:                 struct{}{},
 		container.CPUTopologyMetrics:             struct{}{},
 		container.ResctrlMetrics:                 struct{}{},
 		container.CPUSetMetrics:                  struct{}{},

--- a/cmd/cadvisor_test.go
+++ b/cmd/cadvisor_test.go
@@ -109,6 +109,7 @@ func TestToIncludedMetrics(t *testing.T) {
 			container.HugetlbUsageMetrics:            struct{}{},
 			container.PerfMetrics:                    struct{}{},
 			container.ReferencedMemoryMetrics:        struct{}{},
+			container.MachineMetrics:                 struct{}{},
 			container.CPUTopologyMetrics:             struct{}{},
 			container.ResctrlMetrics:                 struct{}{},
 			container.CPUSetMetrics:                  struct{}{},

--- a/container/factory.go
+++ b/container/factory.go
@@ -63,6 +63,7 @@ const (
 	HugetlbUsageMetrics            MetricKind = "hugetlb"
 	PerfMetrics                    MetricKind = "perf_event"
 	ReferencedMemoryMetrics        MetricKind = "referenced_memory"
+	MachineMetrics                 MetricKind = "machine"
 	CPUTopologyMetrics             MetricKind = "cpu_topology"
 	ResctrlMetrics                 MetricKind = "resctrl"
 	CPUSetMetrics                  MetricKind = "cpuset"
@@ -89,6 +90,7 @@ var AllMetrics = MetricSet{
 	HugetlbUsageMetrics:            struct{}{},
 	PerfMetrics:                    struct{}{},
 	ReferencedMemoryMetrics:        struct{}{},
+	MachineMetrics:                 struct{}{},
 	CPUTopologyMetrics:             struct{}{},
 	ResctrlMetrics:                 struct{}{},
 	CPUSetMetrics:                  struct{}{},

--- a/docs/runtime_options.md
+++ b/docs/runtime_options.md
@@ -128,8 +128,8 @@ cAdvisor stores the latest historical data in memory. How long of a history it s
 --application_metrics_count_limit=100: Max number of application metrics to store (per container) (default 100)
 --collector_cert="": Collector's certificate, exposed to endpoints for certificate based authentication.
 --collector_key="": Key for the collector's certificate
---disable_metrics=<metrics>: comma-separated list of metrics to be disabled. Options are accelerator,advtcp,app,cpu,cpuLoad,cpu_topology,cpuset,disk,diskIO,hugetlb,memory,memory_numa,network,oom_event,percpu,perf_event,process,referenced_memory,resctrl,sched,tcp,udp. (default advtcp,cpu_topology,cpuset,hugetlb,memory_numa,process,referenced_memory,resctrl,sched,tcp,udp)
---enable_metrics=<metrics>: comma-separated list of metrics to be enabled. If set, overrides 'disable_metrics'. Options are accelerator,advtcp,app,cpu,cpuLoad,cpu_topology,cpuset,disk,diskIO,hugetlb,memory,memory_numa,network,oom_event,percpu,perf_event,process,referenced_memory,resctrl,sched,tcp,udp.
+--disable_metrics=<metrics>: comma-separated list of metrics to be disabled. Options are accelerator,advtcp,app,cpu,cpuLoad,cpu_topology,cpuset,disk,diskIO,hugetlb,machine,memory,memory_numa,network,oom_event,percpu,perf_event,process,referenced_memory,resctrl,sched,tcp,udp. (default advtcp,cpu_topology,cpuset,hugetlb,memory_numa,process,referenced_memory,resctrl,sched,tcp,udp)
+--enable_metrics=<metrics>: comma-separated list of metrics to be enabled. If set, overrides 'disable_metrics'. Options are accelerator,advtcp,app,cpu,cpuLoad,cpu_topology,cpuset,disk,diskIO,hugetlb,machine,memory,memory_numa,network,oom_event,percpu,perf_event,process,referenced_memory,resctrl,sched,tcp,udp.
 --prometheus_endpoint="/metrics": Endpoint to expose Prometheus metrics on (default "/metrics")
 --disable_root_cgroup_stats=false: Disable collecting root Cgroup stats
 ```

--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -108,14 +108,14 @@ The table below lists the Prometheus hardware metrics exposed by cAdvisor (in al
 Metric name | Type | Description | Unit (where applicable) | option parameter | addional build flag |
 :-----------|:-----|:------------|:------------------------|:---------------------------|:--------------------
 `machine_cpu_cache_capacity_bytes` | Gauge |  Cache size in bytes assigned to NUMA node and CPU core | bytes | cpu_topology |
-`machine_cpu_cores` | Gauge | Number of logical CPU cores | | |
-`machine_cpu_physical_cores` | Gauge | Number of physical CPU cores | | |
-`machine_cpu_sockets` | Gauge | Number of CPU sockets | | |
-`machine_dimm_capacity_bytes` | Gauge | Total RAM DIMM capacity (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 | bytes | | |
-`machine_dimm_count` | Gauge | Number of RAM DIMM (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 | | |
-`machine_memory_bytes` | Gauge | Amount of memory installed on the machine | bytes | |
+`machine_cpu_cores` | Gauge | Number of logical CPU cores | | machine |
+`machine_cpu_physical_cores` | Gauge | Number of physical CPU cores | | machine |
+`machine_cpu_sockets` | Gauge | Number of CPU sockets | | machine |
+`machine_dimm_capacity_bytes` | Gauge | Total RAM DIMM capacity (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 | bytes | machine | |
+`machine_dimm_count` | Gauge | Number of RAM DIMM (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 | | machine |
+`machine_memory_bytes` | Gauge | Amount of memory installed on the machine | bytes | machine |
 `machine_node_hugepages_count` | Gauge |  Numer of hugepages assigned to NUMA node | | cpu_topology |
 `machine_node_memory_capacity_bytes` | Gauge |  Amount of memory assigned to NUMA node | bytes | cpu_topology |
-`machine_nvm_avg_power_budget_watts` | Gauge |  NVM power budget | watts | | libipmctl
-`machine_nvm_capacity` | Gauge | NVM capacity value labeled by NVM mode (memory mode or app direct mode) | bytes | | libipmctl
+`machine_nvm_avg_power_budget_watts` | Gauge |  NVM power budget | watts | machine | libipmctl
+`machine_nvm_capacity` | Gauge | NVM capacity value labeled by NVM mode (memory mode or app direct mode) | bytes | machine | libipmctl
 `machine_thread_siblings_count` | Gauge | Number of CPU thread siblings | | cpu_topology |

--- a/metrics/prometheus_machine.go
+++ b/metrics/prometheus_machine.go
@@ -70,14 +70,17 @@ type PrometheusMachineCollector struct {
 // NewPrometheusMachineCollector returns a new PrometheusCollector.
 func NewPrometheusMachineCollector(i infoProvider, includedMetrics container.MetricSet) *PrometheusMachineCollector {
 	c := &PrometheusMachineCollector{
-
 		infoProvider: i,
 		errors: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: "machine",
 			Name:      "scrape_error",
 			Help:      "1 if there was an error while getting machine metrics, 0 otherwise.",
 		}),
-		machineMetrics: []machineMetric{
+		machineMetrics: []machineMetric{},
+	}
+
+	if includedMetrics.Has(container.MachineMetrics) {
+		c.machineMetrics = append(c.machineMetrics, []machineMetric{
 			{
 				name:      "machine_cpu_physical_cores",
 				help:      "Number of physical CPU cores.",
@@ -150,7 +153,7 @@ func NewPrometheusMachineCollector(i infoProvider, includedMetrics container.Met
 					return metricValues{{value: float64(machineInfo.NVMInfo.AvgPowerBudget), timestamp: machineInfo.Timestamp}}
 				},
 			},
-		},
+		}...)
 	}
 
 	if includedMetrics.Has(container.CPUTopologyMetrics) {


### PR DESCRIPTION
Resolves #3098 

Adds a flag for optionally disabling machine metrics.

- [x] Background and issue: #3098 
- [x] Add flag
- [x] Ensure it's enabled by default
- [x] Update docs (metric and runtime options)
- [ ] Pass tests and lint
- [ ] Ensure this is documented in release notes and changelog

_(I'm cross-compiling from Mac, unable to run tests locally yet, will rely on github PR checks for now)_