### PR TITLE
Adjust the log level of Initialize Plugins

### DIFF
--- a/container/factory.go
+++ b/container/factory.go
@@ -216,7 +216,9 @@ func InitializePlugins(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includ
 	for name, plugin := range plugins {
 		watcher, err := plugin.Register(factory, fsInfo, includedMetrics)
 		if err != nil {
-			klog.V(5).Infof("Registration of the %s container factory failed: %v", name, err)
+			klog.Infof("Registration of the %s container factory failed: %v", name, err)
+		} else {
+			klog.Infof("Registration of the %s container factory successfully", name)
 		}
 		if watcher != nil {
 			containerWatchers = append(containerWatchers, watcher)


### PR DESCRIPTION
Adjust the log level of Initialize Plugins to make it easier for users to analyze the registration status of Plugins.
Now the default log level of plugin register failure is 5. When plugin register fails, the error info cannot be recorded from the logs, and the issue cannot be analyzed.