### PR TITLE
Add udp metrics

### DIFF
--- a/cmd/cadvisor.go
+++ b/cmd/cadvisor.go
@@ -83,6 +83,7 @@ var (
 		container.NetworkTcpUsageMetrics:         struct{}{},
 		container.NetworkUdpUsageMetrics:         struct{}{},
 		container.NetworkAdvancedTcpUsageMetrics: struct{}{},
+		container.NetworkAdvancedUdpUsageMetrics: struct{}{},
 		container.ProcessSchedulerMetrics:        struct{}{},
 		container.ProcessMetrics:                 struct{}{},
 		container.HugetlbUsageMetrics:            struct{}{},

--- a/cmd/cadvisor_test.go
+++ b/cmd/cadvisor_test.go
@@ -41,6 +41,12 @@ func TestUdpMetricsAreDisabledByDefault(t *testing.T) {
 	assert.True(t, ignoreMetrics.Has(container.NetworkUdpUsageMetrics))
 }
 
+func TestAdvancedUdpMetricsAreDisabledByDefault(t *testing.T) {
+	assert.True(t, ignoreMetrics.Has(container.NetworkAdvancedUdpUsageMetrics))
+	flag.Parse()
+	assert.True(t, ignoreMetrics.Has(container.NetworkAdvancedUdpUsageMetrics))
+}
+
 func TestReferencedMemoryMetricsIsDisabledByDefault(t *testing.T) {
 	assert.True(t, ignoreMetrics.Has(container.ReferencedMemoryMetrics))
 	flag.Parse()
@@ -103,6 +109,7 @@ func TestToIncludedMetrics(t *testing.T) {
 			container.NetworkTcpUsageMetrics:         struct{}{},
 			container.NetworkAdvancedTcpUsageMetrics: struct{}{},
 			container.NetworkUdpUsageMetrics:         struct{}{},
+			container.NetworkAdvancedUdpUsageMetrics: struct{}{},
 			container.ProcessMetrics:                 struct{}{},
 			container.AppMetrics:                     struct{}{},
 			container.HugetlbUsageMetrics:            struct{}{},

--- a/container/factory.go
+++ b/container/factory.go
@@ -57,6 +57,7 @@ const (
 	NetworkTcpUsageMetrics         MetricKind = "tcp"
 	NetworkAdvancedTcpUsageMetrics MetricKind = "advtcp"
 	NetworkUdpUsageMetrics         MetricKind = "udp"
+	NetworkAdvancedUdpUsageMetrics MetricKind = "advudp"
 	AppMetrics                     MetricKind = "app"
 	ProcessMetrics                 MetricKind = "process"
 	HugetlbUsageMetrics            MetricKind = "hugetlb"
@@ -82,6 +83,7 @@ var AllMetrics = MetricSet{
 	NetworkTcpUsageMetrics:         struct{}{},
 	NetworkAdvancedTcpUsageMetrics: struct{}{},
 	NetworkUdpUsageMetrics:         struct{}{},
+	NetworkAdvancedUdpUsageMetrics: struct{}{},
 	ProcessMetrics:                 struct{}{},
 	AppMetrics:                     struct{}{},
 	HugetlbUsageMetrics:            struct{}{},
@@ -99,6 +101,7 @@ var AllNetworkMetrics = MetricSet{
 	NetworkTcpUsageMetrics:         struct{}{},
 	NetworkAdvancedTcpUsageMetrics: struct{}{},
 	NetworkUdpUsageMetrics:         struct{}{},
+	NetworkAdvancedUdpUsageMetrics: struct{}{},
 }
 
 func (mk MetricKind) String() string {

--- a/container/libcontainer/handler_test.go
+++ b/container/libcontainer/handler_test.go
@@ -91,6 +91,18 @@ func TestScanUDPStats(t *testing.T) {
 	}
 }
 
+func TestScanAdvancedTCPStats(t *testing.T) {
+	snmpFile := "testdata/snmp"
+	advancedStats := info.TcpAdvancedStat{}
+	err := scanAdvancedTCPStats(&advancedStats, snmpFile)
+	if err != nil {
+		t.Error(err)
+	}
+	if advancedStats.RtoAlgorithm != 1 {
+		t.Errorf("Expected RtoAlgorithm 1, got %d", advancedStats.RtoAlgorithm)
+	}
+}
+
 // https://github.com/docker/libcontainer/blob/v2.2.1/cgroups/fs/cpuacct.go#L19
 const nanosecondsInSeconds = 1000000000
 

--- a/container/libcontainer/handler_test.go
+++ b/container/libcontainer/handler_test.go
@@ -144,6 +144,21 @@ func TestScanAdvancedTCPStats(t *testing.T) {
 	}
 }
 
+func TestScanAdvanceUDPStats(t *testing.T) {
+	snmpFile := "testdata/snmp"
+	advancedStats := info.UdpAdvancedStat{}
+	err := scanAdvancedUDPStats(&advancedStats, snmpFile)
+	if err != nil {
+		t.Error(err)
+	}
+	if advancedStats.InErrors != 8 {
+		t.Errorf("Expected InErrors 0, got %d", advancedStats.InErrors)
+	}
+	if advancedStats.NoPorts != 8996 {
+		t.Errorf("Expected NoPorts 0, got %d", advancedStats.NoPorts)
+	}
+}
+
 // https://github.com/docker/libcontainer/blob/v2.2.1/cgroups/fs/cpuacct.go#L19
 const nanosecondsInSeconds = 1000000000
 

--- a/container/libcontainer/testdata/snmp
+++ b/container/libcontainer/testdata/snmp
@@ -1,0 +1,12 @@
+Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
+Ip: 1 64 22010002886 126 0 3897 0 0 21992054949 20118212517 1 3835921 465 396834 198179 465 250500 54 501915
+Icmp: InMsgs InErrors InCsumErrors InDestUnreachs InTimeExcds InParmProbs InSrcQuenchs InRedirects InEchos InEchoReps InTimestamps InTimestampReps InAddrMasks InAddrMaskReps OutMsgs OutErrors OutDestUnreachs OutTimeExcds OutParmProbs OutSrcQuenchs OutRedirects OutEchos OutEchoReps OutTimestamps OutTimestampReps OutAddrMasks OutAddrMaskReps
+Icmp: 44109161 84392 2 344441 2262297 0 0 79 25614079 15888259 1 0 2 0 54115640 0 4100211 227 0 0 0 24401136 25614065 0 1 0 0
+IcmpMsg: InType0 InType3 InType5 InType8 InType11 InType13 InType17 InType165 OutType0 OutType3 OutType8 OutType11 OutType14
+IcmpMsg: 15888259 344441 79 25614079 2262297 1 2 1 25614065 4100211 24401136 227 1
+Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 241161083 2999339 892122 2075279 493 21773277356 28027757848 82377554 39722 274330587 0
+Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti
+Udp: 174675874 8996 8 174697410 8 0 0 0
+UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti
+UdpLite: 2 1 0 3 0 0 0 0

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -463,6 +463,8 @@ type NetworkStats struct {
 	Udp6 UdpStat `json:"udp6"`
 	// TCP advanced stats
 	TcpAdvanced TcpAdvancedStat `json:"tcp_advanced"`
+	// UDP advanced stats
+	UdpAdvanced UdpAdvancedStat `json:"udp_advanced"`
 }
 
 type TcpStat struct {
@@ -741,6 +743,34 @@ type UdpStat struct {
 
 	// Count of packets Queued for Transmit
 	TxQueued uint64
+}
+
+type UdpAdvancedStat struct {
+	// The total number of datagrams successfully received, excluding those
+	// discarded due to no ports, errors, etc.
+	InDatagrams uint64
+
+	// The number of datagrams discarded because no listening ports were available.
+	NoPorts uint64
+
+	// The number of datagrams discarded due to errors, including checksum errors,
+	// receive buffer errors, and other related issues.
+	InErrors uint64
+
+	// The total number of datagrams successfully transmitted.
+	OutDatagrams uint64
+
+	// The number of datagrams dropped due to insufficient memory in the received buffer.
+	RcvbufErrors uint64
+
+	// The number of datagrams dropped due to insufficient memory in the send buffer.
+	SndbufErrors uint64
+
+	// The number of datagrams discarded due to invalid checksums.
+	InCsumErrors uint64
+
+	// The number of datagrams discarded because multicast packets were ignored.
+	IgnoredMulti uint64
 }
 
 type FsStats struct {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1515,6 +1515,60 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 			},
 		}...)
 	}
+	if includedMetrics.Has(container.NetworkAdvancedUdpUsageMetrics) {
+		c.containerMetrics = append(c.containerMetrics, []containerMetric{
+			{
+				name:        "container_network_advance_udp_stats_total",
+				help:        "advance udp statistic for container",
+				valueType:   prometheus.CounterValue,
+				extraLabels: []string{"udp_state"},
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{
+						{
+							value:     float64(s.Network.UdpAdvanced.InDatagrams),
+							labels:    []string{"indatagrams"},
+							timestamp: s.Timestamp,
+						},
+						{
+							value:     float64(s.Network.UdpAdvanced.NoPorts),
+							labels:    []string{"noports"},
+							timestamp: s.Timestamp,
+						},
+						{
+							value:     float64(s.Network.UdpAdvanced.InErrors),
+							labels:    []string{"inerrors"},
+							timestamp: s.Timestamp,
+						},
+						{
+							value:     float64(s.Network.UdpAdvanced.OutDatagrams),
+							labels:    []string{"outdatagrams"},
+							timestamp: s.Timestamp,
+						},
+						{
+							value:     float64(s.Network.UdpAdvanced.RcvbufErrors),
+							labels:    []string{"rcvbuferrors"},
+							timestamp: s.Timestamp,
+						},
+						{
+							value:     float64(s.Network.UdpAdvanced.SndbufErrors),
+							labels:    []string{"sndbuferrors"},
+							timestamp: s.Timestamp,
+						},
+						{
+							value:     float64(s.Network.UdpAdvanced.InCsumErrors),
+							labels:    []string{"incsumerrors"},
+							timestamp: s.Timestamp,
+						},
+						{
+							value:     float64(s.Network.UdpAdvanced.IgnoredMulti),
+							labels:    []string{"ignoredmulti"},
+							timestamp: s.Timestamp,
+						},
+					}
+				},
+			},
+		}...)
+	}
 	if includedMetrics.Has(container.ProcessMetrics) {
 		c.containerMetrics = append(c.containerMetrics, []containerMetric{
 			{

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -535,6 +535,16 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 							RxQueued: 0,
 							TxQueued: 0,
 						},
+						UdpAdvanced: info.UdpAdvancedStat{
+							InDatagrams:  174675874,
+							NoPorts:      8996,
+							InErrors:     8,
+							OutDatagrams: 174697410,
+							RcvbufErrors: 8,
+							SndbufErrors: 0,
+							InCsumErrors: 0,
+							IgnoredMulti: 0,
+						},
 					},
 					DiskIo: info.DiskIoStats{
 						IoServiceBytes: []info.PerDiskStats{{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -296,6 +296,16 @@ container_network_advance_tcp_stats_total{container_env_foo_env="prod",container
 container_network_advance_tcp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="tw",zone_name="hello"} 1.0436427e+07 1395066363000
 container_network_advance_tcp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="twkilled",zone_name="hello"} 0 1395066363000
 container_network_advance_tcp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",tcp_state="twrecycled",zone_name="hello"} 0 1395066363000
+# HELP container_network_advance_udp_stats_total advance udp statistic for container
+# TYPE container_network_advance_udp_stats_total counter
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="ignoredmulti",zone_name="hello"} 0 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="incsumerrors",zone_name="hello"} 0 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="indatagrams",zone_name="hello"} 1.74675874e+08 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="inerrors",zone_name="hello"} 8 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="noports",zone_name="hello"} 8996 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="outdatagrams",zone_name="hello"} 1.7469741e+08 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="rcvbuferrors",zone_name="hello"} 8 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",udp_state="sndbuferrors",zone_name="hello"} 0 1395066363000
 # HELP container_network_receive_bytes_total Cumulative count of bytes received
 # TYPE container_network_receive_bytes_total counter
 container_network_receive_bytes_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 14 1395066363000

