### PR TITLE
build docker - add --provenance=false flag

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -71,7 +71,7 @@ done
 for arch in "${!arches[@]}"; do
   GOARCH="$arch" GO_CGO_ENABLED="0" OUTPUT_NAME_WITH_ARCH="true" build/build.sh
   arch_specific_image="${image_name}-${arch}:${VERSION}"
-  docker buildx build --platform "linux/${arch}" --build-arg VERSION="$VERSION" -f deploy/Dockerfile -t "$arch_specific_image"  --progress plain --push .
+  docker buildx build --platform "linux/${arch}" --provenance=false --build-arg VERSION="$VERSION" -f deploy/Dockerfile -t "$arch_specific_image"  --progress plain --push .
   docker manifest create --amend "$final_image" "$arch_specific_image"
   docker manifest annotate --os=linux --arch="$arch" "$final_image" "$arch_specific_image"
 done


### PR DESCRIPTION
This is causing failure to combine the multi-arch images. See https://github.com/docker/buildx/issues/1509 for discussion