### PR TITLE
fix: fix conn leak

### DIFF
--- a/utils/cpuload/netlink/reader.go
+++ b/utils/cpuload/netlink/reader.go
@@ -36,6 +36,7 @@ func New() (*NetlinkReader, error) {
 
 	id, err := getFamilyID(conn)
 	if err != nil {
+		conn.Close()
 		return nil, fmt.Errorf("failed to get netlink family id for task stats: %s", err)
 	}
 	klog.V(4).Infof("Family id for taskstats: %d", id)


### PR DESCRIPTION
The conn leak problem was encountered in a real environment. The following configuration parameters are opened：
-enable_load_reader=true  
#3126 
