### PR TITLE
manager: require higher verbosity level for container info misses

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -698,7 +698,7 @@ func (m *manager) GetRequestedContainersInfo(containerName string, options v2.Re
 		info, err := m.containerDataToContainerInfo(data, &query)
 		if err != nil {
 			if err == memory.ErrDataNotFound {
-				klog.Warningf("Error getting data for container %s because of race condition", name)
+				klog.V(4).Infof("Error getting data for container %s because of race condition", name)
 				continue
 			}
 			errs.append(name, "containerDataToContainerInfo", err)
@@ -1375,7 +1375,7 @@ func (m *manager) containersInfo(containers map[string]*containerData, query *in
 		if err != nil {
 			// Ignore the error because of race condition and return best-effort result.
 			if err == memory.ErrDataNotFound {
-				klog.Warningf("Error getting data for container %s because of race condition", name)
+				klog.V(4).Infof("Error getting data for container %s because of race condition", name)
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
This PR increases the required verbosity level for logging container stats info misses such as:
```
manager.go:694] Error getting data for container / because of race condition
```
When not scrapping root container metrics (using `-disable_root_cgroup_stats`), the above log message is repeated for every metrics scrape request. The error in this case is expected due to to the container stats info not having stats for `/`.

Fixes #3407 
Similar to #3341