### PR TITLE
export-memory-kernal-usage

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -802,6 +802,7 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	ret.Memory.Usage = s.MemoryStats.Usage.Usage
 	ret.Memory.MaxUsage = s.MemoryStats.Usage.MaxUsage
 	ret.Memory.Failcnt = s.MemoryStats.Usage.Failcnt
+	ret.Memory.KernelUsage = s.MemoryStats.KernelUsage.Usage
 
 	if cgroups.IsCgroup2UnifiedMode() {
 		ret.Memory.Cache = s.MemoryStats.Stats["file"]

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -395,6 +395,10 @@ type MemoryStats struct {
 
 	Failcnt uint64 `json:"failcnt"`
 
+	// Size of kernel memory allocated in bytes.
+	// Units: Bytes.
+	KernelUsage uint64 `json:"kernel"`
+
 	ContainerData    MemoryStatsMemoryData `json:"container_data,omitempty"`
 	HierarchicalData MemoryStatsMemoryData `json:"hierarchical_data,omitempty"`
 }

--- a/info/v1/test/datagen.go
+++ b/info/v1/test/datagen.go
@@ -47,6 +47,7 @@ func GenerateRandomStats(numStats, numCores int, duration time.Duration) []*info
 		stats.Memory.Cache = uint64(rand.Int63n(4096))
 		stats.Memory.RSS = uint64(rand.Int63n(4096))
 		stats.Memory.MappedFile = uint64(rand.Int63n(4096))
+		stats.Memory.KernelUsage = uint64(rand.Int63n(4096))
 		stats.ReferencedMemory = uint64(rand.Int63n(1000))
 		ret[i] = stats
 	}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -378,6 +378,13 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 					return metricValues{{value: float64(s.Memory.RSS), timestamp: s.Timestamp}}
 				},
 			}, {
+				name:      "container_memory_kernel_usage",
+				help:      "Size of kernel memory allocated in bytes.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.KernelUsage), timestamp: s.Timestamp}}
+				},
+			}, {
 				name:      "container_memory_mapped_file",
 				help:      "Size of memory mapped files in bytes.",
 				valueType: prometheus.GaugeValue,

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -350,10 +350,11 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Unevictable: map[uint8]uint64{0: 8900, 1: 20000},
 							},
 						},
-						Cache:      14,
-						RSS:        15,
-						MappedFile: 16,
-						Swap:       8192,
+						Cache:       14,
+						RSS:         15,
+						MappedFile:  16,
+						KernelUsage: 17,
+						Swap:        8192,
 					},
 					Hugetlb: map[string]info.HugetlbStats{
 						"2Mi": {

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -148,6 +148,9 @@ container_memory_failures_total{container_env_foo_env="prod",container_label_foo
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",failure_type="pgfault",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",zone_name="hello"} 12 1395066363000
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",failure_type="pgmajfault",id="testcontainer",image="test",name="testcontaineralias",scope="container",zone_name="hello"} 11 1395066363000
 container_memory_failures_total{container_env_foo_env="prod",container_label_foo_label="bar",failure_type="pgmajfault",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",zone_name="hello"} 13 1395066363000
+# HELP container_memory_kernel_usage Size of kernel memory allocated in bytes.
+# TYPE container_memory_kernel_usage gauge
+container_memory_kernel_usage{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 17 1395066363000
 # HELP container_memory_mapped_file Size of memory mapped files in bytes.
 # TYPE container_memory_mapped_file gauge
 container_memory_mapped_file{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 16 1395066363000

--- a/metrics/testdata/prometheus_metrics_whitelist_filtered
+++ b/metrics/testdata/prometheus_metrics_whitelist_filtered
@@ -148,6 +148,9 @@ container_memory_failures_total{container_env_foo_env="prod",failure_type="pgfau
 container_memory_failures_total{container_env_foo_env="prod",failure_type="pgfault",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",zone_name="hello"} 12 1395066363000
 container_memory_failures_total{container_env_foo_env="prod",failure_type="pgmajfault",id="testcontainer",image="test",name="testcontaineralias",scope="container",zone_name="hello"} 11 1395066363000
 container_memory_failures_total{container_env_foo_env="prod",failure_type="pgmajfault",id="testcontainer",image="test",name="testcontaineralias",scope="hierarchy",zone_name="hello"} 13 1395066363000
+# HELP container_memory_kernel_usage Size of kernel memory allocated in bytes.
+# TYPE container_memory_kernel_usage gauge
+container_memory_kernel_usage{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 17 1395066363000
 # HELP container_memory_mapped_file Size of memory mapped files in bytes.
 # TYPE container_memory_mapped_file gauge
 container_memory_mapped_file{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 16 1395066363000


### PR DESCRIPTION
Pick up the PR: https://github.com/google/cadvisor/pull/2302
Fixes: https://github.com/google/cadvisor/issues/2138

>Through prometheus testing the following relationship seems to be present:
container_memory_usage_bytes == container_memory_rss + container_memory_cache + container_memory_kernel

please review @dashpole 
Thanks