### PR TITLE
Disable cgo for static binaries

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -18,6 +18,7 @@ set -e
 
 export GOOS=${GOOS:-$(go env GOOS)}
 export GOARCH=${GOARCH:-$(go env GOARCH)}
+export CGO_ENABLED=${GO_CGO_ENABLED:-"1"}
 GO_FLAGS=${GO_FLAGS:-"-tags netgo"}    # Extra go flags to use in the build.
 BUILD_USER=${BUILD_USER:-"${USER}@${HOSTNAME}"}
 BUILD_DATE=${BUILD_DATE:-$( date +%Y%m%d-%H:%M:%S )}

--- a/build/release.sh
+++ b/build/release.sh
@@ -69,7 +69,7 @@ for arch in "${arches[@]}"; do
 done
 
 for arch in "${!arches[@]}"; do
-  GOARCH="$arch" OUTPUT_NAME_WITH_ARCH="true" build/build.sh
+  GOARCH="$arch" GO_CGO_ENABLED="0" OUTPUT_NAME_WITH_ARCH="true" build/build.sh
   arch_specific_image="${image_name}-${arch}:${VERSION}"
   docker buildx build --platform "linux/${arch}" --build-arg VERSION="$VERSION" -f deploy/Dockerfile -t "$arch_specific_image"  --progress plain --push .
   docker manifest create --amend "$final_image" "$arch_specific_image"


### PR DESCRIPTION
This is to avoid depending on glibc which can be quite old on certain
distros. For the docker image, since glibc is part of the container,
there is no reason to disable cgo.

Fixes #3044

Signed-off-by: David Porter <david@porter.me>