### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-versions }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Run presubmit checks
       run: |
         source ${{ matrix.environment-variables }}


### PR DESCRIPTION
This PR updates workflows to use `actions/checkout@v3`, which will suppress multiple warnings that are raised in GitHub workflows.

Eg:
<img width="1092" alt="image" src="https://github.com/google/cadvisor/assets/110517346/58466fb1-e034-4278-bd67-dfce3d11fcd2">

