### PR TITLE
Revert "reduce_logs_for_kubelet_use_crio"

### DIFF
--- a/container/crio/factory.go
+++ b/container/crio/factory.go
@@ -32,9 +32,6 @@ import (
 // The namespace under which crio aliases are unique.
 const CrioNamespace = "crio"
 
-// The namespace suffix under which crio aliases are unique.
-const CrioNamespaceSuffix = ".scope"
-
 // The namespace systemd runs components under.
 const SystemdNamespace = "system-systemd"
 
@@ -117,20 +114,15 @@ func (f *crioFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 		// TODO(runcom): should we include crio-conmon cgroups?
 		return false, false, nil
 	}
-	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
-		return true, false, nil
-	}
 	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
 		return false, false, nil
+	}
+	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
+		return true, false, nil
 	}
 	// if the container is not associated with CRI-O, we can't handle it or accept it.
 	if !isContainerName(name) {
 		return false, false, nil
-	}
-
-	if !strings.HasSuffix(path.Base(name), CrioNamespaceSuffix) {
-		// this mean it's a sandbox container
-		return true, false, nil
 	}
 	return true, true, nil
 }

--- a/container/crio/factory_test.go
+++ b/container/crio/factory_test.go
@@ -20,11 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type canHandleAndAccept struct {
-	canHandle bool
-	canAccept bool
-}
-
 func TestCanHandleAndAccept(t *testing.T) {
 	as := assert.New(t)
 	f := &crioFactory{
@@ -36,18 +31,16 @@ func TestCanHandleAndAccept(t *testing.T) {
 		storageDir:         "",
 		includedMetrics:    nil,
 	}
-	for k, v := range map[string]canHandleAndAccept{
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":           {true, false},
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.scope":     {true, true},
-		"/system.slice/system-systemd\\\\x2dcoredump.slice":                                                                                 {true, false},
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.mount":     {false, false},
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":    {false, false},
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/no-crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f": {false, false},
-		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75":                    {false, false},
+	for k, v := range map[string]bool{
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":           true,
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.mount":     false,
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f":    false,
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/no-crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f": false,
+		"/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75":                    false,
 	} {
 		b1, b2, err := f.CanHandleAndAccept(k)
 		as.Nil(err)
-		as.Equal(b1, v.canHandle)
-		as.Equal(b2, v.canAccept)
+		as.Equal(b1, v)
+		as.Equal(b2, v)
 	}
 }


### PR DESCRIPTION
cherry-pick ca820b635076e6d7bfb85b39202836157966cb7b to v0.49

This reverts commit b407dcd7447be18a4e83c1fa4973469dacc32572.

Reference: https://github.com/google/cadvisor/issues/3577#issuecomment-2329906031