### PR TITLE
Update README.md with latest Docker image version and registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cAdvisor has native support for [Docker](https://github.com/docker/docker) conta
 To quickly tryout cAdvisor on your machine with Docker, we have a Docker image that includes everything you need to get started. You can run a single cAdvisor to monitor the whole machine. Simply run:
 
 ```
-VERSION=v0.49.1 # use the latest release version from https://github.com/google/cadvisor/releases
+VERSION=v0.53.0 # use the latest release version from https://github.com/google/cadvisor/releases
 sudo docker run \
   --volume=/:/rootfs:ro \
   --volume=/var/run:/var/run:ro \
@@ -23,7 +23,7 @@ sudo docker run \
   --name=cadvisor \
   --privileged \
   --device=/dev/kmsg \
-  gcr.io/cadvisor/cadvisor:$VERSION
+  ghcr.io/google/cadvisor:$VERSION # for versions prior to v0.53.0, use gcr.io/cadvisor/cadvisor instead
 ```
 
 cAdvisor is now running (in the background) on `http://localhost:8080`. The setup includes directories with Docker state cAdvisor needs to observe.


### PR DESCRIPTION
Bump image version to 0.53.0 and update container registry to ghcr.io in README.md

Fixes #3712

Let me know if you would prefer using a variable for the container registry or something else instead of a comment on the `docker run` command, I'll be happy to fix it!