### PR TITLE
Add a metric for machine swap capacity

### DIFF
--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -111,6 +111,7 @@ Metric name | Type | Description | Unit (where applicable) | option parameter | 
 `machine_dimm_capacity_bytes` | Gauge | Total RAM DIMM capacity (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 | bytes | | |
 `machine_dimm_count` | Gauge | Number of RAM DIMM (all types memory modules) value labeled by dimm type,<br>information is retrieved from sysfs edac per-DIMM API (/sys/devices/system/edac/mc/) introduced in kernel 3.6 | | |
 `machine_memory_bytes` | Gauge | Amount of memory installed on the machine | bytes | |
+`machine_swap_bytes` | Gauge | Amount of swap memory available on the machine | bytes | |
 `machine_node_distance` | Gauge | Distance between NUMA node and target NUMA node | | cpu_topology |
 `machine_node_hugepages_count` | Gauge |  Numer of hugepages assigned to NUMA node | | cpu_topology |
 `machine_node_memory_capacity_bytes` | Gauge |  Amount of memory assigned to NUMA node | bytes | cpu_topology |

--- a/metrics/prometheus_machine.go
+++ b/metrics/prometheus_machine.go
@@ -112,6 +112,14 @@ func NewPrometheusMachineCollector(i infoProvider, includedMetrics container.Met
 				},
 			},
 			{
+				name:      "machine_swap_bytes",
+				help:      "Amount of swap memory available on the machine.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(machineInfo *info.MachineInfo) metricValues {
+					return metricValues{{value: float64(machineInfo.SwapCapacity), timestamp: machineInfo.Timestamp}}
+				},
+			},
+			{
 				name:        "machine_dimm_count",
 				help:        "Number of RAM DIMM (all types memory modules) value labeled by dimm type.",
 				valueType:   prometheus.GaugeValue,

--- a/metrics/testdata/prometheus_machine_metrics
+++ b/metrics/testdata/prometheus_machine_metrics
@@ -71,6 +71,9 @@ machine_nvm_capacity{boot_id="boot-id-test",machine_id="machine-id-test",mode="m
 # HELP machine_scrape_error 1 if there was an error while getting machine metrics, 0 otherwise.
 # TYPE machine_scrape_error gauge
 machine_scrape_error 0
+# HELP machine_swap_bytes Amount of swap memory available on the machine.
+# TYPE machine_swap_bytes gauge
+machine_swap_bytes{boot_id="boot-id-test",machine_id="machine-id-test",system_uuid="system-uuid-test"} 0 1395066363000
 # HELP machine_thread_siblings_count Number of CPU thread siblings.
 # TYPE machine_thread_siblings_count gauge
 machine_thread_siblings_count{boot_id="boot-id-test",core_id="0",machine_id="machine-id-test",node_id="0",system_uuid="system-uuid-test",thread_id="0"} 2 1395066363000


### PR DESCRIPTION
While for memory there are metrics for both current consumption (`container_memory_usage_bytes`) and total machine capacity (`machine_memory_bytes`), for swap memory the only supported metric is for current consumption (`container_memory_swap`).

This PR adds the missing piece by adding `machine_swap_bytes` metric that would be helpful to monitor the total amount of swap memory available on the machine.