### PR TITLE
Fix RFC reference in TcpAdvancedStat comments

### DIFF
--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -516,7 +516,7 @@ type TcpStat struct {
 
 type TcpAdvancedStat struct {
 	// The algorithm used to determine the timeout value used for
-	// retransmitting unacknowledged octets, ref: RFC2698, default 1
+	// retransmitting unacknowledged octets, ref: RFC2012, default 1
 	RtoAlgorithm uint64
 	// The minimum value permitted by a TCP implementation for the
 	// retransmission timeout, measured in milliseconds, default 200ms


### PR DESCRIPTION
See https://github.com/torvalds/linux/blob/7e161a991ea71e6ec526abc8f40c6852ebe3d946/include/net/tcp.h#L1805.