### PR TITLE
allow for cadvisor to detect disk stats when the read-only and writeable layers are on separate disks.

### DIFF
--- a/container/crio/client.go
+++ b/container/crio/client.go
@@ -44,6 +44,7 @@ var (
 type Info struct {
 	StorageDriver string `json:"storage_driver"`
 	StorageRoot   string `json:"storage_root"`
+	StorageImage  string `json:"storage_image"`
 }
 
 // ContainerInfo represents a given container information

--- a/container/crio/plugin.go
+++ b/container/crio/plugin.go
@@ -40,7 +40,7 @@ func (p *plugin) InitializeFSContext(context *fs.Context) error {
 	if err != nil {
 		klog.V(5).Infof("CRI-O not connected: %v", err)
 	} else {
-		context.Crio = fs.CrioContext{Root: crioInfo.StorageRoot}
+		context.Crio = fs.CrioContext{Root: crioInfo.StorageRoot, ImageStore: crioInfo.StorageImage, Driver: crioInfo.StorageDriver}
 	}
 	return nil
 }

--- a/fs/types.go
+++ b/fs/types.go
@@ -38,7 +38,9 @@ type PodmanContext struct {
 }
 
 type CrioContext struct {
-	Root string
+	Root       string
+	ImageStore string
+	Driver     string
 }
 
 type DeviceInfo struct {


### PR DESCRIPTION
https://github.com/kubernetes/enhancements/issues/4191

We are working on splitting the image disk and we realize that some upstream changes are needed in cadvisor in order to account for crio splitting the containers between a read-only and writeable layer.  

This is only mergeable once the K8s KEP is approved and the CRIO changes are merged.  

Pre Reqs:

- [CRIO](https://github.com/cri-o/cri-o/pull/7401)
- [KEP-PR](https://github.com/kubernetes/enhancements/pull/4198)
- [k8s/k8s](https://github.com/kubernetes/kubernetes/pull/120616)

Note we vendored these cadisvor changes in the k8s/k8s PR to test this idea out.  