### PR TITLE
feat: support podman volatile containers

### DIFF
--- a/container/podman/fs.go
+++ b/container/podman/fs.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	containersJSONFilename = "containers.json"
+	containersJSONFilename         = "containers.json"
+	volatileContainersJSONFilename = "volatile-containers.json"
 )
 
 type containersJSON struct {
@@ -42,6 +43,25 @@ func rwLayerID(storageDriver docker.StorageDriver, storageDir string, containerI
 	err = json.Unmarshal(data, &containers)
 	if err != nil {
 		return "", err
+	}
+
+	// Read volatile-containers.json if it exists.
+	// This is important for Podman Quadlets since they are not presented in the containers.json file.
+	volatileData, err := os.ReadFile(filepath.Join(
+		storageDir,
+		string(storageDriver)+"-containers",
+		volatileContainersJSONFilename,
+	))
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if volatileData != nil {
+		var volatileContainers []containersJSON
+		err = json.Unmarshal(volatileData, &volatileContainers)
+		if err != nil {
+			return "", err
+		}
+		containers = append(containers, volatileContainers...)
 	}
 
 	for _, c := range containers {


### PR DESCRIPTION
It's used by all Podman Quadlets. Those containers are not in fact volatile, but due to the managed nature of those containers, they probably decided to make them transient.

This fix will close #3648.