### PR TITLE
Revert "Revert "dockerfile: Fix typo in go build tags.""

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -40,11 +40,11 @@ ADD . .
 ARG VERSION
 
 # libipmctl only works on x86_64 CPUs.
-RUN export GO_TAGS="-tags=libfpm,netgo"; \
+RUN export GO_TAGS="--tags=libpfm,netgo"; \
     if [ "$(uname --machine)" = "x86_64" ]; then \
           export GO_TAGS="$GO_TAGS,libipmctl"; \
     fi; \
-    GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
+    GO_FLAGS="$GO_TAGS" ./build/build.sh
 
 FROM mirror.gcr.io/library/alpine:3.16
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com


### PR DESCRIPTION
Reverts google/cadvisor#3250

```
#18 [build 12/12] RUN export GO_TAGS="-tags=libfpm,netgo";     if [ "$(uname --machine)" = "x86_64" ]; then           export GO_TAGS="$GO_TAGS,libipmctl";     fi;     GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
#18 sha256:108c42c1b16ba7719a5eb90cb914e7cf449d49a5e6c8f3b04847a38aa902c657
#18 0.692 >> building cadvisor
#18 DONE 432.9s

```

It seems that bumping up the Go version (e6f8575fc8f959a20376b3ac31630f2144311702) resolved that.