### PR TITLE
fix: containerd handler missing `restartCount` label

### DIFF
--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -146,6 +147,16 @@ func newContainerdContainerHandler(
 	}
 	// Add the name and bare ID as aliases of the container.
 	handler.image = cntr.Image
+
+	// ignore err and get zero as default, this happens with sandboxes, not sure why...
+	// kube isn't sending restart count in labels for sandboxes.
+	if spec.Annotations != nil {
+		restartCount, _ := strconv.Atoi(spec.Annotations["io.kubernetes.container.restartCount"])
+		// Only adds restartcount label if it's greater than 0
+		if restartCount > 0 {
+			handler.labels["restartcount"] = strconv.Itoa(restartCount)
+		}
+	}
 
 	for _, exposedEnv := range metadataEnvAllowList {
 		if exposedEnv == "" {


### PR DESCRIPTION
```
root@localhost: crictl inspect 09eef3cd60125 | grep -i restart -C 5
      "version": "RELEASE.2022-11-17T23-20-09Z"
    },
    "annotations": {
      "io.kubernetes.container.hash": "cbda2490",
      "io.kubernetes.container.ports": "[{\"name\":\"api\",\"containerPort\":9000,\"protocol\":\"TCP\"},{\"name\":\"dashboard\",\"containerPort\":9001,\"protocol\":\"TCP\"}]",
      "io.kubernetes.container.restartCount": "1",
      "io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
      "io.kubernetes.container.terminationMessagePolicy": "File",
      "io.kubernetes.pod.terminationGracePeriod": "30"
    },
    "mounts": [
```

containerd handler could get `restartCount` from spec.Annotations, like `crio`
