### PR TITLE
Updating Alpine deploy image version to be in line with build image version

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -50,7 +50,7 @@ RUN export GO_TAGS="libpfm,netgo"; \
     fi; \
     GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
 
-FROM mirror.gcr.io/library/alpine:3.18
+FROM mirror.gcr.io/library/alpine:3.21
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils ndctl zfs && \


### PR DESCRIPTION
Updates deploy version of Alpine from 3.18 to 3.21

* 3.18 is no longer supported
* 3.21 is the same as the build version