### PR TITLE
Bump to alpine 3.18 and disable libipmctl

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,14 +18,16 @@ RUN export DBG="-g -Wall" && \
 
 # ipmctl only supports Intel x86_64 processors.
 # https://github.com/intel/ipmctl/issues/163
-RUN if [ "$(uname --machine)" = "x86_64" ]; then \
-    git clone -b v02.00.00.3885 https://github.com/intel/ipmctl/ && \
-    cd ipmctl && \
-    mkdir output && \
-    cd output && \
-    cmake -DRELEASE=ON -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_INSTALL_LIBDIR=/usr/local/lib .. && \
-    make -j all && \
-    make install; fi
+
+# Disable libipmctl due to https://github.com/google/cadvisor/issues/3482
+#RUN if [ "$(uname --machine)" = "x86_64" ]; then \
+    #git clone -b v02.00.00.3885 https://github.com/intel/ipmctl/ && \
+    #cd ipmctl && \
+    #mkdir output && \
+    #cd output && \
+    #cmake -DRELEASE=ON -DCMAKE_INSTALL_PREFIX=/ -DCMAKE_INSTALL_LIBDIR=/usr/local/lib .. && \
+    #make -j all && \
+    #make install; fi
 
 WORKDIR /go/src/github.com/google/cadvisor
 
@@ -42,11 +44,13 @@ ARG VERSION
 # libipmctl only works on x86_64 CPUs.
 RUN export GO_TAGS="libpfm,netgo"; \
     if [ "$(uname --machine)" = "x86_64" ]; then \
-          export GO_TAGS="$GO_TAGS,libipmctl"; \
+          # Disable libipmctl due to https://github.com/google/cadvisor/issues/3482
+          #export GO_TAGS="$GO_TAGS,libipmctl"; \
+          export GO_TAGS="$GO_TAGS"; \
     fi; \
     GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
 
-FROM mirror.gcr.io/library/alpine:3.16
+FROM mirror.gcr.io/library/alpine:3.18
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils ndctl zfs && \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.20-alpine3.16 AS build
+FROM registry.hub.docker.com/library/golang:1.22-alpine3.18 AS build
 
 # Install build depdencies for all supported arches
 RUN apk --no-cache add bash build-base cmake device-mapper findutils git \

--- a/perf/collector_libpfm.go
+++ b/perf/collector_libpfm.go
@@ -253,9 +253,9 @@ func (c *collector) createLeaderFileDescriptors(events []Event, cgroupFd int, gr
 }
 
 func readPerfEventAttr(name string, pfmGetOsEventEncoding func(string, unsafe.Pointer) error) (*unix.PerfEventAttr, error) {
-	perfEventAttrMemory := C.malloc(C.ulong(unsafe.Sizeof(unix.PerfEventAttr{})))
+	perfEventAttrMemory := C.malloc(C.size_t(unsafe.Sizeof(unix.PerfEventAttr{})))
 	// Fill memory with 0 values.
-	C.memset(perfEventAttrMemory, 0, C.ulong(unsafe.Sizeof(unix.PerfEventAttr{})))
+	C.memset(perfEventAttrMemory, 0, C.size_t(unsafe.Sizeof(unix.PerfEventAttr{})))
 	err := pfmGetOsEventEncoding(name, unsafe.Pointer(perfEventAttrMemory))
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func pfmGetOsEventEncoding(name string, perfEventAttrMemory unsafe.Pointer) erro
 	defer C.free(unsafe.Pointer(fstr))
 	event.fstr = unsafe.Pointer(fstr)
 	event.attr = perfEventAttrMemory
-	event.size = C.ulong(unsafe.Sizeof(event))
+	event.size = C.size_t(unsafe.Sizeof(event))
 	cSafeName := C.CString(name)
 	defer C.free(unsafe.Pointer(cSafeName))
 	pErr := C.pfm_get_os_event_encoding(cSafeName, C.PFM_PLM0|C.PFM_PLM3, C.PFM_OS_PERF_EVENT, unsafe.Pointer(&event))


### PR DESCRIPTION
See https://github.com/google/cadvisor/issues/3482 for more context

Built on top of https://github.com/google/cadvisor/pull/3480