### PR TITLE
Support f2fs filesystem

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -183,6 +183,7 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 		"tmpfs":   true,
 		"xfs":     true,
 		"zfs":     true,
+                "f2fs":    true,
 	}
 
 	for _, mnt := range mounts {

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -570,6 +570,7 @@ func TestProcessMounts(t *testing.T) {
 				{Root: "/", Mountpoint: "/g", Source: "127.0.0.1:/nfs", FSType: "nfs4", Major: 253, Minor: 6},
 				{Root: "/", Mountpoint: "/test1", Source: "tmpfs", FSType: "tmpfs", Major: 253, Minor: 4},
 				{Root: "/", Mountpoint: "/test2", Source: "tmpfs", FSType: "tmpfs", Major: 253, Minor: 4},
+				{Root: "/", Mountpoint: "/h", Source: "/dev/sdh", FSType: "f2fs", Major: 253, Minor: 7},
 			},
 			expected: map[string]partition{
 				"/dev/sda":       {fsType: "ext3", mountpoint: "/a", major: 253, minor: 0},
@@ -581,6 +582,7 @@ func TestProcessMounts(t *testing.T) {
 				"127.0.0.1:/nfs": {fsType: "nfs4", mountpoint: "/g", major: 253, minor: 6},
 				"/test1":         {fsType: "tmpfs", mountpoint: "/test1", major: 253, minor: 4},
 				"/test2":         {fsType: "tmpfs", mountpoint: "/test2", major: 253, minor: 4},
+				"/dev/sdh":       {fsType: "f2fs", mountpoint: "/h", major: 253, minor: 7},
 			},
 		},
 	}


### PR DESCRIPTION
There is effort to run docker on Android https://github.com/opencontainers/runc/issues/4443. It is possible to run also k3s. Without this k3s will exit with following error
```
E1012 16:21:00.216260    7851 kubelet.go:1431] "Failed to start ContainerManager" err="failed to get rootfs info: failed to get mount point for device \"/dev/block/dm-53\": no partition info for device \"/dev/block/dm-53\""
```

Android uses following options to mount /data.
```
/dev/block/dm-53 on /data type f2fs (rw,lazytime,seclabel,nosuid,nodev,noatime,background_gc=on,discard,no_heap,user_xattr,inline_xattr,acl,inline_data,inline_dentry,extent_cache,mode=adaptive,active_logs=6,reserve_root=32768,resuid=0,resgid=1065,noatgc,inlinecrypt,alloc_mode=default,fsync_mode=nobarrier)
```
which is ignored during look up.

Testing requires:
1. patching kernel
2. adding this patch
3. patching https://github.com/opencontainers/runc/issues/4443
4. k3s can run in agent mode