### PR TITLE
Bump minimum Go version to 1.22 release

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,8 @@
 module github.com/google/cadvisor/cmd
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0
 
 // Record that the cmd module requires the cadvisor library module.
 // The github.com/google/cadvisor/cmd module is built using the Makefile

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/google/cadvisor
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
Per request in https://github.com/google/cadvisor/pull/3513#issuecomment-2433422512

cc @SergeyKanzhelev