### PR TITLE
Reduce kubelet logs 'Failed to create existing container' when kubelet is using crio

### DIFF
--- a/container/crio/factory.go
+++ b/container/crio/factory.go
@@ -32,6 +32,9 @@ import (
 // The namespace under which crio aliases are unique.
 const CrioNamespace = "crio"
 
+// The namespace suffix under which crio aliases are unique.
+const CrioNamespaceSuffix = ".scope"
+
 // The namespace systemd runs components under.
 const SystemdNamespace = "system-systemd"
 
@@ -114,15 +117,20 @@ func (f *crioFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 		// TODO(runcom): should we include crio-conmon cgroups?
 		return false, false, nil
 	}
-	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
-		return false, false, nil
-	}
 	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
 		return true, false, nil
+	}
+	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
+		return false, false, nil
 	}
 	// if the container is not associated with CRI-O, we can't handle it or accept it.
 	if !isContainerName(name) {
 		return false, false, nil
+	}
+
+	if !strings.HasSuffix(path.Base(name), CrioNamespaceSuffix) {
+		// this mean it's a sandbox container
+		return true, false, nil
 	}
 	return true, true, nil
 }

--- a/container/crio/factory_test.go
+++ b/container/crio/factory_test.go
@@ -20,6 +20,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type canHandleAndAccept struct {
+	canHandle bool
+	canAccept bool
+}
+
 func TestCanHandleAndAccept(t *testing.T) {
 	as := assert.New(t)
 	f := &crioFactory{
@@ -31,16 +36,18 @@ func TestCanHandleAndAccept(t *testing.T) {
 		storageDir:         "",
 		includedMetrics:    nil,
 	}
-	for k, v := range map[string]bool{
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":           true,
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.mount":     false,
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":    false,
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/no-crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f": false,
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75":                    false,
+	for k, v := range map[string]canHandleAndAccept{
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":           {true, false},
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.scope":     {true, true},
+		"/system.slice/system-systemd\\\\x2dcoredump.slice":                                                                                 {true, false},
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.mount":     {false, false},
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":    {false, false},
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/no-crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f": {false, false},
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75":                    {false, false},
 	} {
 		b1, b2, err := f.CanHandleAndAccept(k)
 		as.Nil(err)
-		as.Equal(b1, v)
-		as.Equal(b2, v)
+		as.Equal(b1, v.canHandle)
+		as.Equal(b2, v.canAccept)
 	}
 }


### PR DESCRIPTION
fix #3456

![lanxin_20240119105118](https://github.com/google/cadvisor/assets/8870947/372ccbeb-3552-40c4-8b95-de26f0cf1be3)

when We found that these logs are related to crio sandbox containers. The root cause is that when a pod is created, there will be a sandbox container folder in the cgroup file. When cadvisor scans the cgroup directory to identify containers, it recognizes the sandbox container. It then uses CanHandleAndAccept to determine that it needs to retrieve container information from crio using the id parameter. However, when attempting to get container information from crio via grpc, crio does not query the sandbox container, resulting in a 404 error(https://github.com/cri-o/cri-o/blob/main/server/inspect.go#L68). so cadvisor **createContainer** failed and print the logs periodically(https://github.com/google/cadvisor/blob/master/manager/manager.go#L1116) 

We think that this situation should be handled in the crio factory, filtering out sandbox containers. similar to this pr:https://github.com/google/cadvisor/pull/2957 for https://bugzilla.redhat.com/show_bug.cgi?id=1978528#c4
