### PR TITLE
memory: Add support for active_anon and inactive_anon

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -828,6 +828,20 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 		ret.Memory.HierarchicalData.Pgmajfault = v
 	}
 
+	inactiveAnonKeyName := "total_inactive_anon"
+	activeAnonKeyName := "total_active_anon"
+	if cgroups.IsCgroup2UnifiedMode() {
+		inactiveAnonKeyName = "inactive_anon"
+		activeAnonKeyName = "active_anon"
+	}
+
+	if v, ok := s.MemoryStats.Stats[activeAnonKeyName]; ok {
+		ret.Memory.TotalActiveAnon = v
+	}
+	if v, ok := s.MemoryStats.Stats[inactiveAnonKeyName]; ok {
+		ret.Memory.TotalInactiveAnon = v
+	}
+
 	inactiveFileKeyName := "total_inactive_file"
 	if cgroups.IsCgroup2UnifiedMode() {
 		inactiveFileKeyName = "inactive_file"

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -425,6 +425,14 @@ type MemoryStats struct {
 	// Units: Bytes.
 	TotalInactiveFile uint64 `json:"total_inactive_file"`
 
+	// The total amount of active anonymous memory.
+	// Units: Bytes.
+	TotalActiveAnon uint64 `json:"total_active_anon"`
+
+	// The total amount of inactive anonymous memory.
+	// Units: Bytes.
+	TotalInactiveAnon uint64 `json:"total_inactive_anon"`
+
 	Failcnt uint64 `json:"failcnt"`
 
 	// Size of kernel memory allocated in bytes.

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -444,6 +444,22 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				},
 			},
 			{
+				name:      "container_memory_total_inactive_anon_bytes",
+				help:      "Current total inactive anonymous in bytes.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.TotalInactiveAnon), timestamp: s.Timestamp}}
+				},
+			},
+			{
+				name:      "container_memory_total_active_anon_bytes",
+				help:      "Current total active anonymous in bytes.",
+				valueType: prometheus.GaugeValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.TotalActiveAnon), timestamp: s.Timestamp}}
+				},
+			},
+			{
 				name:      "container_memory_total_active_file_bytes",
 				help:      "Current total active file in bytes.",
 				valueType: prometheus.GaugeValue,
@@ -459,6 +475,7 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 					return metricValues{{value: float64(s.Memory.TotalInactiveFile), timestamp: s.Timestamp}}
 				},
 			},
+
 			{
 				name:        "container_memory_failures_total",
 				help:        "Cumulative count of memory allocation failures.",


### PR DESCRIPTION
This is exposing active and inactive anonymous memory regions.

Relevant for KubeVirt where guest memory is anonymous.