### PR TITLE
Replace `commonLabels` with `labels`

### DIFF
--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cadvisor
-commonLabels:
-  app: cadvisor
+labels:
+  - pairs:
+      app: cadvisor
 resources:
 - daemonset.yaml
 - namespace.yaml


### PR DESCRIPTION
**Proposed change:**
Replaced the deprecated `commonLabels` with `labels`

**Supporting point:**
Currently, if executing the following command, the error will pop:
```bash
VERSION=v0.49.1
kustomize build "https://github.com/google/cadvisor/deploy/kubernetes/base?ref=${VERSION}" | kubectl apply -f -
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

**Justification of the change:**
In my consideration, both `includeSelectors` and `includeTemplates` are not needed. It does work without using them. But the behaviour of `commonLabels` (referring to old method) will use `includeSelectors` and `includeTemplates` mandatory, while these are not necessary at all.
If the team believes `includeSelectors` and `includeTemplates` are needed, please comment so and I will add them.