### PR TITLE
Cherrpick #3485 to release-v0.49- Remove s390x support

### DIFF
--- a/build/check_container.sh
+++ b/build/check_container.sh
@@ -28,7 +28,7 @@
 target_image=$1
 
 # Architectures officially supported by cadvisor
-arches=( "amd64" "arm" "arm64" "s390x" )
+arches=( "amd64" "arm" "arm64" )
 
 # Docker doesn't handle images with different architectures but the same tag.
 # Remove the container and the image use by it to avoid problems.

--- a/build/release.sh
+++ b/build/release.sh
@@ -55,7 +55,7 @@ docker buildx inspect cadvisor-builder > /dev/null \
 # Build binaries
 
 # A mapping of the docker arch name to the qemu arch name
-declare -A arches=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" ["s390x"]="s390x")
+declare -A arches=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" )
 
 for arch in "${arches[@]}"; do
   if ! hash "qemu-${arch}-static"; then


### PR DESCRIPTION
Cherrypick https://github.com/google/cadvisor/pull/3485

We can't build with s390x now due to missing package (thin-provisioning-tools)

```
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/s390x/APKINDEX.tar.gz
ERROR: unable to select packages:
thin-provisioning-tools (no such package):
required by: world[thin-provisioning-tools]
```