### PR TITLE
oomparser - new constructor to support streaming of new/current OOM events only.

### DIFF
--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -154,16 +154,21 @@ func (p *OomParser) StreamOoms(outStream chan<- *OomInstance) {
 // NewFromNow initializes an OomParser object that returns current OOM events only. In this mode the OomParser object
 // will not send OOM events that occurred before the OomParser object was constructed.
 func NewFromNow() (*OomParser, error) {
-	parser, err := New()
+	parser, err := kmsgparser.NewParser()
 	if err != nil {
 		return nil, err
 	}
+	parser.SetLogger(glogAdapter{})
 
+	return newFromNow(parser)
+}
+
+func newFromNow(parser kmsgparser.Parser) (*OomParser, error) {
 	// seek to and set the offset at the end of /dev/kmsg to avoid reporting old OOM events
-	if err := parser.parser.SeekEnd(); err != nil {
+	if err := parser.SeekEnd(); err != nil {
 		return nil, err
 	}
-	return parser, nil
+	return &OomParser{parser: parser}, nil
 }
 
 // initializes an OomParser object. Returns an OomParser object and an error.

--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -151,6 +151,21 @@ func (p *OomParser) StreamOoms(outStream chan<- *OomInstance) {
 	klog.Errorf("exiting analyzeLines. OOM events will not be reported.")
 }
 
+// NewFromEndOfFile initializes an OomParser object that starts reading from the end of the kernel log.
+// This will ignore any OOM events that occurred before the parser was created.
+func NewFromEndOfFile() (*OomParser, error) {
+	parser, err := New()
+	if err != nil {
+		return nil, err
+	}
+
+	// seek to and set the offset at the end of /dev/kmsg to avoid reporting old OOM events
+	if err := parser.parser.SeekEnd(); err != nil {
+		return nil, err
+	}
+	return parser, nil
+}
+
 // initializes an OomParser object. Returns an OomParser object and an error.
 func New() (*OomParser, error) {
 	parser, err := kmsgparser.NewParser()

--- a/utils/oomparser/oomparser.go
+++ b/utils/oomparser/oomparser.go
@@ -151,9 +151,9 @@ func (p *OomParser) StreamOoms(outStream chan<- *OomInstance) {
 	klog.Errorf("exiting analyzeLines. OOM events will not be reported.")
 }
 
-// NewFromEndOfFile initializes an OomParser object that starts reading from the end of the kernel log.
-// This will ignore any OOM events that occurred before the parser was created.
-func NewFromEndOfFile() (*OomParser, error) {
+// NewFromNow initializes an OomParser object that returns current OOM events only. In this mode the OomParser object
+// will not send OOM events that occurred before the OomParser object was constructed.
+func NewFromNow() (*OomParser, error) {
 	parser, err := New()
 	if err != nil {
 		return nil, err

--- a/utils/oomparser/oomparser_test.go
+++ b/utils/oomparser/oomparser_test.go
@@ -473,11 +473,14 @@ func TestStreamOOMs(t *testing.T) {
 }
 
 type mockKmsgParser struct {
-	messages chan kmsgparser.Message
+	messages      chan kmsgparser.Message
+	seekEndCalled bool
+	seekEndErr    error
 }
 
 func (m *mockKmsgParser) SeekEnd() error {
-	return nil
+	m.seekEndCalled = true
+	return m.seekEndErr
 }
 
 func (m *mockKmsgParser) Parse() <-chan kmsgparser.Message {
@@ -488,4 +491,29 @@ func (m *mockKmsgParser) SetLogger(kmsgparser.Logger) {}
 func (m *mockKmsgParser) Close() error {
 	close(m.messages)
 	return nil
+}
+
+func TestNewFromNow(t *testing.T) {
+	mockParser := &mockKmsgParser{
+		messages: make(chan kmsgparser.Message),
+	}
+
+	p, err := newFromNow(mockParser)
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.Equal(t, mockParser, p.parser)
+	assert.True(t, mockParser.seekEndCalled, "SeekEnd should have been called")
+}
+
+func TestNewFromNow_SeekEndError(t *testing.T) {
+	expectedErr := fmt.Errorf("seek error")
+	mockParser := &mockKmsgParser{
+		messages:   make(chan kmsgparser.Message),
+		seekEndErr: expectedErr,
+	}
+
+	p, err := newFromNow(mockParser)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, p)
+	assert.True(t, mockParser.seekEndCalled)
 }


### PR DESCRIPTION
### Summary

This adds a new constructor `NewFromNow` that moves the `/dev/kmsg` reader offset to the end of the queue. Allowing the user to ignore OOM events that occurred prior to the creation of the `OomParser` object.

### Examples

#### Create stream using `New` (default behaviour)

Returns all available OOM events in the kmsg buffer. This is the default behaviour and is _not_ changed.

```sh
$ sudo go run oomexample/main.go 
I0727 20:31:50.742685 1989715 main.go:48] Reading the buffer. Output is &{393038 stress-ng-vm 2025-07-25 23:11:27.182087673 +0000 UTC m=-163223.536149722 /system.slice/docker-4876bd1d7f860bacc8df1c342f058bb861c41a328a1cce0b753eae6f0849b241.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podd993a249_6fb5_48dc_90fe_5c176fa43a7f.slice/cri-containerd-85a888cadb58adab390959abaa0db3996a9997193d137ed321dcf0e0b56c680b.scope /system.slice/docker-4876bd1d7f860bacc8df1c342f058bb861c41a328a1cce0b753eae6f0849b241.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podd993a249_6fb5_48dc_90fe_5c176fa43a7f.slice CONSTRAINT_MEMCG}
I0727 20:31:50.743393 1989715 main.go:48] Reading the buffer. Output is &{393053 stress-ng-vm 2025-07-25 23:11:27.910033673 +0000 UTC m=-163222.808203722 /system.slice/docker-4876bd1d7f860bacc8df1c342f058bb861c41a328a1cce0b753eae6f0849b241.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podd993a249_6fb5_48dc_90fe_5c176fa43a7f.slice/cri-containerd-85a888cadb58adab390959abaa0db3996a9997193d137ed321dcf0e0b56c680b.scope /system.slice/docker-4876bd1d7f860bacc8df1c342f058bb861c41a328a1cce0b753eae6f0849b241.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podd993a249_6fb5_48dc_90fe_5c176fa43a7f.slice CONSTRAINT_MEMCG}
I0727 20:31:50.744026 1989715 main.go:48] Reading the buffer. Output is &{393056 stress-ng-vm 2025-07-25 23:11:28.623308673 +0000 UTC m=-163222.094928722 /system.slice/docker-4876bd1d7f860bacc8df1c342f058bb861c41a328a1cce0b753eae6f0849b241.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podd993a249_6fb5_48dc_90fe_5c176fa43a7f.slice/cri-containerd-85a888cadb58adab390959abaa0db3996a9997193d137ed321dcf0e0b56c680b.scope /system.slice/docker-4876bd1d7f860bacc8df1c342f058bb861c41a328a1cce0b753eae6f0849b241.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podd993a249_6fb5_48dc_90fe_5c176fa43a7f.slice CONSTRAINT_MEMCG}
```

#### Create stream using `NewFromNow`

When launched, old OOM events are ignored and net new events are reported (as seen at `I0727 20:05:50.120013`)

```
$ sudo go run oomexample/main.go -ignore_old
I0727 20:05:50.120013 1966714 main.go:48] Reading the buffer. Output is &{1967893 awk 2025-07-27 20:05:46.893944354 +0000 UTC m=+51.345637220 /system.slice/docker-8e95fa377f7d8be8aa72ddb5cf50b76111d3d6c4d89f2048c597a7b2fb6970b0.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-pod0997ebc7_7b70_4a20_9a87_c7eca4342fc9.slice/cri-containerd-cb0c72b671bad34ce5255356006d91fdd704506e8da2b51887168f29815ef9ac.scope /system.slice/docker-8e95fa377f7d8be8aa72ddb5cf50b76111d3d6c4d89f2048c597a7b2fb6970b0.scope/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-pod0997ebc7_7b70_4a20_9a87_c7eca4342fc9.slice CONSTRAINT_MEMCG}
```



## Related

* Resolves https://github.com/google/cadvisor/issues/3715