### PR TITLE
Add support for building multi-arch images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 cadvisor
 /release
 .vscode
+_output/
 
 # Log files
 *.log

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,6 @@ GOLANGCI_VER := v1.45.2
 GO_TEST ?= $(GO) test $(or $(GO_FLAGS),-race)
 arch ?= $(shell go env GOARCH)
 
-ifeq ($(arch), amd64)
-  Dockerfile_tag := ''
-else
-  Dockerfile_tag := '.''$(arch)'
-endif
-
-
 all: presubmit build test
 
 test:
@@ -76,7 +69,7 @@ release:
 	@./build/release.sh
 
 docker-%:
-	@docker build -t cadvisor:$(shell git rev-parse --short HEAD) -f deploy/Dockerfile$(Dockerfile_tag) .
+	@docker build -t cadvisor:$(shell git rev-parse --short HEAD) -f deploy/Dockerfile .
 
 docker-build:
 	@docker run --rm -w /go/src/github.com/google/cadvisor -v ${PWD}:/go/src/github.com/google/cadvisor golang:1.18 make build
@@ -99,5 +92,6 @@ lint:
 
 clean:
 	@rm -f *.test cadvisor
+	@rm -rf _output/
 
 .PHONY: all build docker format release test test-integration lint presubmit tidy

--- a/build/check_container.sh
+++ b/build/check_container.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Description:
+# This script is meant to run a basic test against each of the CPU architectures
+# cadvisor should support.
+#
+# This script requires that you have run qemu-user-static so that your machine
+# can interpret ELF binaries for other architectures using QEMU:
+# https://github.com/multiarch/qemu-user-static#getting-started
+#
+# $ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+#
+# Usage:
+# ./check_container.sh gcr.io/tstapler-gke-dev/cadvisor:v0.44.1-test-4
+target_image=$1
+
+# Architectures officially supported by cadvisor
+arches=( "amd64" "arm" "arm64" )
+
+# Docker doesn't handle images with different architectures but the same tag.
+# Remove the container and the image use by it to avoid problems.
+cleanup() {
+    echo Cleaning up the container $1
+    docker stop $1
+    docker rmi $target_image
+    echo
+}
+
+for arch in "${arches[@]}"; do
+  echo Testing that we can run $1 on $arch and curl the /healthz endpoint
+  echo
+  container_id=$(docker run --platform "linux/$arch" -p 8080:8080 --rm --detach "$target_image")
+  docker_exit_code=$?
+  if [ $docker_exit_code -ne 0 ]; then
+    echo Failed to run container docker exited with $docker_exit_code
+    cleanup $container_id
+    exit $docker_exit_code
+  fi
+  sleep 10
+  echo
+  echo Testing the container with curl:
+  curl --show-error --retry 5 --fail -L 127.0.0.1:8080/healthz
+  echo
+  echo
+  curl_exit=$?
+  if [ $curl_exit -ne 0 ]; then
+    echo  Curling $target_image did not work
+    cleanup $container_id
+    exit $curl_exit
+  fi
+  echo Success!
+  echo
+  cleanup $container_id
+done

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -26,10 +26,10 @@ function delete() {
     rm -rf "${TMPDIR}"
   fi
 }
