### PR TITLE
Latest releases from github are not immediately available in the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cAdvisor has native support for [Docker](https://github.com/docker/docker) conta
 To quickly tryout cAdvisor on your machine with Docker, we have a Docker image that includes everything you need to get started. You can run a single cAdvisor to monitor the whole machine. Simply run:
 
 ```
-VERSION=v0.49.1 # use the latest release version from https://github.com/google/cadvisor/releases
+VERSION=v0.49.1 # use the latest release version from https://gcr.io/cadvisor/cadvisor
 sudo docker run \
   --volume=/:/rootfs:ro \
   --volume=/var/run:/var/run:ro \


### PR DESCRIPTION
If you attempt to follow the instructions and the latest release on GitHub is not available in the registry, you will receive an error. It is best to instruct the user to look directly at the registry instead.