### PR TITLE
Reduce cgroups read frequency to avoid kernel kernfs clock pressure

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -541,8 +541,10 @@ func (m *manager) GetContainerInfoV2(containerName string, options v2.RequestOpt
 }
 
 func (m *manager) containerDataToContainerInfo(cont *containerData, query *info.ContainerInfoRequest) (*info.ContainerInfo, error) {
-	// Get the info from the container.
-	cinfo, err := cont.GetInfo(true)
+	// Get the info from the container. When GetInfo is set to false,
+	// it reads cgroups once every 5 seconds and gets data from containerData cache at other times,
+	// reducing the frequency of reading cgroups to avoid kernel kernfs clock pressure that could cause Linux machine to hang
+	cinfo, err := cont.GetInfo(false)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -65,6 +65,10 @@ func createManagerAndAddContainers(
 			spec,
 			nil,
 		).Once()
+		mockHandler.On("ListContainers", container.ListSelf).Return(
+			[]info.ContainerReference(nil),
+			nil,
+		).Once()
 		cont, err := newContainerData(name, memoryCache, mockHandler, false, &collector.GenericCollectorManager{}, 60*time.Second, true, clock.NewFakeClock(time.Now()))
 		if err != nil {
 			t.Fatal(err)
@@ -181,10 +185,6 @@ func expectManagerWithContainers(containers []string, query *info.ContainerInfoR
 			}
 			spec := cinfo.Spec
 
-			h.On("ListContainers", container.ListSelf).Return(
-				[]info.ContainerReference(nil),
-				nil,
-			)
 			h.On("GetSpec").Return(
 				spec,
 				nil,


### PR DESCRIPTION
Fixes #https://github.com/google/cadvisor/issues/3528

When `GetInfo` is called with false parameter, it now reads cgroups data once every 5 seconds and gets data from containerData cache at other times. This change reduces the frequency of reading cgroups to prevent potential Linux 
machine hangs caused by kernel kernfs clock pressure.

The change affects the `containerDataToContainerInfo` method in manager.go which is used to retrieve container information. By caching and reusing the cgroups data between reads, we reduce system load while still maintaining 
reasonably up-to-date container metrics.