### PR TITLE
Determine online CPUs from a standard source.

### DIFF
--- a/machine/machine.go
+++ b/machine/machine.go
@@ -45,7 +45,7 @@ var (
 	swapCapacityRegexp   = regexp.MustCompile(`SwapTotal:\s*([0-9]+) kB`)
 	vendorIDRegexp       = regexp.MustCompile(`vendor_id\s*:\s*(\w+)`)
 
-	cpuBusPath         = "/sys/bus/cpu/devices/"
+	cpuAttributesPath  = "/sys/devices/system/cpu/"
 	isMemoryController = regexp.MustCompile("mc[0-9]+")
 	isDimm             = regexp.MustCompile("dimm[0-9]+")
 	machineArch        = getMachineArch()
@@ -76,7 +76,7 @@ func GetPhysicalCores(procInfo []byte) int {
 	if numCores == 0 {
 		// read number of cores from /sys/bus/cpu/devices/cpu*/topology/core_id to deal with processors
 		// for which 'core id' is not available in /proc/cpuinfo
-		numCores = sysfs.GetUniqueCPUPropertyCount(cpuBusPath, sysfs.CPUCoreID)
+		numCores = sysfs.GetUniqueCPUPropertyCount(cpuAttributesPath, sysfs.CPUCoreID)
 	}
 	if numCores == 0 {
 		klog.Errorf("Cannot read number of physical cores correctly, number of cores set to %d", numCores)
@@ -90,7 +90,7 @@ func GetSockets(procInfo []byte) int {
 	if numSocket == 0 {
 		// read number of sockets from /sys/bus/cpu/devices/cpu*/topology/physical_package_id to deal with processors
 		// for which 'physical id' is not available in /proc/cpuinfo
-		numSocket = sysfs.GetUniqueCPUPropertyCount(cpuBusPath, sysfs.CPUPhysicalPackageID)
+		numSocket = sysfs.GetUniqueCPUPropertyCount(cpuAttributesPath, sysfs.CPUPhysicalPackageID)
 	}
 	if numSocket == 0 {
 		klog.Errorf("Cannot read number of sockets correctly, number of sockets set to %d", numSocket)

--- a/machine/topology_test.go
+++ b/machine/topology_test.go
@@ -41,12 +41,12 @@ func TestPhysicalCores(t *testing.T) {
 }
 
 func TestPhysicalCoresReadingFromCpuBus(t *testing.T) {
-	origCPUBusPath := cpuBusPath
+	origCPUAttributesPath := cpuAttributesPath
 	defer func() {
-		cpuBusPath = origCPUBusPath
+		cpuAttributesPath = origCPUAttributesPath
 	}()
-	cpuBusPath = "./testdata/sysfs_cpus/" // overwriting package variable to mock sysfs
-	testfile := "./testdata/cpuinfo_arm"  // mock cpuinfo without core id
+	cpuAttributesPath = "./testdata/sysfs_cpus/" // overwriting package variable to mock sysfs
+	testfile := "./testdata/cpuinfo_arm"         // mock cpuinfo without core id
 
 	testcpuinfo, err := os.ReadFile(testfile)
 	assert.Nil(t, err)
@@ -57,12 +57,12 @@ func TestPhysicalCoresReadingFromCpuBus(t *testing.T) {
 }
 
 func TestPhysicalCoresFromWrongSysFs(t *testing.T) {
-	origCPUBusPath := cpuBusPath
+	origCPUAttributesPath := cpuAttributesPath
 	defer func() {
-		cpuBusPath = origCPUBusPath
+		cpuAttributesPath = origCPUAttributesPath
 	}()
-	cpuBusPath = "./testdata/wrongsysfs" // overwriting package variable to mock sysfs
-	testfile := "./testdata/cpuinfo_arm" // mock cpuinfo without core id
+	cpuAttributesPath = "./testdata/wrongsysfs" // overwriting package variable to mock sysfs
+	testfile := "./testdata/cpuinfo_arm"        // mock cpuinfo without core id
 
 	testcpuinfo, err := os.ReadFile(testfile)
 	assert.Nil(t, err)
@@ -84,12 +84,12 @@ func TestSockets(t *testing.T) {
 }
 
 func TestSocketsReadingFromCpuBus(t *testing.T) {
-	origCPUBusPath := cpuBusPath
+	origCPUAttributesPath := cpuAttributesPath
 	defer func() {
-		cpuBusPath = origCPUBusPath
+		cpuAttributesPath = origCPUAttributesPath
 	}()
-	cpuBusPath = "./testdata/wrongsysfs" // overwriting package variable to mock sysfs
-	testfile := "./testdata/cpuinfo_arm" // mock cpuinfo without physical id
+	cpuAttributesPath = "./testdata/wrongsysfs" // overwriting package variable to mock sysfs
+	testfile := "./testdata/cpuinfo_arm"        // mock cpuinfo without physical id
 
 	testcpuinfo, err := os.ReadFile(testfile)
 	assert.Nil(t, err)
@@ -103,11 +103,11 @@ func TestSocketsReadingFromWrongSysFs(t *testing.T) {
 	path, err := filepath.Abs("./testdata/sysfs_cpus/")
 	assert.NoError(t, err)
 
-	origCPUBusPath := cpuBusPath
+	origCPUAttributesPath := cpuAttributesPath
 	defer func() {
-		cpuBusPath = origCPUBusPath
+		cpuAttributesPath = origCPUAttributesPath
 	}()
-	cpuBusPath = path                    // overwriting package variable to mock sysfs
+	cpuAttributesPath = path             // overwriting package variable to mock sysfs
 	testfile := "./testdata/cpuinfo_arm" // mock cpuinfo without physical id
 
 	testcpuinfo, err := os.ReadFile(testfile)

--- a/utils/sysfs/sysfs_test.go
+++ b/utils/sysfs/sysfs_test.go
@@ -125,7 +125,9 @@ func TestGetHugePagesNrWhenFileIsMissing(t *testing.T) {
 }
 
 func TestIsCPUOnline(t *testing.T) {
-	sysFs := NewRealSysFs()
+	sysFs := &realSysFs{
+		cpuPath: "./testdata_epyc7402_nohyperthreading",
+	}
 	online := sysFs.IsCPUOnline("./testdata_epyc7402_nohyperthreading/cpu14")
 	assert.True(t, online)
 
@@ -141,7 +143,9 @@ func TestIsCPUOnlineNoFileAndCPU0MustBeOnline(t *testing.T) {
 	}()
 	isX86 = false
 
-	sysFs := NewRealSysFs()
+	sysFs := &realSysFs{
+		cpuPath: "./testdata/missing_online/node0",
+	}
 	online := sysFs.IsCPUOnline("./testdata/missing_online/node0/cpu33")
 	assert.True(t, online)
 }
@@ -167,7 +171,9 @@ func TestCPU0OfflineOnNotx86(t *testing.T) {
 	}()
 	isX86 = false
 
-	sysFs := NewRealSysFs()
+	sysFs := &realSysFs{
+		cpuPath: "./testdata_graviton2",
+	}
 	online := sysFs.IsCPUOnline("./testdata_graviton2/cpu0")
 	assert.False(t, online)
 }
@@ -180,7 +186,9 @@ func TestIsCpuOnlineRaspberryPi4(t *testing.T) {
 	}()
 	isX86 = false
 
-	sysFS := NewRealSysFs()
+	sysFS := &realSysFs{
+		cpuPath: "./testdata_rpi4",
+	}
 	online := sysFS.IsCPUOnline("./testdata_rpi4/cpu0")
 	assert.True(t, online)
 
@@ -202,7 +210,9 @@ func TestIsCpuOnlineGraviton2(t *testing.T) {
 	}()
 	isX86 = false
 
-	sysFS := NewRealSysFs()
+	sysFS := &realSysFs{
+		cpuPath: "./testdata_graviton2",
+	}
 	online := sysFS.IsCPUOnline("./testdata_graviton2/cpu0")
 	assert.False(t, online)
 


### PR DESCRIPTION
Determine CPUs that are online from `/sys/devices/system/cpu/online` compared to the path generated from the parameters, which may not exist.

I'm really looking forward to any suggestions or insights from the community. 

Addresses: https://github.com/google/cadvisor/issues/3317