### PR TITLE
Add s390x support again 

### DIFF
--- a/build/check_container.sh
+++ b/build/check_container.sh
@@ -28,7 +28,7 @@
 target_image=$1
 
 # Architectures officially supported by cadvisor
-arches=( "amd64" "arm" "arm64" )
+arches=( "amd64" "arm" "arm64" "s390x" )
 
 # Docker doesn't handle images with different architectures but the same tag.
 # Remove the container and the image use by it to avoid problems.

--- a/build/release.sh
+++ b/build/release.sh
@@ -55,7 +55,7 @@ docker buildx inspect cadvisor-builder > /dev/null \
 # Build binaries
 
 # A mapping of the docker arch name to the qemu arch name
-declare -A arches=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" )
+declare -A arches=( ["amd64"]="x86_64" ["arm"]="arm" ["arm64"]="aarch64" ["s390x"]="s390x" )
 
 for arch in "${arches[@]}"; do
   if ! hash "qemu-${arch}-static"; then


### PR DESCRIPTION
thin-provisioning-tools package is now available in Alpine Linux. We have tested and added it in latest, 3.19 and 3.18 releases. 