### PR TITLE
Use total_pgfault and total_pgmajfault from mem.stat for hierachical metrics

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -821,10 +821,14 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	}
 	if v, ok := s.MemoryStats.Stats["pgfault"]; ok {
 		ret.Memory.ContainerData.Pgfault = v
+	}
+	if v, ok := s.MemoryStats.Stats["total_pgfault"]; ok {
 		ret.Memory.HierarchicalData.Pgfault = v
 	}
 	if v, ok := s.MemoryStats.Stats["pgmajfault"]; ok {
 		ret.Memory.ContainerData.Pgmajfault = v
+	}
+	if v, ok := s.MemoryStats.Stats["total_pgmajfault"]; ok {
 		ret.Memory.HierarchicalData.Pgmajfault = v
 	}
 


### PR DESCRIPTION
Hi,

This MR is to update to use total_pgfault & total_pgmajfault for hierarchical memory data.

As mentioned in kernel doc, pgfault & pgmajfault in mem.stat should be local value of the cgroup, and total_* is for the hierachy. 
- https://github.com/torvalds/linux/blame/master/Documentation/admin-guide/cgroup-v1/memory.rst#L524
- https://github.com/torvalds/linux/blame/master/Documentation/admin-guide/cgroup-v1/memory.rst#L560-L563
(The doc is for cgroupv1 but looks like cgroupv2 uses the same concept)

Signed-off-by: Nguyen Phan Huy <phanhuy1502@gmail.com>