### PR TITLE
sysfs: trim spaces in device hidden check

### DIFF
--- a/utils/sysfs/sysfs.go
+++ b/utils/sysfs/sysfs.go
@@ -229,10 +229,8 @@ func (fs *realSysFs) IsBlockDeviceHidden(name string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to read %s: %w", devHiddenPath, err)
 	}
-	if string(hidden) == "1" {
-		return true, nil
-	}
-	return false, nil
+
+	return strings.TrimSpace(string(hidden)) == "1", nil
 }
 
 func (fs *realSysFs) GetBlockDeviceScheduler(name string) (string, error) {


### PR DESCRIPTION
The hidden file might have an endline, so the check for equals to 1 would not be true. Trimming the spaces would help to cover this case.