### PR TITLE
Retry when we get a unknown status from containerd task API

### DIFF
--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -24,6 +24,7 @@ import (
 	containersapi "github.com/containerd/containerd/api/services/containers/v1"
 	tasksapi "github.com/containerd/containerd/api/services/tasks/v1"
 	versionapi "github.com/containerd/containerd/api/services/version/v1"
+	tasktypes "github.com/containerd/containerd/api/types/task"
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/google/cadvisor/container/containerd/containers"
 	"github.com/google/cadvisor/container/containerd/errdefs"
@@ -113,6 +114,9 @@ func (c *client) TaskPid(ctx context.Context, id string) (uint32, error) {
 	})
 	if err != nil {
 		return 0, errdefs.FromGRPC(err)
+	}
+	if response.Process.Status == tasktypes.StatusUnknown {
+		return 0, errdefs.ErrUnknown
 	}
 	return response.Process.Pid, nil
 }


### PR DESCRIPTION
Let's check if `response.Process.Status` is `tasktypes.Status_UNKNOWN` and ensure we retry under this condition as it is most probably a context timeout on containerd side as mentioned here:

https://github.com/kubernetes/kubernetes/pull/109608#issuecomment-1106653373

got some inspiration from:

https://github.com/containerd/containerd/blob/3633cae64b0dc854764f3f121d6739d5c05b5c2a/container.go#L388-L405

Signed-off-by: Davanum Srinivas <davanum@gmail.com>