### PR TITLE
address another nil ptr check in podmanFactory.CanHandleAndAccept()

### DIFF
--- a/container/podman/factory.go
+++ b/container/podman/factory.go
@@ -94,7 +94,7 @@ func (f *podmanFactory) CanHandleAndAccept(name string) (handle bool, accept boo
 	if err != nil {
 		return false, true, fmt.Errorf("error inspecting container: %v", err)
 	}
-	if ctnr.State == nil || !ctnr.State.Running {
+	if ctnr.ContainerJSONBase == nil || ctnr.State == nil || !ctnr.State.Running {
 		return false, true, fmt.Errorf("container not running")
 	}
 	return true, true, nil


### PR DESCRIPTION
We ran into the same issue as #3464, but adding the check against `cntr.State` was insufficient to prevent the nil ptr panic.

The `ContainerJSON` type returned by `InspectContainer` embeds a ptr to `ContainerJSONBase`, and it seemed this ptr was nil in the return, leading cadvisor to crash loop on startup.

I haven't looked into the specific JSON response podman is returning to trigger this, so there's potentially a bug in the podman API itself where it returned a nil error and an empty payload in response to the inspect call.

I do see the podman daemon returning 500 error codes for some inspect queries, and it appears `validateResponse` (container/podman/podman.go:41) doesn't handle 5xx status codes? so that may be the underlying issue here - podman returns a 5xx and empty body, and the json decoder unmarshals it to a nil.

Happy to add handling for 5xx to this PR as an added measure if that is appropriate.