### PR TITLE
Docs: remove note on Debian not supporting memory controller

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -82,11 +82,6 @@ docker run
 google/cadvisor:latest
 ```
 
-
-### Debian
-
-By default, Debian disables the memory cgroup which does not allow cAdvisor to gather memory stats. To enable the memory cgroup take a look at [these instructions](https://github.com/google/cadvisor/issues/432).
-
 ### LXC Docker exec driver
 
 If you are using Docker with the LXC exec driver, then you need to manually specify all cgroup mounts by adding the:


### PR DESCRIPTION
Since Debian 9, the memory controller is enabled by default. As that version has been EOL for 3 years (2022-07-01), I think this note can be removed.