### PR TITLE
Avoid linting in Prow CI jobs

### DIFF
--- a/build/prow_e2e.sh
+++ b/build/prow_e2e.sh
@@ -35,7 +35,7 @@ if [[ ! -z "$(git diff --name-only -- cmd/internal/pages)" ]]; then
   exit 1
 fi
 
-make all
+make build test
 
 # compile integration tests so they can be run without go installed
 go test -c github.com/google/cadvisor/integration/tests/api


### PR DESCRIPTION
Linting is failing in prow CI jobs. We should not be running linters in periodic CI jobs, 

By definition in Makefile, `all` is defined as:
```
all: presubmit build test
```

Since linters SHOULD be run in presubmits, let's skip them in https://testgrid.k8s.io/sig-node-cadvisor#cadvisor-e2e by limiting the targets to `build test`