### PR TITLE
exclude cgroups slab_reclaimable from container_memory_working_set_bytes

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -848,6 +848,12 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 			workingSet -= v
 		}
 	}
+
+	// Exclude "slab_reclaimable" from workingSet
+	if v, ok := s.MemoryStats.Stats["slab_reclaimable"]; ok {
+		workingSet -= v
+	}
+
 	ret.Memory.WorkingSet = workingSet
 }
 


### PR DESCRIPTION
Related to issue: #3081

"slab_reclaimable" should be excluded from container_memory_working_set_bytes. 

"slab_reclaimable" is only unused cached kernel structured, which can be freed on mem pressure. 