### PR TITLE
No NVM devices: information should be logged on increased verbosity only

### DIFF
--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -61,7 +61,7 @@ func getAvgPowerBudget() (uint, error) {
 	}
 
 	if count == 0 {
-		klog.V(1).Infof("There are no NVM devices.")
+		klog.V(4).Infof("There are no NVM devices.")
 		return uint(0), nil
 	}
 


### PR DESCRIPTION
Fixes #3198 