### PR TITLE
fix container_oom_events_total always returns 0.

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -967,8 +967,6 @@ type ContainerStats struct {
 	Resctrl ResctrlStats `json:"resctrl,omitempty"`
 
 	CpuSet CPUSetStats `json:"cpuset,omitempty"`
-
-	OOMEvents uint64 `json:"oom_events,omitempty"`
 }
 
 func timeEq(t1, t2 time.Time, tolerance time.Duration) bool {

--- a/manager/container.go
+++ b/manager/container.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/cadvisor/cache/memory"
@@ -65,7 +64,6 @@ type containerInfo struct {
 }
 
 type containerData struct {
-	oomEvents                uint64
 	handler                  container.ContainerHandler
 	info                     containerInfo
 	memoryCache              *memory.InMemoryCache
@@ -668,8 +666,6 @@ func (cd *containerData) updateStats() error {
 			klog.V(2).Infof("Failed to add summary stats for %q: %v", cd.info.Name, err)
 		}
 	}
-
-	stats.OOMEvents = atomic.LoadUint64(&cd.oomEvents)
 
 	var customStatsErr error
 	cm := cd.collectorManager.(*collector.GenericCollectorManager)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -37,6 +37,7 @@ import (
 	info "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
 	"github.com/google/cadvisor/machine"
+	"github.com/google/cadvisor/metrics"
 	"github.com/google/cadvisor/nvm"
 	"github.com/google/cadvisor/perf"
 	"github.com/google/cadvisor/resctrl"
@@ -144,6 +145,8 @@ type Manager interface {
 	AllPodmanContainers(c *info.ContainerInfoRequest) (map[string]info.ContainerInfo, error)
 
 	PodmanContainer(containerName string, query *info.ContainerInfoRequest) (info.ContainerInfo, error)
+
+	GetOOMInfos() map[string]*oomparser.ContainerOomInfo
 }
 
 // Housekeeping configuration for the manager
@@ -153,7 +156,9 @@ type HousekeepingConfig = struct {
 }
 
 // New takes a memory storage and returns a new manager.
-func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, HousekeepingConfig HousekeepingConfig, includedMetricsSet container.MetricSet, collectorHTTPClient *http.Client, rawContainerCgroupPathPrefixWhiteList, containerEnvMetadataWhiteList []string, perfEventsFile string, resctrlInterval time.Duration) (Manager, error) {
+func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, HousekeepingConfig HousekeepingConfig, includedMetricsSet container.MetricSet,
+	collectorHTTPClient *http.Client, rawContainerCgroupPathPrefixWhiteList, containerEnvMetadataWhiteList []string,
+	perfEventsFile string, resctrlInterval time.Duration, f metrics.ContainerLabelsFunc, oomRetainDuration *time.Duration) (Manager, error) {
 	if memoryCache == nil {
 		return nil, fmt.Errorf("manager requires memory storage")
 	}
@@ -208,6 +213,9 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, HousekeepingConfi
 		collectorHTTPClient:                   collectorHTTPClient,
 		rawContainerCgroupPathPrefixWhiteList: rawContainerCgroupPathPrefixWhiteList,
 		containerEnvMetadataWhiteList:         containerEnvMetadataWhiteList,
+		oomInfos:                              map[string]*oomparser.ContainerOomInfo{},
+		containerLabelFunc:                    f,
+		oomRetainDuration:                     oomRetainDuration,
 	}
 
 	machineInfo, err := machine.Info(sysfs, fsInfo, inHostNamespace)
@@ -247,6 +255,7 @@ type namespacedContainerName struct {
 }
 
 type manager struct {
+	oomInfos                 map[string]*oomparser.ContainerOomInfo
 	containers               map[namespacedContainerName]*containerData
 	containersLock           sync.RWMutex
 	memoryCache              *memory.InMemoryCache
@@ -271,6 +280,8 @@ type manager struct {
 	rawContainerCgroupPathPrefixWhiteList []string
 	// List of container env prefix whitelist, the matched container envs would be collected into metrics as extra labels.
 	containerEnvMetadataWhiteList []string
+	containerLabelFunc            metrics.ContainerLabelsFunc
+	oomRetainDuration             *time.Duration
 }
 
 func (m *manager) PodmanContainer(containerName string, query *info.ContainerInfoRequest) (info.ContainerInfo, error) {
@@ -318,7 +329,7 @@ func (m *manager) Start() error {
 		return err
 	}
 	klog.V(2).Infof("Starting recovery of all containers")
-	err = m.detectSubcontainers("/")
+	err = m.detectSubContainers("/")
 	if err != nil {
 		return err
 	}
@@ -340,6 +351,7 @@ func (m *manager) Start() error {
 	quitUpdateMachineInfo := make(chan error)
 	m.quitChannels = append(m.quitChannels, quitUpdateMachineInfo)
 	go m.updateMachineInfo(quitUpdateMachineInfo)
+	go m.cleanUpOomInfos()
 
 	return nil
 }
@@ -360,6 +372,61 @@ func (m *manager) Stop() error {
 	m.quitChannels = make([]chan error, 0, 2)
 	nvm.Finalize()
 	perf.Finalize()
+	return nil
+}
+
+func (m *manager) GetOOMInfos() map[string]*oomparser.ContainerOomInfo {
+	m.containersLock.RLock()
+	defer m.containersLock.RUnlock()
+	oomInfos := make(map[string]*oomparser.ContainerOomInfo)
+	for k, v := range m.oomInfos {
+		if time.Since(v.TimeOfDeath) > *m.oomRetainDuration {
+			continue
+		}
+		oomInfos[k] = v
+	}
+	return oomInfos
+}
+
+func (m *manager) cleanUpOomInfos() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			m.containersLock.Lock()
+			for k, v := range m.oomInfos {
+				if time.Since(v.TimeOfDeath) > *m.oomRetainDuration {
+					delete(m.oomInfos, k)
+				}
+			}
+			m.containersLock.Unlock()
+		}
+	}
+}
+
+func (m *manager) addOrUpdateOomInfo(cont *containerData, timeOfDeath time.Time) error {
+	m.containersLock.Lock()
+	defer m.containersLock.Unlock()
+
+	contInfo, err := m.containerDataToContainerInfo(cont, &info.ContainerInfoRequest{
+		NumStats: 60,
+	})
+	if err != nil {
+		return err
+	}
+	if oomInfo, ok := m.oomInfos[contInfo.Id]; ok {
+		atomic.AddUint64(&oomInfo.OomEvents, 1)
+		return nil
+	}
+	containerLabels := m.containerLabelFunc(contInfo)
+	newOomInfo := &oomparser.ContainerOomInfo{
+		MetricLabels: containerLabels,
+		TimeOfDeath:  timeOfDeath,
+	}
+	atomic.AddUint64(&newOomInfo.OomEvents, 1)
+	m.oomInfos[contInfo.Id] = newOomInfo
 	return nil
 }
 
