### PR TITLE
Rebase to alpine 3.22, install thin-provisioning-tools from main repo

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,9 +1,8 @@
-FROM registry.hub.docker.com/library/golang:1.24-alpine3.21 AS build
+FROM registry.hub.docker.com/library/golang:1.24-alpine3.22 AS build
 
 # Install build depdencies for all supported arches
 RUN apk --no-cache add bash build-base cmake device-mapper findutils git \
-                       libc6-compat linux-headers ndctl-dev pkgconfig python3 wget zfs && \
-    apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
+                       libc6-compat linux-headers ndctl-dev pkgconfig python3 thin-provisioning-tools wget zfs && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     rm -rf /var/cache/apk/*
 
@@ -50,11 +49,10 @@ RUN export GO_TAGS="libpfm,netgo"; \
     fi; \
     GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
 
-FROM mirror.gcr.io/library/alpine:3.18
+FROM mirror.gcr.io/library/alpine:3.22
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
-RUN apk --no-cache add libc6-compat device-mapper findutils ndctl zfs && \
-    apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
+RUN apk --no-cache add libc6-compat device-mapper findutils ndctl thin-provisioning-tools zfs && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
This PR rebases the build and runtime base images to the latest stable Alpine 3.22. Golang version is still the same 1.24. It also installs thin-provisioning-tools from the 3.22 repo instead of edge.

It looks like thin-provisioning-tools was being installed from the edge repo 5 years ago, presumably because at the time the edge repo contained a newer version that was required. At this point the edge repo contains the same exact version as the 3.22 repo so there is no need to install from edge.

Plus, installing packages from the edge repo is usually not recommended unless absolutely necessary. Even then, the base version needs to be recent enough to prevent dep clashes. Currently, the base image used is still 3.18, which is several years old. Edge on the other hand is a rolling branch, so it is trying to install a brand new package on a base from several years ago, which is not an ideal situation.