-trap delete EXIT INT
+trap delete EXIT INT TERM
 
 function run_tests() {
-  BUILD_CMD="env GOOS=linux GO_FLAGS='$GO_FLAGS' ./build/build.sh amd64 && \
+  BUILD_CMD="env GOOS=linux GOARCH=amd64 GO_FLAGS='$GO_FLAGS' ./build/build.sh && \
     env GOOS=linux GOFLAGS='$GO_FLAGS' go test -c github.com/google/cadvisor/integration/tests/api && \
     env GOOS=linux GOFLAGS='$GO_FLAGS' go test -c github.com/google/cadvisor/integration/tests/healthz"
 

--- a/build/release.sh
+++ b/build/release.sh
@@ -16,12 +16,20 @@
 
 set -e
 
-VERSION=$( git describe --tags --dirty --abbrev=14 | sed -E 's/-([0-9]+)-g/.\1+/' )
-# Only allow releases of tagged versions.
-TAGGED='^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.?[0-9]*)?$'
-if [[ ! "$VERSION" =~ $TAGGED ]]; then
-  echo "Error: Only tagged versions are allowed for releases" >&2
-  echo "Found: $VERSION" >&2
+if [ -z "$VERSION" ]; then
+  VERSION=$( git describe --tags --dirty --abbrev=14 | sed -E 's/-([0-9]+)-g/.\1+/' )
+  # Only allow releases of tagged versions.
+  TAGGED='^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.?[0-9]*)?$'
+  if [[ ! "$VERSION" =~ $TAGGED ]]; then
+    echo "Error: Only tagged versions are allowed for releases" >&2
+    echo "Found: $VERSION" >&2
+    exit 1
+  fi
+fi
+
+read -p "Please confirm: $VERSION is the desired version (Type y/n to continue):" -n 1 -r
+echo
+if ! [[ $REPLY =~ ^[Yy]$ ]]; then
   exit 1
 fi
 
@@ -36,31 +44,49 @@ export BUILD_USER="$git_user"
 export BUILD_DATE=$( date +%Y%m%d ) # Release date is only to day-granularity
 export VERBOSE=true
 
-# Build the release binary with libpfm4 for docker container
-export GO_FLAGS="-tags=libpfm,netgo"
-build/build.sh
-
 # Build the docker image
 echo ">> building cadvisor docker image"
-gcr_tag="gcr.io/cadvisor/cadvisor:$VERSION"
-docker build -t $gcr_tag -f deploy/Dockerfile .
+image_name=${IMAGE_NAME:-"gcr.io/cadvisor/cadvisor"}
+final_image="$image_name:${VERSION}"
 
-# Build the release binary without libpfm4 to not require libpfm4 in runtime environment
-unset GO_FLAGS
-build/build.sh
+docker buildx inspect cadvisor-builder > /dev/null \
+|| docker buildx create --name cadvisor-builder --use
 
-echo
-echo "double-check the version below:"
-echo "VERSION=$VERSION"
-echo
-echo "To push docker image to gcr:"
-echo "docker push $gcr_tag"
-echo
-echo "Release info (copy to the release page):"
-echo
-echo "Docker Image: N/A"
-echo "gcr.io Image: $gcr_tag"
-echo
-sha256sum --tag cadvisor
+# Build binaries
 
+# A mapping of the docker arch name to the qemu arch name
+declare -A arches=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64")
+
+for arch in "${arches[@]}"; do
+  if ! hash "qemu-${arch}-static"; then
+    echo Releasing multi arch containers requires qemu-user-static.
+    echo
+    echo Please install using apt-get install qemu-user-static or
+    echo a similar package for your OS.
+
+    exit 1
+  fi
+done
+
+for arch in "${!arches[@]}"; do
+  GOARCH="$arch" OUTPUT_NAME_WITH_ARCH="true" build/build.sh
+  arch_specific_image="${image_name}-${arch}:${VERSION}"
+  docker buildx build --platform "linux/${arch}" --build-arg VERSION="$VERSION" -f deploy/Dockerfile -t "$arch_specific_image"  --progress plain --push .
+  docker manifest create --amend "$final_image" "$arch_specific_image"
+  docker manifest annotate --os=linux --arch="$arch" "$final_image" "$arch_specific_image"
+done
+docker manifest push "$final_image"
+echo
+echo "Release info (copy to the release page)":
+echo
+echo Multi Arch Container Image:
+echo $final_image
+echo
+echo Architecture Specific Container Images:
+for arch in "${!arches[@]}"; do
+  echo "${image_name}-${arch}:${VERSION}"
+done
+echo
+echo Binaries:
+(cd _output && find . -name "cadvisor-${VERSION}*" -exec sha256sum --tag {} \;)
 exit 0

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3.15 AS build
+FROM mirror.gcr.io/library/golang:1.18-alpine3.16 AS build
 
-RUN apk --no-cache add libc6-compat device-mapper findutils zfs build-base linux-headers python3 bash git wget cmake pkgconfig ndctl-dev && \
+# Install build depdencies for all supported arches
+RUN apk --no-cache add bash build-base cmake device-mapper findutils git \
+                       libc6-compat linux-headers ndctl-dev pkgconfig python3 wget zfs && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
-    apk --no-cache add go==1.16.10-r0 --repository http://dl-3.alpinelinux.org/alpine/v3.14/community/ && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     rm -rf /var/cache/apk/*
 
@@ -15,35 +16,48 @@ RUN export DBG="-g -Wall" && \
   make -e -C libpfm-4.11.0 && \
   make install -C libpfm-4.11.0
 
-RUN git clone -b v02.00.00.3820 https://github.com/intel/ipmctl/ && \
+# ipmctl only supports Intel x86_64 processors.
+# https://github.com/intel/ipmctl/issues/163
+RUN if [ "$(uname --machine)" = "x86_64" ]; then \
+    git clone -b v02.00.00.3885 https://github.com/intel/ipmctl/ && \
     cd ipmctl && \
     mkdir output && \
     cd output && \
     cmake -DRELEASE=ON -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_INSTALL_LIBDIR=/usr/local/lib .. && \
     make -j all && \
-    make install
+    make install; fi
 
-ADD . /go/src/github.com/google/cadvisor
 WORKDIR /go/src/github.com/google/cadvisor
 
-ENV GOROOT /usr/lib/go
-ENV GOPATH /go
-ENV GO_FLAGS="-tags=libpfm,netgo,libipmctl"
+# Cache Golang Dependencies for faster incremental builds
+ADD go.mod go.sum ./
+RUN go mod download
+ADD cmd/go.mod cmd/go.sum ./cmd/
+RUN cd cmd && go mod download
 
-RUN ./build/build.sh
+ADD . .
 
-FROM alpine:3.15
+ARG VERSION
+
+# libipmctl only works on x86_64 CPUs.
+RUN export GO_TAGS="-tags=libfpm,netgo"; \
+    if [ "$(uname --machine)" = "x86_64" ]; then \
+          export GO_TAGS="$GO_TAGS,libipmctl"; \
+    fi; \
+    GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
+
+FROM mirror.gcr.io/library/alpine:3.16
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
-RUN apk --no-cache add libc6-compat device-mapper findutils zfs ndctl && \
+RUN apk --no-cache add libc6-compat device-mapper findutils ndctl zfs && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     rm -rf /var/cache/apk/*
 
-# Grab cadvisor,libpfm4 and libipmctl from "build" container.
+# Grab cadvisor,libpfm4 and libipmctl from "build" container if they exist (libipmctl only works on amd64/x86_64).
 COPY --from=build /usr/local/lib/libpfm.so* /usr/local/lib/
 COPY --from=build /usr/local/lib/libipmctl.so* /usr/local/lib/
-COPY --from=build /go/src/github.com/google/cadvisor/cadvisor /usr/bin/cadvisor
+COPY --from=build /go/src/github.com/google/cadvisor/_output/cadvisor /usr/bin/cadvisor
 
 EXPOSE 8080
 

--- a/deploy/Dockerfile.ppc64le
+++ b/deploy/Dockerfile.ppc64le
@@ -1,5 +1,7 @@
 FROM ppc64le/alpine:3.15
 MAINTAINER dashpole@google.com lysannef@us.ibm.com
+# Deprecated: the Dockerfile in this directory should support ppc64le
+# Simply build using: docker buildx build --platform linux/ppc64le -f Dockerfile .
 
 RUN apk --no-cache add libc6-compat device-mapper findutils zfs && \
     apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \


### PR DESCRIPTION
I took a prototype by @bobbypage and added support for additional architectures, simplified the docker build, and  wrote a script to test the images generated by release.sh.

Note: My GCR repository is private you'll have to use your own container registry that you have permissions to.
```
VERSION=v0.44.1-test-8 IMAGE_NAME=gcr.io/tstapler-gke-dev/cadvisor make release
```

Starting each of the images and curling the healthz endpoint:
```
build/check_container.sh gcr.io/tstapler-gke-dev/cadvisor:v0.44.1-test-8
Testing that we can run gcr.io/tstapler-gke-dev/cadvisor:v0.44.1-test-8 on ppc64le and curl the /healthz endpoint

Unable to find image 'gcr.io/tstapler-gke-dev/cadvisor:v0.44.1-test-8' locally
v0.44.1-test-8: Pulling from tstapler-gke-dev/cadvisor
602896d44249: Already exists
e803f340c0e7: Pulling fs layer
68310738913e: Pulling fs layer
4f4fb700ef54: Pulling fs layer
cab919d5ac51: Pulling fs layer
cab919d5ac51: Waiting
4f4fb700ef54: Verifying Checksum
4f4fb700ef54: Download complete
68310738913e: Verifying Checksum
68310738913e: Download complete
e803f340c0e7: Verifying Checksum
e803f340c0e7: Download complete
cab919d5ac51: Verifying Checksum
cab919d5ac51: Download complete
e803f340c0e7: Pull complete
68310738913e: Pull complete
4f4fb700ef54: Pull complete
cab919d5ac51: Pull complete
Digest: sha256:00a2e625014c262f7cef381451cebad48d46908549f1f508797865bbaf072aaa
Status: Downloaded newer image for gcr.io/tstapler-gke-dev/cadvisor:v0.44.1-test-8

Testing the container with curl:
ok

Success!

Cleaning up the container 9f6aebe538c2775030b0c31d7bb875b0f00b54d913c28898ac7ad2d1f36e2694
9f6aebe538c2775030b0c31d7bb875b0f00b54d913c28898ac7ad2d1f36e2694
Untagged: gcr.io/tstapler-gke-dev/cadvisor:v0.44.1-test-8
Untagged: gcr.io/tstapler-gke-dev/cadvisor@sha256:00a2e625014c262f7cef381451cebad48d46908549f1f508797865bbaf072aaa
Deleted: sha256:c15692c504860fe061c739af8d7c1113b5f3c90b738b1fbd5ce7f1526eb58bdf
Deleted: sha256:f9bdfbb0c703807ba7314b93da1ca15b1acebf9c950c08c5699ff693992d42ae
Deleted: sha256:49d7509cfbf1e63e49f864238813d32a56f7a768885f9a01a99634c90238007b
Deleted: sha256:5ad517b5d81b6af6b0b88a8d9c604b7d0454deaaf674584e74b88dd3f287f59b
Deleted: sha256:1b228a3ba7f23b82e9e9f8f07bfea8caf7c8e6cb9a35097fe325592b53f6ad61

Testing that we can run gcr.io/tstapler-gke-dev/cadvisor:v0.44.1-test-8 on arm and curl the /healthz endpoint
...
```

![image](https://user-images.githubusercontent.com/3860386/181136636-1ab8c6dc-81a7-4bf3-8c98-38996a241316.png)


Co-authored-by: David Porter <porterdavid@google.com>
Signed-of-by: Tyler Stapler <tystapler@gmail.com>