### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -51,6 +51,7 @@ RUN export GO_TAGS="libpfm,netgo"; \
     GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
 
 FROM mirror.gcr.io/library/alpine:3.18
+LABEL org.opencontainers.image.source="https://github.com/google/cadvisor"
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils ndctl zfs && \


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md