### PR TITLE
fix: add space trimming for label allowlist

### DIFF
--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -156,6 +156,10 @@ func main() {
 	containerLabelFunc := metrics.DefaultContainerLabels
 	if !*storeContainerLabels {
 		whitelistedLabels := strings.Split(*whitelistedContainerLabels, ",")
+		// Trim spacing in labels
+		for i := range whitelistedLabels {
+			whitelistedLabels[i] = strings.TrimSpace(whitelistedLabels[i])
+		}
 		containerLabelFunc = metrics.BaseContainerLabels(whitelistedLabels)
 	}
 


### PR DESCRIPTION
Some developers prefer to write lists by adding spaces after commas, so add handling of spaces to increase code robustness