### PR TITLE
sysinfo: Ignore "hidden" sysfs device entries

### DIFF
--- a/utils/sysfs/fakesysfs/fake.go
+++ b/utils/sysfs/fakesysfs/fake.go
@@ -128,6 +128,10 @@ func (fs *FakeSysFs) GetBlockDeviceNumbers(name string) (string, error) {
 	return "8:0\n", nil
 }
 
+func (fs *FakeSysFs) IsBlockDeviceHidden(name string) (bool) {
+	return false
+}
+
 func (fs *FakeSysFs) GetNetworkDevices() ([]os.FileInfo, error) {
 	return []os.FileInfo{&fs.info}, nil
 }

--- a/utils/sysfs/sysfs.go
+++ b/utils/sysfs/sysfs.go
@@ -102,6 +102,9 @@ type SysFs interface {
 	GetBlockDeviceScheduler(string) (string, error)
 	// Get device major:minor number string.
 	GetBlockDeviceNumbers(string) (string, error)
+	// Is the device "hidden" (meaning will not have a device handle)
+	// This is the case with native nvme multipathing.
+	IsBlockDeviceHidden(string) (bool)
 
 	GetNetworkDevices() ([]os.FileInfo, error)
 	GetNetworkAddress(string) (string, error)
@@ -199,6 +202,19 @@ func (fs *realSysFs) GetBlockDeviceNumbers(name string) (string, error) {
 		return "", err
 	}
 	return string(dev), nil
+}
+
+func (fs *realSysFs) IsBlockDeviceHidden(name string) (bool) {
+	hidden, err := ioutil.ReadFile(path.Join(blockDir, name, "/hidden"))
+	if err != nil {
+		// older OS may not have /hidden sysfs entry, so for sure
+		// it is not a hidden device...
+		return false
+	}
+	if string(hidden) == "1" {
+		return true
+	}
+	return false
 }
 
 func (fs *realSysFs) GetBlockDeviceScheduler(name string) (string, error) {

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -57,6 +57,12 @@ func GetBlockDeviceInfo(sysfs sysfs.SysFs) (map[string]info.DiskInfo, error) {
 		if strings.HasPrefix(name, "loop") || strings.HasPrefix(name, "ram") || strings.HasPrefix(name, "sr") {
 			continue
 		}
+		// Ignore "hidden" devices (i.e. nvme path device sysfs entries).
+		// These devices are in the form of /dev/nvme$Xc$Yn$Z and will
+		// not have a device handle (i.e. "hidden")
+		if sysfs.IsBlockDeviceHidden(name) {
+			continue
+		}
 		diskInfo := info.DiskInfo{
 			Name: name,
 		}


### PR DESCRIPTION
Some devices are "hidden" from userspace due to various reasons. One reason is native nvme multipathing, where the path devices do not present a device node to the user but only exposes the stacking device as the only nvme device. Still there are sysfs attributes for these hidden devices, but we should ignore them altogether because these are not "real" devices at all.