### PR TITLE
fix array index out of bounds

### DIFF
--- a/summary/percentiles.go
+++ b/summary/percentiles.go
@@ -44,9 +44,17 @@ func (s Uint64Slice) GetPercentile(d float64) uint64 {
 		return 0
 	}
 	sort.Sort(s)
+	if d == 1 {
+		return s[count-1]
+	}
 	n := float64(d * (float64(count) + 1))
 	idx, frac := math.Modf(n)
 	index := int(idx)
+
+	if index < 1 {
+		index = 1
+	}
+
 	percentile := float64(s[index-1])
 	if index > 1 && index < count {
 		percentile += frac * float64(s[index]-s[index-1])

--- a/summary/percentiles_test.go
+++ b/summary/percentiles_test.go
@@ -46,6 +46,14 @@ func TestPercentile(t *testing.T) {
 	assertPercentile(t, s, 0.2, 21)
 	assertPercentile(t, s, 0.7, 74)
 	assertPercentile(t, s, 0.9, 95)
+
+	// boundary value
+	assertPercentile(t, s[:5], 0.9, 5)
+	assertPercentile(t, s[:5], 1.1, 0)
+	assertPercentile(t, []uint64{}, 0, 0)
+	assertPercentile(t, s, 0, 1)
+	assertPercentile(t, s[:11], 1, 11)
+	assertPercentile(t, s, 1.0, 105)
 }
 
 func TestMean(t *testing.T) {


### PR DESCRIPTION
panic stack:
```
panic: runtime error: index out of range [-1]

goroutine 565 [running]:
k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary.Uint64Slice.GetPercentile({0xc001216ba0?, 0x1, 0x1000000000008?}, 0x3fee666666666666)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary/percentiles.go:50 +0x16a
k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary.(*resource).GetAllPercentiles(0xc001026440)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary/percentiles.go:123 +0xef
k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary.GetDerivedPercentiles({0xc000435848, 0x1, 0xc0010265a0?})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary/percentiles.go:145 +0x2a8
k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary.(*StatsSummary).getDerivedUsage(0x7fac0c1608c0?, 0x3c)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary/summary.go:157 +0x252
k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary.(*StatsSummary).updateDerivedStats(0xc001f0b040)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary/summary.go:127 +0x1c9
k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary.(*StatsSummary).AddSample(_, {{0xc1e67c2f39724857, 0xeeb2856cf, 0x55d669537980}, {{0xcef01a09f, {0x0, 0x0, 0x0}, 0xa33478c80, 0x260903c80}, ...}, ...})
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/summary/summary.go:88 +0x3bb
k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager.(*containerData).updateStats(0xc001c37b80)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager/container.go:677 +0x345
k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager.(*containerData).housekeepingTick(0xc001c37b80, 0x7c?, 0x5f5e100)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager/container.go:595 +0x165
k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager.(*containerData).housekeeping(0xc001c37b80)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager/container.go:543 +0x446
created by k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager.(*containerData).Start
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/google/cadvisor/manager/container.go:130 +0x56
```
