### PR TITLE
Fix wget ignoring env vars for no_proxy

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -66,6 +66,6 @@ EXPOSE 8080
 ENV CADVISOR_HEALTHCHECK_URL=http://localhost:8080/healthz
 
 HEALTHCHECK --interval=30s --timeout=3s \
-  CMD wget --quiet --tries=1 --spider $CADVISOR_HEALTHCHECK_URL || exit 1
+  CMD wget --quiet --tries=1 -Y off --spider $CADVISOR_HEALTHCHECK_URL || exit 1
 
 ENTRYPOINT ["/usr/bin/cadvisor", "-logtostderr"]

--- a/deploy/Dockerfile.ppc64le
+++ b/deploy/Dockerfile.ppc64le
@@ -14,7 +14,7 @@ ADD cadvisor /usr/bin/cadvisor
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s \
-  CMD wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
+  CMD wget --quiet --tries=1 -Y off --spider http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["/usr/bin/cadvisor", "-logtostderr"]
 


### PR DESCRIPTION
The cadvisor health check ends up sending requests to proxy instead of localhost. 

No_proxy being configured correctly I was able to narrow down the issue to the wget version within the image. As this should never be sent anywhere else than localhost disabling proxy entirely for the health-check is a valid solution.

```
# docker exec -it cadvisor /bin/sh
/ # wget --help
BusyBox v1.36.1 (2023-11-06 11:32:24 UTC) multi-call binary.
/ # wget --quiet --tries=1 --spider $CADVISOR_HEALTHCHECK_URL
wget: server returned error: HTTP/1.1 403 Forbidden
/ # wget --quiet --tries=1 -Y off --spider $CADVISOR_HEALTHCHECK_URL
```