### PR TITLE
Add response headers to containers page

### DIFF
--- a/cmd/internal/api/versions.go
+++ b/cmd/internal/api/versions.go
@@ -455,8 +455,12 @@ func (api *version2_0) HandleRequest(requestType string, request []string, m man
 		klog.V(4).Infof("Api - Spec for container %q, options %+v", name, opt)
 		ps, err := m.GetProcessList(name, opt)
 		if err != nil {
-			return fmt.Errorf("process listing failed: %v", err)
-		}
+                        klog.Errorf("Process listing failed: %v", err)
+                        // Process listing failed since the process is not running/found on the machine.
+                        // Set the header accordingly and return the error.
+                        w.WriteHeader(http.StatusNotFound)
+                        return fmt.Errorf("Process listing failed.")
+                }
 		return writeResult(ps, w)
 	default:
 		return fmt.Errorf("unknown request type %q", requestType)

--- a/cmd/internal/pages/containers.go
+++ b/cmd/internal/pages/containers.go
@@ -164,6 +164,10 @@ func printUnit(bytes uint64) string {
 }
 
 func serveContainersPage(m manager.Manager, w http.ResponseWriter, u *url.URL) {
+
+        w.Header().Set("Content-Security-Policy", "default-src 'self'")
+        w.Header().Set("X-Frame-Options", "DENY")
+
 	start := time.Now()
 
 	// The container name is the path after the handler


### PR DESCRIPTION
Add 'Content-Security-Policy' and 'X-Frame-Options' response headers to /containers/ page requests for security reasons. Also, avoided disclosing application error message for 'api/v2.0/ps' endpoint.