### PR TITLE
Optimize network metrics collection

### DIFF
--- a/container/common/helpers.go
+++ b/container/common/helpers.go
@@ -437,3 +437,20 @@ func (m deviceIdentifierMap) Find(major, minor uint64, namer DeviceNamer) string
 	m[d] = s
 	return s
 }
+
+// RemoveNetMetrics is used to remove any network metrics from the given MetricSet.
+// It returns the original set as is if remove is false, or if there are no metrics
+// to remove.
+func RemoveNetMetrics(metrics container.MetricSet, remove bool) container.MetricSet {
+	if !remove {
+		return metrics
+	}
+
+	// Check if there is anything we can remove, to avoid useless copying.
+	if !metrics.HasAny(container.AllNetworkMetrics) {
+		return metrics
+	}
+
+	// A copy of all metrics except for network ones.
+	return metrics.Difference(container.AllNetworkMetrics)
+}

--- a/container/common/helpers_test.go
+++ b/container/common/helpers_test.go
@@ -16,13 +16,16 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/google/cadvisor/container"
 	info "github.com/google/cadvisor/info/v1"
 	v2 "github.com/google/cadvisor/info/v2"
 )
@@ -192,4 +195,55 @@ func TestGetSpecCgroupV2Max(t *testing.T) {
 	assert.EqualValues(t, spec.Cpu.Quota, 0)
 
 	assert.EqualValues(t, spec.Processes.Limit, max)
+}
+
+func TestRemoveNetMetrics(t *testing.T) {
+	for _, ts := range []struct {
+		desc    string
+		in, out container.MetricSet
+	}{
+		{
+			desc: "nil set",
+			in:   nil,
+		},
+		{
+			desc: "empty set",
+			in:   container.MetricSet{},
+		},
+		{
+			desc: "nothing to remove",
+			in:   container.MetricSet{container.MemoryUsageMetrics: struct{}{}, container.PerfMetrics: struct{}{}},
+		},
+		{
+			desc: "also nothing to remove",
+			in:   container.AllMetrics.Difference(container.AllNetworkMetrics),
+		},
+		{
+			desc: "remove net from all",
+			in:   container.AllMetrics,
+			out:  container.AllMetrics.Difference(container.AllNetworkMetrics),
+		},
+		{
+			desc: "remove net from some",
+			in:   container.MetricSet{container.MemoryUsageMetrics: struct{}{}, container.NetworkTcpUsageMetrics: struct{}{}},
+			out:  container.MetricSet{container.MemoryUsageMetrics: struct{}{}},
+		},
+	} {
+		for _, remove := range []bool{true, false} {
+			ts, remove := ts, remove
+			desc := fmt.Sprintf("%s, remove: %v", ts.desc, remove)
+			t.Run(desc, func(t *testing.T) {
+				out := RemoveNetMetrics(ts.in, remove)
+				if !remove || ts.out == nil {
+					// Compare the actual underlying pointers. Can't use assert.Same
+					// because it checks for pointer type, and these are maps.
+					if reflect.ValueOf(ts.in) != reflect.ValueOf(out) {
+						t.Errorf("expected original map %p, got %p", ts.in, out)
+					}
+				} else {
+					assert.Equal(t, ts.out, out)
+				}
+			})
+		}
+	}
 }

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -126,7 +126,14 @@ func newContainerdContainerHandler(
 		Aliases:   []string{id, name},
 	}
 
