### PR TITLE
Go 1.21 compatibility: Set verbosity after flag definition

### DIFF
--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -100,14 +100,13 @@ func init() {
 	optstr := container.AllMetrics.String()
 	flag.Var(&ignoreMetrics, "disable_metrics", fmt.Sprintf("comma-separated list of `metrics` to be disabled. Options are %s.", optstr))
 	flag.Var(&enableMetrics, "enable_metrics", fmt.Sprintf("comma-separated list of `metrics` to be enabled. If set, overrides 'disable_metrics'. Options are %s.", optstr))
-
-	// Default logging verbosity to V(2)
-	_ = flag.Set("v", "2")
 }
 
 func main() {
 	klog.InitFlags(nil)
 	defer klog.Flush()
+	// Default logging verbosity to V(2)
+	_ = flag.Set("v", "2")
 	flag.Parse()
 
 	if *versionFlag {


### PR DESCRIPTION
This seems to be related to a change in the klog library where the "v" flag isn't defined until after InitFlags() is called. Defer the call of setting the default verbosity until after we do that instead of during init(). Fixes startup:

    $ GO_FLAGS=-trimpath build/build.sh && _output/cadvisor -logtostderr
    >> building cadvisor
    go: downloading github.com/prometheus/common v0.38.0
    panic: flag v set at github.com/google/cadvisor/cmd/cadvisor.go:105 before being defined

    goroutine 1 [running]:
    flag.(*FlagSet).Var(0xc00017a150, {0x1874460, 0x2213bc8}, {0x1866490, 0x1}, {0x15f0596, 0x22})
            flag/flag.go:1031 +0x33a
    k8s.io/klog/v2.InitFlags.func1(0xc0001ab2f0?)
            k8s.io/klog/v2@v2.80.1/klog.go:439 +0x31
    flag.(*FlagSet).VisitAll(0xc00032fa50?, 0xc0005e1c90)
            flag/flag.go:458 +0x42
    k8s.io/klog/v2.InitFlags(0x7fbe00b2f5b8?)
            k8s.io/klog/v2@v2.80.1/klog.go:438 +0x45
    main.main()
            github.com/google/cadvisor/cmd/cadvisor.go:109 +0x36

Possibly broken due to this? https://github.com/kubernetes/klog/commit/28f790698e907ffbd2ac80fe4d6954429f827fbf 