### PR TITLE
feat: add LoadTaskProcess api in containerd client

### DIFF
--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -45,6 +45,7 @@ type client struct {
 type ContainerdClient interface {
 	LoadContainer(ctx context.Context, id string) (*containers.Container, error)
 	TaskPid(ctx context.Context, id string) (uint32, error)
+	LoadTaskProcess(ctx context.Context, id string) (*tasktypes.Process, error)
 	Version(ctx context.Context) (string, error)
 }
 
@@ -130,6 +131,17 @@ func (c *client) TaskPid(ctx context.Context, id string) (uint32, error) {
 		return 0, ErrTaskIsInUnknownState
 	}
 	return response.Process.Pid, nil
+}
+
+func (c *client) LoadTaskProcess(ctx context.Context, id string) (*tasktypes.Process, error) {
+	response, err := c.taskService.Get(ctx, &tasksapi.GetRequest{
+		ContainerID: id,
+	})
+	if err != nil {
+		return nil, errgrpc.ToNative(err)
+	}
+
+	return response.Process, nil
 }
 
 func (c *client) Version(ctx context.Context) (string, error) {


### PR DESCRIPTION
This commit aims to add an api to get the task process of the containerd client.
We have a use case where we are trying to consume the exited containers and get their exit code however the current implementation of the client doesn't expose this api.
The broader issue and use case is captured here
https://github.com/google/cadvisor/issues/3722, currently we are working on a workaround and require this api.