### PR TITLE
CI: update busybox image to fix CI

### DIFF
--- a/integration/framework/framework.go
+++ b/integration/framework/framework.go
@@ -220,7 +220,7 @@ func (a dockerActions) RunPause() string {
 // Run the specified command in a Docker busybox container.
 func (a dockerActions) RunBusybox(cmd ...string) string {
 	return a.Run(DockerRunArgs{
-		Image: "registry.k8s.io/busybox",
+		Image: "registry.k8s.io/busybox:1.27",
 	}, cmd...)
 }
 


### PR DESCRIPTION
![image](https://github.com/google/cadvisor/assets/18641678/617d59c1-4094-485f-b294-f934cfd2b1e9)

```
# skopeo list-tags docker://registry.k8s.io/busybox
{
    "Repository": "registry.k8s.io/busybox",
    "Tags": [
        "1.24",
        "1.27",
        "1.27.2",
        "latest"
    ]
}
# docker pull registry.k8s.io/busybox
Using default tag: latest
latest: Pulling from busybox
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of registry.k8s.io/busybox:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
$ docker pull registry.k8s.io/busybox:1.27
1.27: Pulling from busybox
Digest: sha256:545e6a6310a27636260920bc07b994a299b6708a1b26910cfefd335fdfb60d2b
Status: Image is up to date for registry.k8s.io/busybox:1.27
registry.k8s.io/busybox:1.27

```