--- a/metrics/testdata/prometheus_metrics_whitelist_filtered
+++ b/metrics/testdata/prometheus_metrics_whitelist_filtered
@@ -296,6 +296,16 @@ container_network_advance_tcp_stats_total{container_env_foo_env="prod",id="testc
 container_network_advance_tcp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",tcp_state="tw",zone_name="hello"} 1.0436427e+07 1395066363000
 container_network_advance_tcp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",tcp_state="twkilled",zone_name="hello"} 0 1395066363000
 container_network_advance_tcp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",tcp_state="twrecycled",zone_name="hello"} 0 1395066363000
+# HELP container_network_advance_udp_stats_total advance udp statistic for container
+# TYPE container_network_advance_udp_stats_total counter
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="ignoredmulti",zone_name="hello"} 0 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="incsumerrors",zone_name="hello"} 0 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="indatagrams",zone_name="hello"} 1.74675874e+08 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="inerrors",zone_name="hello"} 8 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="noports",zone_name="hello"} 8996 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="outdatagrams",zone_name="hello"} 1.7469741e+08 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="rcvbuferrors",zone_name="hello"} 8 1395066363000
+container_network_advance_udp_stats_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",udp_state="sndbuferrors",zone_name="hello"} 0 1395066363000
 # HELP container_network_receive_bytes_total Cumulative count of bytes received
 # TYPE container_network_receive_bytes_total counter
 container_network_receive_bytes_total{container_env_foo_env="prod",id="testcontainer",image="test",interface="eth0",name="testcontaineralias",zone_name="hello"} 14 1395066363000


