### PR TITLE
Fixed deprecated objects for kustomize

### DIFF
--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,8 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cadvisor
-commonLabels:
-  app: cadvisor
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    app.kubernetes.io/name: cadvisor
 resources:
 - daemonset.yaml
 - namespace.yaml

--- a/deploy/kubernetes/overlays/examples/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples/kustomization.yaml
@@ -4,4 +4,3 @@ patches:
 - path: ./stackdriver-sidecar.yaml
 - path: ./critical-priority.yaml
 - path: ./cadvisor-args.yaml
-- path: ./gpu-privilages.yaml

--- a/deploy/kubernetes/overlays/examples/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples/kustomization.yaml
@@ -1,7 +1,7 @@
 bases:
 - ../../base
 patches:
-- stackdriver-sidecar.yaml
-- critical-priority.yaml
-- cadvisor-args.yaml
-- gpu-privilages.yaml
+- path: ./stackdriver-sidecar.yaml
+- path: ./critical-priority.yaml
+- path: ./cadvisor-args.yaml
+- path: ./gpu-privilages.yaml

--- a/deploy/kubernetes/overlays/examples/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - ../../base
 patches:
 - path: ./stackdriver-sidecar.yaml

--- a/deploy/kubernetes/overlays/examples_perf/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples_perf/kustomization.yaml
@@ -1,6 +1,5 @@
-bases:
-- ../../base
 resources:
-- configmap.yaml
+- ../../base
+- ./configmap.yaml
 patches:
 - path: ./cadvisor-perf.yaml

--- a/deploy/kubernetes/overlays/examples_perf/kustomization.yaml
+++ b/deploy/kubernetes/overlays/examples_perf/kustomization.yaml
@@ -3,4 +3,4 @@ bases:
 resources:
 - configmap.yaml
 patches:
-- cadvisor-perf.yaml
+- path: ./cadvisor-perf.yaml


### PR DESCRIPTION
this PR addresses and fixed deprecated patches and objects in kustomize examples

1) replaced deprecated patches with the Patches field, which provides a superset of the functionality of PatchesStrategicMerge
2) removed non-existent patch that was previously causing issues
3) updated deprecated bases for resources to the correct format
4) replace deprecated commonLabels to align with the latest best practices