### PR TITLE
reduce inotify watch

### DIFF
--- a/container/raw/watcher.go
+++ b/container/raw/watcher.go
@@ -24,6 +24,7 @@ import (
 
 	inotify "k8s.io/utils/inotify"
 
+	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/common"
 	"github.com/google/cadvisor/container/libcontainer"
 	"github.com/google/cadvisor/watcher"
@@ -42,8 +43,8 @@ type rawContainerWatcher struct {
 	stopWatcher chan error
 }
 
-func NewRawContainerWatcher() (watcher.ContainerWatcher, error) {
-	cgroupSubsystems, err := libcontainer.GetCgroupSubsystems(nil)
+func NewRawContainerWatcher(includedMetrics container.MetricSet) (watcher.ContainerWatcher, error) {
+	cgroupSubsystems, err := libcontainer.GetCgroupSubsystems(includedMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cgroup subsystems: %v", err)
 	}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -295,7 +295,7 @@ func (m *manager) Start() error {
 		klog.Errorf("Registration of the raw container factory failed: %v", err)
 	}
 
-	rawWatcher, err := raw.NewRawContainerWatcher()
+	rawWatcher, err := raw.NewRawContainerWatcher(m.includedMetrics)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Only setup inotify watch for included metrics

fix https://github.com/google/cadvisor/issues/3353

Before the change, number of container is 190+ , and number of inotify watch is 4800+

![lanxin_20230720171104](https://github.com/google/cadvisor/assets/74715700/361072d2-346f-44f9-a1d5-0987b31bd1f6)

After this change, the number of inotify watch is 2052

![image](https://github.com/google/cadvisor/assets/74715700/3cb634f2-0a2f-4e9f-a4f1-b2c1b629ba52)
 