### PR TITLE
Bump golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 15m
   linters-settings:
     govet:
       enable-all: true


### PR DESCRIPTION
5 mins is too small as i think the linter is doing more work ... (and failing in CI tests consistently)

https://testgrid.k8s.io/sig-node-cadvisor#cadvisor-e2e&width=20