### PR TITLE
nvm: Decrease the "no nvm devices" warning log.

### DIFF
--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 // getAvgPowerBudget retrieves configured power budget
-// (in watts) for NVM devices. When libipmct is not available
+// (in watts) for NVM devices. When libipmctl is not available
 // zero is returned.
 func getAvgPowerBudget() (uint, error) {
 	// Get number of devices on the platform

--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -61,7 +61,7 @@ func getAvgPowerBudget() (uint, error) {
 	}
 
 	if count == 0 {
-		klog.Warningf("There are no NVM devices!")
+		klog.V(1).Infof("There are no NVM devices.")
 		return uint(0), nil
 	}
 


### PR DESCRIPTION
Official cAdvisor image is built with the `libimpmctl` flag. This causes trying to gather information about non-volatile memory modules.
This log confuses users. It's verbosity should be decreased.

Fixes #3241