### PR TITLE
Remove cgroupv2 log warning

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -155,9 +155,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, houskeepingConfig
 	selfContainer := "/"
 	var err error
 	// Avoid using GetOwnCgroupPath on cgroup v2 as it is not supported by libcontainer
-	if cgroups.IsCgroup2UnifiedMode() {
-		klog.Warningf("Cannot detect current cgroup on cgroup v2")
-	} else {
+	if !cgroups.IsCgroup2UnifiedMode() {
 		selfContainer, err = cgroups.GetOwnCgroup("cpu")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Remove cgroupv2 related log warning as it confused users and doesn't
provide any value.

Fixed https://github.com/google/cadvisor/issues/3121

Signed-off-by: David Porter <porterdavid@google.com>