@@ -406,7 +473,7 @@ func (m *manager) globalHousekeeping(quit chan error) {
 			start := time.Now()
 
 			// Check for new containers.
-			err := m.detectSubcontainers("/")
+			err := m.detectSubContainers("/")
 			if err != nil {
 				klog.Errorf("Failed to detect containers: %s", err)
 			}
@@ -1056,7 +1123,7 @@ func (m *manager) destroyContainerLocked(containerName string) error {
 
 // Detect all containers that have been added or deleted from the specified container.
 func (m *manager) getContainersDiff(containerName string) (added []info.ContainerReference, removed []info.ContainerReference, err error) {
-	// Get all subcontainers recursively.
+	// Get all subContainers recursively.
 	m.containersLock.RLock()
 	cont, ok := m.containers[namespacedContainerName{
 		Name: containerName,
@@ -1103,8 +1170,8 @@ func (m *manager) getContainersDiff(containerName string) (added []info.Containe
 	return
 }
 
-// Detect the existing subcontainers and reflect the setup here.
-func (m *manager) detectSubcontainers(containerName string) error {
+// Detect the existing subContainers and reflect the setup here.
+func (m *manager) detectSubContainers(containerName string) error {
 	added, removed, err := m.getContainersDiff(containerName)
 	if err != nil {
 		return err
@@ -1147,7 +1214,7 @@ func (m *manager) watchForNewContainers(quit chan error) error {
 	}
 
 	// There is a race between starting the watch and new container creation so we do a detection before we read new containers.
-	err := m.detectSubcontainers("/")
+	err := m.detectSubContainers("/")
 	if err != nil {
 		return err
 	}
@@ -1247,7 +1314,9 @@ func (m *manager) watchForNewOoms() error {
 				continue
 			}
 			for _, cont := range conts {
-				atomic.AddUint64(&cont.oomEvents, 1)
+				if err := m.addOrUpdateOomInfo(cont, oomInstance.TimeOfDeath); err != nil {
+					klog.Errorf("failed to add OOM info for %q: %v", oomInstance.ContainerName, err)
+				}
 			}
 		}
 	}()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 
 	info "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/utils/oomparser"
 )
 
 // metricValue describes a single metric value for a given set of label values
@@ -39,4 +40,6 @@ type infoProvider interface {
 	GetVersionInfo() (*info.VersionInfo, error)
 	// GetMachineInfo provides information about the machine.
 	GetMachineInfo() (*info.MachineInfo, error)
+	// GetOOMInfos provides information about OOMs.
+	GetOOMInfos() map[string]*oomparser.ContainerOomInfo
 }

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -20,6 +20,7 @@ import (
 
 	info "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/utils/oomparser"
 )
 
 type testSubcontainersInfoProvider struct{}
@@ -739,6 +740,23 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 	}, nil
 }
 
+func (p testSubcontainersInfoProvider) GetOOMInfos() map[string]*oomparser.ContainerOomInfo {
+	return map[string]*oomparser.ContainerOomInfo{
+		"testcontainer": {
+			OomEvents:   0,
+			TimeOfDeath: time.Unix(1395066363, 0),
+			MetricLabels: map[string]string{
+				"container_env_foo+env":     "prod",
+				"container_label_foo.label": "bar",
+				"id":                        "testcontainer",
+				"image":                     "test",
+				"name":                      "testcontaineralias",
+				"zone.name":                 "hello",
+			},
+		},
+	}
+}
+
 type erroringSubcontainersInfoProvider struct {
 	successfulProvider testSubcontainersInfoProvider
 	shouldFail         bool
@@ -764,4 +782,11 @@ func (p *erroringSubcontainersInfoProvider) GetRequestedContainersInfo(
 		return map[string]*info.ContainerInfo{}, errors.New("Oops 3")
 	}
 	return p.successfulProvider.GetRequestedContainersInfo(a, opt)
+}
+
+func (p *erroringSubcontainersInfoProvider) GetOOMInfos() map[string]*oomparser.ContainerOomInfo {
+	if p.shouldFail {
+		return map[string]*oomparser.ContainerOomInfo{}
+	}
+	return p.successfulProvider.GetOOMInfos()
 }

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cadvisor/container"
 	info "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/utils/oomparser"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -148,6 +149,10 @@ func (m *mockInfoProvider) GetVersionInfo() (*info.VersionInfo, error) {
 
 func (m *mockInfoProvider) GetMachineInfo() (*info.MachineInfo, error) {
 	return nil, errors.New("not supported")
+}
+
+func (m *mockInfoProvider) GetOOMInfos() map[string]*oomparser.ContainerOomInfo {
+	return nil
 }
 
 func mockLabelFunc(*info.ContainerInfo) map[string]string {

--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/euank/go-kmsg-parser/kmsgparser"
-
 	"k8s.io/klog/v2"
 )
 
@@ -37,6 +36,12 @@ var (
 // individual kernel ring buffer messages.
 type OomParser struct {
 	parser kmsgparser.Parser
+}
+
+type ContainerOomInfo struct {
+	MetricLabels map[string]string
+	OomEvents    uint64
+	TimeOfDeath  time.Time
 }
 
 // struct that contains information related to an OOM kill instance


### PR DESCRIPTION
fix #3015 
In a Kubernetes pod, if a container is OOM-killed, it will be deleted and a new container will be created. Therefore, the `container_oom_events_total` metric will always be 0. this pr refactor the collector of oom events, and retain the deleted container oom information for a period of events. And add flag `oom_event_retain_time` to decide how long the oom event will be keep, default is 5 minutes