### PR TITLE
reduce useless check in resctrl file system

### DIFF
--- a/resctrl/utils.go
+++ b/resctrl/utils.go
@@ -42,6 +42,8 @@ const (
 	cpusListFileName         = "cpus_list"
 	schemataFileName         = "schemata"
 	tasksFileName            = "tasks"
+	modeFileName             = "mode"
+	sizeFileName             = "size"
 	infoDirName              = "info"
 	monDataDirName           = "mon_data"
 	monGroupsDirName         = "mon_groups"
@@ -72,6 +74,8 @@ var (
 		monGroupsDirName: {},
 		schemataFileName: {},
 		tasksFileName:    {},
+		modeFileName:     {},
+		sizeFileName:     {},
 	}
 )
 

--- a/resctrl/utils_test.go
+++ b/resctrl/utils_test.go
@@ -118,6 +118,14 @@ func mockResctrl() string {
 			touch,
 		},
 		{
+			filepath.Join(path, modeFileName),
+			touch,
+		},
+		{
+			filepath.Join(path, sizeFileName),
+			touch,
+		},
+		{
 			filepath.Join(path, tasksFileName),
 			touch,
 		},


### PR DESCRIPTION
Fix https://github.com/google/cadvisor/issues/3263

In the resctrl file system, there will be automatically created mode and size files, so we can remove the useless check for them in the `findGroup` function.