### PR TITLE
Remove section about canary image

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -47,12 +47,6 @@ otherwise cAdvisor can not connect to docker daemon.
   gcr.io/cadvisor/cadvisor:<tag> -perf_events_config=/etc/configs/perf/perf.json
   ```
 
-## Latest Canary
-
-The latest cAdvisor canary release is continuously built from HEAD and available
-as an Automated Build Docker image:
-[google/cadvisor-canary](https://registry.hub.docker.com/u/google/cadvisor-canary/). We do *not* recommend using this image in production due to its large size and volatility.
-
 ## With Boot2Docker
 
 After booting up a boot2docker instance, run cAdvisor image with the same docker command mentioned above. cAdvisor can now be accessed at port 8080 of your boot2docker instance. The host IP can be found through DOCKER_HOST environment variable setup by boot2docker:


### PR DESCRIPTION
The image in question (https://hub.docker.com/r/google/cadvisor-canary) has not been updated in 5 years, so this section of running.md is misleading. 