### PR TITLE
fix: support podman `volatile-containers.json` and/or `containers.json`

### DIFF
--- a/container/podman/fs.go
+++ b/container/podman/fs.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	containersJSONFilename = "containers.json"
+	containersJSONFilename         = "containers.json"
+	volatileContainersJSONFilename = "volatile-containers.json"
 )
 
 type containersJSON struct {
@@ -42,6 +43,25 @@ func rwLayerID(storageDriver docker.StorageDriver, storageDir string, containerI
 	err = json.Unmarshal(data, &containers)
 	if err != nil {
 		return "", err
+	}
+
+	// Read volatile-containers.json if it exists.
+	// This is important for Podman Quadlets since they are not presented in the containers.json file.
+	volatileData, err := os.ReadFile(filepath.Join(
+		storageDir,
+		string(storageDriver)+"-containers",
+		volatileContainersJSONFilename,
+	))
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if volatileData != nil {
+		var volatileContainers []containersJSON
+		err = json.Unmarshal(volatileData, &volatileContainers)
+		if err != nil {
+			return "", err
+		}
+		containers = append(containers, volatileContainers...)
 	}
 
 	for _, c := range containers {

--- a/container/podman/fs.go
+++ b/container/podman/fs.go
@@ -23,10 +23,10 @@ import (
 	"github.com/google/cadvisor/container/docker"
 )
 
-const (
-	containersJSONFilename         = "containers.json"
-	volatileContainersJSONFilename = "volatile-containers.json"
-)
+var containersJsonFilnames = []string{
+	"containers.json",
+	"volatile-containers.json",
+}
 
 type containersJSON struct {
 	ID    string `json:"id"`
@@ -35,33 +35,26 @@ type containersJSON struct {
 }
 
 func rwLayerID(storageDriver docker.StorageDriver, storageDir string, containerID string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(storageDir, string(storageDriver)+"-containers", containersJSONFilename))
-	if err != nil {
-		return "", err
-	}
 	var containers []containersJSON
-	err = json.Unmarshal(data, &containers)
-	if err != nil {
-		return "", err
-	}
 
-	// Read volatile-containers.json if it exists.
-	// This is important for Podman Quadlets since they are not presented in the containers.json file.
-	volatileData, err := os.ReadFile(filepath.Join(
-		storageDir,
-		string(storageDriver)+"-containers",
-		volatileContainersJSONFilename,
-	))
-	if err != nil && !os.IsNotExist(err) {
-		return "", err
-	}
-	if volatileData != nil {
-		var volatileContainers []containersJSON
-		err = json.Unmarshal(volatileData, &volatileContainers)
-		if err != nil {
+	for _, filename := range containersJsonFilnames {
+		data, err := os.ReadFile(filepath.Join(storageDir, string(storageDriver)+"-containers", filename))
+		if err != nil && !os.IsNotExist(err) {
 			return "", err
 		}
-		containers = append(containers, volatileContainers...)
+
+		if data != nil {
+			var buffer []containersJSON
+			err = json.Unmarshal(data, &buffer)
+			if err != nil {
+				return "", err
+			}
+			containers = append(containers, buffer...)
+		}
+	}
+
+	if len(containers) == 0 {
+		return "", fmt.Errorf("no containers found in containers.json or volatile-containers.json in %q", filepath.Join(storageDir, string(storageDriver)+"-containers"))
 	}
 
 	for _, c := range containers {


### PR DESCRIPTION
This PR is directly derived from #3684 and fixes an issue I encountered when `containers.json` does not exist.

It ensures either `volatile-containers.json`, `containers.json` or both are read.