-	libcontainerHandler := containerlibcontainer.NewHandler(cgroupManager, rootfs, int(taskPid), includedMetrics)
+	// Containers that don't have their own network -- this includes
+	// containers running in Kubernetes pods that use the network of the
+	// infrastructure container -- does not need their stats to be
+	// reported. This stops metrics being reported multiple times for each
+	// container in a pod.
+	metrics := common.RemoveNetMetrics(includedMetrics, cntr.Labels["io.cri-containerd.kind"] != "sandbox")
+
+	libcontainerHandler := containerlibcontainer.NewHandler(cgroupManager, rootfs, int(taskPid), metrics)
 
 	handler := &containerdContainerHandler{
 		machineInfoFactory:  machineInfoFactory,
@@ -134,7 +141,7 @@ func newContainerdContainerHandler(
 		fsInfo:              fsInfo,
 		envs:                make(map[string]string),
 		labels:              cntr.Labels,
-		includedMetrics:     includedMetrics,
+		includedMetrics:     metrics,
 		reference:           containerReference,
 		libcontainerHandler: libcontainerHandler,
 	}
@@ -164,22 +171,12 @@ func (h *containerdContainerHandler) ContainerReference() (info.ContainerReferen
 	return h.reference, nil
 }
 
-func (h *containerdContainerHandler) needNet() bool {
-	// Since containerd does not handle networking ideally we need to return based
-	// on includedMetrics list. Here the assumption is the presence of cri-containerd
-	// label
-	if h.includedMetrics.Has(container.NetworkUsageMetrics) {
-		//TODO change it to exported cri-containerd constants
-		return h.labels["io.cri-containerd.kind"] == "sandbox"
-	}
-	return false
-}
-
 func (h *containerdContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	// TODO: Since we dont collect disk usage stats for containerd, we set hasFilesystem
 	// to false. Revisit when we support disk usage stats for containerd
 	hasFilesystem := false
-	spec, err := common.GetSpec(h.cgroupPaths, h.machineInfoFactory, h.needNet(), hasFilesystem)
+	hasNet := h.includedMetrics.Has(container.NetworkUsageMetrics)
+	spec, err := common.GetSpec(h.cgroupPaths, h.machineInfoFactory, hasNet, hasFilesystem)
 	spec.Labels = h.labels
 	spec.Envs = h.envs
 	spec.Image = h.image
@@ -203,13 +200,6 @@ func (h *containerdContainerHandler) GetStats() (*info.ContainerStats, error) {
 	stats, err := h.libcontainerHandler.GetStats()
 	if err != nil {
 		return stats, err
-	}
-	// Clean up stats for containers that don't have their own network - this
-	// includes containers running in Kubernetes pods that use the network of the
-	// infrastructure container. This stops metrics being reported multiple times
-	// for each container in a pod.
-	if !h.needNet() {
-		stats.Network = info.NetworkStats{}
 	}
 
 	// Get filesystem stats.

--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -148,7 +148,15 @@ func newCrioContainerHandler(
 		Namespace: CrioNamespace,
 	}
 
-	libcontainerHandler := containerlibcontainer.NewHandler(cgroupManager, rootFs, cInfo.Pid, includedMetrics)
+	// Find out if we need network metrics reported for this container.
+	// Containers that don't have their own network -- this includes
+	// containers running in Kubernetes pods that use the network of the
+	// infrastructure container -- does not need their stats to be
+	// reported. This stops metrics being reported multiple times for each
+	// container in a pod.
+	metrics := common.RemoveNetMetrics(includedMetrics, cInfo.Labels["io.kubernetes.container.name"] != "POD")
+
+	libcontainerHandler := containerlibcontainer.NewHandler(cgroupManager, rootFs, cInfo.Pid, metrics)
 
 	// TODO: extract object mother method
 	handler := &crioContainerHandler{
@@ -161,7 +169,7 @@ func newCrioContainerHandler(
 		rootfsStorageDir:    rootfsStorageDir,
 		envs:                make(map[string]string),
 		labels:              cInfo.Labels,
-		includedMetrics:     includedMetrics,
+		includedMetrics:     metrics,
 		reference:           containerReference,
 		libcontainerHandler: libcontainerHandler,
 		cgroupManager:       cgroupManager,
@@ -210,16 +218,10 @@ func (h *crioContainerHandler) ContainerReference() (info.ContainerReference, er
 	return h.reference, nil
 }
 
-func (h *crioContainerHandler) needNet() bool {
-	if h.includedMetrics.Has(container.NetworkUsageMetrics) {
-		return h.labels["io.kubernetes.container.name"] == "POD"
-	}
-	return false
-}
-
 func (h *crioContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	hasFilesystem := h.includedMetrics.Has(container.DiskUsageMetrics)
-	spec, err := common.GetSpec(h.cgroupPaths, h.machineInfoFactory, h.needNet(), hasFilesystem)
+	hasNet := h.includedMetrics.Has(container.NetworkUsageMetrics)
+	spec, err := common.GetSpec(h.cgroupPaths, h.machineInfoFactory, hasNet, hasFilesystem)
 
 	spec.Labels = h.labels
 	spec.Envs = h.envs
@@ -306,13 +308,7 @@ func (h *crioContainerHandler) GetStats() (*info.ContainerStats, error) {
 		return stats, err
 	}
 
-	if !h.needNet() {
-		// Clean up stats for containers that don't have their own network - this
-		// includes containers running in Kubernetes pods that use the network of the
-		// infrastructure container. This stops metrics being reported multiple times
-		// for each container in a pod.
-		stats.Network = info.NetworkStats{}
-	} else if len(stats.Network.Interfaces) == 0 {
+	if h.includedMetrics.Has(container.NetworkUsageMetrics) && len(stats.Network.Interfaces) == 0 {
 		// No network related information indicates that the pid of the
 		// container is not longer valid and we need to ask crio to
 		// provide the pid of another container from that pod

--- a/container/factory.go
+++ b/container/factory.go
@@ -93,6 +93,14 @@ var AllMetrics = MetricSet{
 	OOMMetrics:                     struct{}{},
 }
 
+// AllNetworkMetrics represents all network metrics that cAdvisor supports.
+var AllNetworkMetrics = MetricSet{
+	NetworkUsageMetrics:            struct{}{},
+	NetworkTcpUsageMetrics:         struct{}{},
+	NetworkAdvancedTcpUsageMetrics: struct{}{},
+	NetworkUdpUsageMetrics:         struct{}{},
+}
+
 func (mk MetricKind) String() string {
 	return string(mk)
 }
@@ -102,6 +110,15 @@ type MetricSet map[MetricKind]struct{}
 func (ms MetricSet) Has(mk MetricKind) bool {
 	_, exists := ms[mk]
 	return exists
+}
+
+func (ms MetricSet) HasAny(ms1 MetricSet) bool {
+	for m := range ms1 {
+		if _, ok := ms[m]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (ms MetricSet) add(mk MetricKind) {


### PR DESCRIPTION
Apparently, we collect network stats for all containers, and then discarding some or most of it:

 - for docker, we collect and discard stats for containers which share netns with another container (which is rare I guess);

 - for both crio and containerd, we collect and discard stats for containers that are not infra (sandbox, pod, pause) containers (which is very common).

Instead of reading and parsing a bunch of files in /proc/PID/net and when removing those, let's set things up in a way so we don't collect useless stats in the first place.

This should improve performance, memory usage, and ease the load on garbage collection.