### PR TITLE
[containerd-cri]Set HasFilesystem to true

### DIFF
--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -286,7 +286,7 @@ func (h *containerdContainerHandler) needNet() bool {
 func (h *containerdContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	// TODO: Since we dont collect disk usage stats for containerd, we set hasFilesystem
 	// to false. Revisit when we support disk usage stats for containerd
-	hasFilesystem := false
+	hasFilesystem := true
 	spec, err := common.GetSpec(h.cgroupPaths, h.machineInfoFactory, h.needNet(), hasFilesystem)
 	spec.Labels = h.labels
 	spec.Envs = h.envs


### PR DESCRIPTION
This PR sets the hasFilesystem to true in `containerd-cri` branch to collect `ContainerFS` metrics. Referring to this [comment](https://github.com/google/cadvisor/issues/2785#issuecomment-1204837267).

```
    "Timestamp": "1677108918008",
    "Type": "ContainerFS",
    "Version": "0",
    "container_filesystem_available": 0,
    "container_filesystem_capacity": 85886742528,
    "container_filesystem_usage": 3396182016,
    "container_filesystem_utilization": 3.954256403300903,
    "device": "/dev/nvme0n1p1",
    "fstype": "vfs",
    "kubernetes": {
        "container_name": "coredns",
        "containerd": {
            "container_id": "dfd1a40358cd9e3ee41c09753943a75f1d20450abad921de68e326678d622ba3"
        },