### PR TITLE
Expose Podman version info

### DIFF
--- a/container/podman/podman.go
+++ b/container/podman/podman.go
@@ -108,7 +108,15 @@ func Status() (v1.DockerStatus, error) {
 		return v1.DockerStatus{}, err
 	}
 
-	return docker.StatusFromDockerInfo(*podmanInfo)
+	status, err := docker.StatusFromDockerInfo(*podmanInfo)
+	if err != nil {
+		return v1.DockerStatus{}, err
+	}
+
+	status.Version, _ = VersionString()
+	status.APIVersion, _ = APIVersionString()
+
+	return status, nil
 }
 
 func GetInfo() (*dockersystem.Info, error) {
@@ -125,6 +133,16 @@ func VersionString() (string, error) {
 	}
 
 	return version.Version, nil
+}
+
+func APIVersionString() (string, error) {
+	var version dockertypes.Version
+	err := apiGetRequest("http://d/v1.0.0/version", &version)
+	if err != nil {
+		return "Unknown", err
+	}
+
+	return version.APIVersion, nil
 }
 
 func InspectContainer(id string) (dockertypes.ContainerJSON, error) {

--- a/container/podman/podman.go
+++ b/container/podman/podman.go
@@ -113,8 +113,19 @@ func Status() (v1.DockerStatus, error) {
 		return v1.DockerStatus{}, err
 	}
 
-	status.Version, _ = VersionString()
-	status.APIVersion, _ = APIVersionString()
+	podmanVersion, err := VersionString()
+	if err != nil {
+		// status.Version will be "Unknown"
+		return status, err
+	}
+	status.Version = podmanVersion
+
+	podmanAPIVersion, err := APIVersionString()
+	if err != nil {
+		// status.APIVersion will be "Unknown"
+		return status, err
+	}
+	status.APIVersion = podmanAPIVersion
 
 	return status, nil
 }


### PR DESCRIPTION
This exposes the Podman version and it's Docker API version. The fields were there, but they were always showing "Unknown".

This is how it looks after the patch:
![cAdvisor - Podman versions](https://github.com/google/cadvisor/assets/99679/3adf80e9-bbe9-4870-8add-f9f45162d3e1)