### PR DESCRIPTION
# Add Advanced UDP Statistics

## What
Add advanced UDP statistics for problem diagnosis, sourcing data from `/proc/net/snmp`. Currently, cAdvisor only retrieves basic UDP metrics from `/proc/net/udp` and `/proc/net/udp6`, which tend to be unreliable due to frequent value changes.
related: #3657 

## Why
- Current UDP metrics are of low quality due to frequent value changes leading to inconsistent data
- `/proc/net/snmp` provides more comprehensive UDP statistics, similar to existing advanced TCP metrics

## How
1. Add new UdpAdvancedStat structure with the following fields:
- InDatagrams - Total number of datagrams successfully received
- NoPorts - Number of datagrams discarded due to no available ports
- InErrors - Number of datagrams discarded due to errors
- OutDatagrams - Total number of datagrams successfully transmitted
- RcvbufErrors - Number of datagrams dropped due to insufficient receive buffer
- SndbufErrors - Number of datagrams dropped due to insufficient send buffer
- InCsumErrors - Number of datagrams discarded due to checksum errors
- IgnoredMulti - Number of datagrams discarded due to ignored multicast


2. Parse these metrics from `/proc/net/snmp` and add them to container statistics

Example output:
```json
"udp_advanced": {
    "InDatagrams": 174527561,
    "NoPorts": 8979,
    "InErrors": 8,
    "OutDatagrams": 174548568,
    "RcvbufErrors": 8,
    "SndbufErrors": 0,
    "InCsumErrors": 0,
    "IgnoredMulti": 0
}
```

## Testing
- Added unit tests to verify UDP statistics parsing from `/proc/net/snmp`
- Manually tested metric collection
