### PR TITLE
Update kustomization.yaml to address obsolete old syntax

### DIFF
--- a/deploy/kubernetes/overlays/examples/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples/kustomization.yaml
@@ -1,7 +1,7 @@
 bases:
 - ../../base
 patches:
-- stackdriver-sidecar.yaml
-- critical-priority.yaml
-- cadvisor-args.yaml
-- gpu-privilages.yaml
+- path: stackdriver-sidecar.yaml
+- path: critical-priority.yaml
+- path: cadvisor-args.yaml
+- path: gpu-privilages.yaml

--- a/deploy/kubernetes/overlays/examples_perf/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples_perf/kustomization.yaml
@@ -3,4 +3,4 @@ bases:
 resources:
 - configmap.yaml
 patches:
-- cadvisor-perf.yaml
+- path: cadvisor-perf.yaml


### PR DESCRIPTION
From Kustomize v5, old `patches` syntax are removed.
https://github.com/kubernetes-sigs/kustomize/pull/4911

This PR updates old `patches` syntax in example.