### PR TITLE
machine: use `unix.ByteSliceToString`

### DIFF
--- a/machine/info.go
+++ b/machine/info.go
@@ -15,7 +15,6 @@
 package machine
 
 import (
-	"bytes"
 	"flag"
 	"os"
 	"path/filepath"
@@ -169,10 +168,8 @@ func ContainerOsVersion() string {
 
 func KernelVersion() string {
 	uname := &unix.Utsname{}
-
 	if err := unix.Uname(uname); err != nil {
 		return "Unknown"
 	}
-
-	return string(uname.Release[:bytes.IndexByte(uname.Release[:], 0)])
+	return unix.ByteSliceToString(uname.Release[:])
 }

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -257,7 +257,7 @@ func getMachineArch() string {
 		klog.Errorf("Cannot get machine architecture, err: %v", err)
 		return ""
 	}
-	return string(uname.Machine[:])
+	return unix.ByteSliceToString(uname.Machine[:])
 }
 
 // arm32 changes


### PR DESCRIPTION
Use the convenience function `ByteSliceToString` from `x/sys/unix` to convert `Utsname` members to string.