### PR TITLE
Revert "dockerfile: Fix typo in go build tags."

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -40,11 +40,11 @@ ADD . .
 ARG VERSION
 
 # libipmctl only works on x86_64 CPUs.
-RUN export GO_TAGS="--tags=libpfm,netgo"; \
+RUN export GO_TAGS="-tags=libfpm,netgo"; \
     if [ "$(uname --machine)" = "x86_64" ]; then \
           export GO_TAGS="$GO_TAGS,libipmctl"; \
     fi; \
-    GO_FLAGS="$GO_TAGS" ./build/build.sh
+    GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
 
 FROM mirror.gcr.io/library/alpine:3.16
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com


### PR DESCRIPTION
Reverts google/cadvisor#3237

This is breaking the release build:

```
$ make release

...


#19 [build 12/12] RUN export GO_TAGS="--tags=libpfm,netgo";     if [ "$(uname --machine)" = "x86_64" ]; then           export GO_TAGS="$GO_TAGS,libipmctl";     fi;     GO_FLAGS="$GO_TAGS" ./build/build.sh
#19 1.443 >> building cadvisor
#19 73.36 # github.com/google/cadvisor/perf
#19 73.36 ../perf/collector_libpfm.go:256:34: cannot use _Ctype_ulong(unsafe.Sizeof(unix.PerfEventAttr{})) (constant 128 of type _Ctype_ulong) as type _Ctype_uint in argument to (_Cfunc__CMalloc)
#19 73.36 ../perf/collector_libpfm.go:258:61: cannot use _Ctype_ulong(unsafe.Sizeof(unix.PerfEventAttr{})) (constant 128 of type _Ctype_ulong) as type _Ctype_uint in variable declaration
#19 73.36 ../perf/collector_libpfm.go:271:15: cannot use _Ctype_ulong(unsafe.Sizeof(event)) (constant 24 of type _Ctype_ulong) as type _Ctype_uint in assignment
#19 ERROR: process "/bin/sh -c export GO_TAGS=\"--tags=libpfm,netgo\";     if [ \"$(uname --machine)\" = \"x86_64\" ]; then           export GO_TAGS=\"$GO_TAGS,libipmctl\";     fi;     GO_FLAGS=\"$GO_TAGS\" ./build/build.sh" did not complete successfully: exit code: 2
------
 > [build 12/12] RUN export GO_TAGS="--tags=libpfm,netgo";     if [ "$(uname --machine)" = "x86_64" ]; then           export GO_TAGS="$GO_TAGS,libipmctl";     fi;     GO_FLAGS="$GO_TAGS" ./build/build.sh:
#19 1.443 >> building cadvisor
#19 73.36 # github.com/google/cadvisor/perf
#19 73.36 ../perf/collector_libpfm.go:256:34: cannot use _Ctype_ulong(unsafe.Sizeof(unix.PerfEventAttr{})) (constant 128 of type _Ctype_ulong) as type _Ctype_uint in argument to (_Cfunc__CMalloc)
#19 73.36 ../perf/collector_libpfm.go:258:61: cannot use _Ctype_ulong(unsafe.Sizeof(unix.PerfEventAttr{})) (constant 128 of type _Ctype_ulong) as type _Ctype_uint in variable declaration
#19 73.36 ../perf/collector_libpfm.go:271:15: cannot use _Ctype_ulong(unsafe.Sizeof(event)) (constant 24 of type _Ctype_ulong) as type _Ctype_uint in assignment
------
Dockerfile:43
--------------------
  42 |     # libipmctl only works on x86_64 CPUs.
  43 | >>> RUN export GO_TAGS="--tags=libpfm,netgo"; \
  44 | >>>     if [ "$(uname --machine)" = "x86_64" ]; then \
  45 | >>>           export GO_TAGS="$GO_TAGS,libipmctl"; \
  46 | >>>     fi; \
  47 | >>>     GO_FLAGS="$GO_TAGS" ./build/build.sh
  48 |
--------------------
ERROR: failed to solve: process "/bin/sh -c export GO_TAGS=\"--tags=libpfm,netgo\";     if [ \"$(uname --machine)\" = \"x86_64\" ]; then           export GO_TAGS=\"$GO_TAGS,libipmctl\";     fi;     GO_FLAGS=\"$GO_TAGS\" ./build/build.sh" did not complete successfully: exit code: 2
make: *** [Makefile:69: release] Error 1

```

See full logs - https://gist.github.com/bobbypage/25570419f1d59f7b0fcbae9f1540be5b