### PR TITLE
fix: update very old test infra image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-versions: ['1.22', '1.21']
-        platform: [ubuntu-20.04]
+        platform: [ubuntu-22.04]
         environment-variables: [build/config/plain.sh, build/config/libpfm4.sh, build/config/libipmctl.sh]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         go-versions: ['1.22', '1.21']
-        platform: [ubuntu-20.04]
+        platform: [ubuntu-22.04]
         environment-variables: [build/config/plain.sh, build/config/libpfm4.sh, build/config/libipmctl.sh]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30

--- a/build/config/libipmctl.sh
+++ b/build/config/libipmctl.sh
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 export GO_FLAGS="-tags=libipmctl,cgo -race"
-export PACKAGES="sudo libipmctl4"
-export BUILD_PACKAGES="libipmctl4 libipmctl-dev"
+export PACKAGES="sudo libipmctl5"
+export BUILD_PACKAGES="libipmctl5 libipmctl-dev"
 export CADVISOR_ARGS="-perf_events_config=perf/testing/perf-non-hardware.json"

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -58,12 +58,12 @@ function run_tests() {
     --privileged \
     --cap-add="sys_admin" \
     --entrypoint="" \
-    gcr.io/k8s-testimages/bootstrap \
+    gcr.io/k8s-staging-test-infra/bootstrap \
     bash -c "export DEBIAN_FRONTEND=noninteractive && \
-    echo 'deb http://deb.debian.org/debian buster-backports main'>/etc/apt/sources.list.d/buster.list && \
-    cat /etc/apt/sources.list.d/buster.list && \
+    echo 'deb http://deb.debian.org/debian bookworm-backports main'>/etc/apt/sources.list.d/bookworm.list && \
+    cat /etc/apt/sources.list.d/bookworm.list && \
     apt update && \
-    apt install -y -t buster-backports $PACKAGES && \
+    apt install -y -t bookworm-backports $PACKAGES && \
     CADVISOR_ARGS="$CADVISOR_ARGS" /usr/local/bin/runner.sh build/integration.sh"
 }
 

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -42,7 +42,7 @@ function run_tests() {
   docker run --rm \
     -w /go/src/github.com/google/cadvisor \
     -v ${PWD}:/go/src/github.com/google/cadvisor \
-    golang:"$GOLANG_VERSION-bullseye" \
+    golang:"$GOLANG_VERSION-bookworm" \
     bash -c "$BUILD_CMD"
 
   EXTRA_DOCKER_OPTS="-e DOCKER_IN_DOCKER_ENABLED=true"


### PR DESCRIPTION
* Updates bootstrap testing image used in integration test with newer version which is failing due to [debian buster backports deprecation](https://backports.debian.org/news/Removal_of_buster-backports_from_the_debian_archive/)
* https://github.com/kubernetes/k8s.io/issues/1523