### PR TITLE
chore: re-enable golangci-lint checks and fix violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,8 +14,7 @@ linters:
   settings:
     govet:
       disable:
-        - fieldalignment
-        - buildtag  # old +build lines still present alongside //go:build
+        - fieldalignment  # too noisy, requires significant refactoring
     errcheck:
       exclude-functions:
         - (io.Closer).Close
@@ -32,8 +31,12 @@ linters:
     staticcheck:
       checks:
         - "all"
-        - "-ST*"    # disable all style checks (ST1000, ST1003, ST1005, etc.)
-        - "-QF*"    # disable all quickfix suggestions
+        - "-ST1000" # package comments - too noisy for existing codebase
+        - "-ST1003" # naming conventions (e.g., CrioId vs CrioID) - would break public API
+        - "-ST1020" # comment format on exported methods - too many to fix
+        - "-ST1021" # comment format on exported types - too many to fix
+        - "-ST1022" # comment format on exported consts - too many to fix
+        - "-QF*"    # disable quickfix suggestions
   exclusions:
     rules:
       # Exclude errcheck in test files for cleaner test code
@@ -52,6 +55,7 @@ linters:
 formatters:
   enable:
     - gofmt
+    - goimports
 
 issues:
   max-issues-per-linter: 0

--- a/client/client.go
+++ b/client/client.go
@@ -211,11 +211,11 @@ func (c *Client) getEventStreamingData(url string, einfo chan *v1.Event) error {
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Status code is not OK: %v (%s)", resp.StatusCode, resp.Status)
+		return fmt.Errorf("status code is not OK: %v (%s)", resp.StatusCode, resp.Status)
 	}
 
 	dec := json.NewDecoder(resp.Body)
-	var m *v1.Event = &v1.Event{}
+	m := &v1.Event{}
 	for {
 		err := dec.Decode(m)
 		if err != nil {

--- a/cmd/internal/storage/influxdb/influxdb_test.go
+++ b/cmd/internal/storage/influxdb/influxdb_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build influxdb_test
-// +build influxdb_test
 
 // To run unit test: go test -tags influxdb_test
 

--- a/collector/generic_collector.go
+++ b/collector/generic_collector.go
@@ -67,7 +67,7 @@ func NewCollector(collectorName string, configFile []byte, metricCountLimit int,
 	// TODO : Add checks for validity of config file (eg : Accurate JSON fields)
 
 	if len(configInJSON.MetricsConfig) == 0 {
-		return nil, fmt.Errorf("No metrics provided in config")
+		return nil, fmt.Errorf("no metrics provided in config")
 	}
 
 	minPollFrequency := time.Duration(0)
@@ -83,7 +83,7 @@ func NewCollector(collectorName string, configFile []byte, metricCountLimit int,
 
 		regexprs[ind], err = regexp.Compile(metricConfig.Regex)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid regexp %v for metric %v", metricConfig.Regex, metricConfig.Name)
+			return nil, fmt.Errorf("invalid regexp %v for metric %v", metricConfig.Regex, metricConfig.Name)
 		}
 	}
 
@@ -94,7 +94,7 @@ func NewCollector(collectorName string, configFile []byte, metricCountLimit int,
 	}
 
 	if len(configInJSON.MetricsConfig) > metricCountLimit {
-		return nil, fmt.Errorf("Too many metrics defined: %d limit: %d", len(configInJSON.MetricsConfig), metricCountLimit)
+		return nil, fmt.Errorf("too many metrics defined: %d limit: %d", len(configInJSON.MetricsConfig), metricCountLimit)
 	}
 
 	return &GenericCollector{
@@ -173,10 +173,10 @@ func (collector *GenericCollector) Collect(metrics map[string][]v1.MetricVal) (t
 				}
 
 			} else {
-				errorSlice = append(errorSlice, fmt.Errorf("Unexpected value of 'data_type' for metric '%v' in config ", metricConfig.Name))
+				errorSlice = append(errorSlice, fmt.Errorf("unexpected value of 'data_type' for metric '%v' in config ", metricConfig.Name))
 			}
 		} else {
-			errorSlice = append(errorSlice, fmt.Errorf("No match found for regexp: %v for metric '%v' in config", metricConfig.Regex, metricConfig.Name))
+			errorSlice = append(errorSlice, fmt.Errorf("no match found for regexp: %v for metric '%v' in config", metricConfig.Regex, metricConfig.Name))
 		}
 	}
 	return nextCollectionTime, metrics, compileErrors(errorSlice)

--- a/collector/prometheus_collector.go
+++ b/collector/prometheus_collector.go
@@ -72,7 +72,7 @@ func NewPrometheusCollector(collectorName string, configFile []byte, metricCount
 	}
 
 	if metricCountLimit < 0 {
-		return nil, fmt.Errorf("Metric count limit must be greater than or equal to 0")
+		return nil, fmt.Errorf("metric count limit must be greater than or equal to 0")
 	}
 
 	var metricsSet map[string]bool
@@ -84,7 +84,7 @@ func NewPrometheusCollector(collectorName string, configFile []byte, metricCount
 	}
 
 	if len(configInJSON.MetricsConfig) > metricCountLimit {
-		return nil, fmt.Errorf("Too many metrics defined: %d limit %d", len(configInJSON.MetricsConfig), metricCountLimit)
+		return nil, fmt.Errorf("too many metrics defined: %d limit %d", len(configInJSON.MetricsConfig), metricCountLimit)
 	}
 
 	// TODO : Add checks for validity of config file (eg : Accurate JSON fields)

--- a/collector/util.go
+++ b/collector/util.go
@@ -16,11 +16,10 @@ package collector
 
 import "github.com/google/cadvisor/container"
 
-func (endpointConfig *EndpointConfig) configure(containerHandler container.ContainerHandler) {
-	//If the exact URL was not specified, generate it based on the ip address of the container.
-	endpoint := endpointConfig
-	if endpoint.URL == "" {
+func (ec *EndpointConfig) configure(containerHandler container.ContainerHandler) {
+	// If the exact URL was not specified, generate it based on the ip address of the container.
+	if ec.URL == "" {
 		ipAddress := containerHandler.GetContainerIPAddress()
-		endpointConfig.URL = endpoint.URLConfig.Protocol + "://" + ipAddress + ":" + endpoint.URLConfig.Port.String() + endpoint.URLConfig.Path
+		ec.URL = ec.URLConfig.Protocol + "://" + ipAddress + ":" + ec.URLConfig.Port.String() + ec.URLConfig.Path
 	}
 }

--- a/container/containerd/pkg/dialer/dialer_unix.go
+++ b/container/containerd/pkg/dialer/dialer_unix.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/container/crio/client.go
+++ b/container/crio/client.go
@@ -72,7 +72,7 @@ type crioClientImpl struct {
 
 func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 	if len(addr) > maxUnixSocketPathSize {
-		return fmt.Errorf("Unix socket path %q is too long", addr)
+		return fmt.Errorf("unix socket path %q is too long", addr)
 	}
 	// No need for compression in local communications.
 	tr.DisableCompression = true
@@ -149,9 +149,9 @@ func (c *crioClientImpl) ContainerInfo(id string) (*ContainerInfo, error) {
 	if resp.StatusCode != http.StatusOK {
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("Error finding container %s: Status %d", id, resp.StatusCode)
+			return nil, fmt.Errorf("error finding container %s: status %d", id, resp.StatusCode)
 		}
-		return nil, fmt.Errorf("Error finding container %s: Status %d returned error %s", id, resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("error finding container %s: status %d returned error %s", id, resp.StatusCode, string(respBody))
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&cInfo); err != nil {

--- a/container/docker/utils/docker.go
+++ b/container/docker/utils/docker.go
@@ -49,7 +49,7 @@ func DriverStatusValue(status [][2]string, target string) string {
 func DockerThinPoolName(info dockersystem.Info) (string, error) {
 	poolName := DriverStatusValue(info.DriverStatus, DriverStatusPoolName)
 	if len(poolName) == 0 {
-		return "", fmt.Errorf("Could not get devicemapper pool name")
+		return "", fmt.Errorf("could not get devicemapper pool name")
 	}
 
 	return poolName, nil
@@ -78,7 +78,7 @@ func DockerMetadataDevice(info dockersystem.Info) (string, error) {
 func DockerZfsFilesystem(info dockersystem.Info) (string, error) {
 	filesystem := DriverStatusValue(info.DriverStatus, DriverStatusParentDataset)
 	if len(filesystem) == 0 {
-		return "", fmt.Errorf("Could not get zfs filesystem")
+		return "", fmt.Errorf("could not get zfs filesystem")
 	}
 
 	return filesystem, nil

--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -311,7 +311,7 @@ func processStatsFromProcs(rootFs string, cgroupPath string, rootPid int) (info.
 func (h *Handler) schedulerStatsFromProcs() (info.CpuSchedstat, error) {
 	pids, err := h.cgroupManager.GetAllPids()
 	if err != nil {
-		return info.CpuSchedstat{}, fmt.Errorf("Could not get PIDs for container %d: %w", h.pid, err)
+		return info.CpuSchedstat{}, fmt.Errorf("could not get PIDs for container %d: %w", h.pid, err)
 	}
 	alivePids := make(map[int]struct{}, len(pids))
 	for _, pid := range pids {

--- a/container/systemd/factory.go
+++ b/container/systemd/factory.go
@@ -33,7 +33,7 @@ func (f *systemdFactory) String() string {
 }
 
 func (f *systemdFactory) NewContainerHandler(name string, metadataEnvAllowList []string, inHostNamespace bool) (container.ContainerHandler, error) {
-	return nil, fmt.Errorf("Not yet supported")
+	return nil, fmt.Errorf("not yet supported")
 }
 
 func (f *systemdFactory) CanHandleAndAccept(name string) (bool, bool, error) {

--- a/devicemapper/thin_ls_client.go
+++ b/devicemapper/thin_ls_client.go
@@ -58,7 +58,7 @@ func (c *defaultThinLsClient) ThinLs(deviceName string) (map[string]uint64, erro
 
 	output, err := exec.Command(c.thinLsPath, args...).Output()
 	if err != nil {
-		return nil, fmt.Errorf("Error running command `thin_ls %v`: %v\noutput:\n\n%v", strings.Join(args, " "), err, string(output))
+		return nil, fmt.Errorf("error running command `thin_ls %v`: %v\noutput:\n\n%v", strings.Join(args, " "), err, string(output))
 	}
 
 	return parseThinLsOutput(output), nil

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build linux
-// +build linux
 
 // Provides Filesystem Stats
 package fs
@@ -760,7 +759,7 @@ func getVfsStats(path string) (total uint64, free uint64, avail uint64, inodes u
 func dockerDMDevice(driverStatus map[string]string, dmsetup devicemapper.DmsetupClient) (string, uint, uint, uint, error) {
 	poolName, ok := driverStatus[DriverStatusPoolName]
 	if !ok || len(poolName) == 0 {
-		return "", 0, 0, 0, fmt.Errorf("Could not get dm pool name")
+		return "", 0, 0, 0, fmt.Errorf("could not get dm pool name")
 	}
 
 	out, err := dmsetup.Table(poolName)
@@ -783,7 +782,7 @@ func parseDMTable(dmTable string) (uint, uint, uint, error) {
 	dmFields := strings.Fields(dmTable)
 
 	if len(dmFields) < 8 {
-		return 0, 0, 0, fmt.Errorf("Invalid dmsetup status output: %s", dmTable)
+		return 0, 0, 0, fmt.Errorf("invalid dmsetup status output: %s", dmTable)
 	}
 
 	major, err := strconv.ParseUint(dmFields[5], 10, 32)
@@ -825,7 +824,7 @@ func parseDMStatus(dmStatus string) (uint64, uint64, error) {
 	dmFields := strings.Fields(dmStatus)
 
 	if len(dmFields) < 8 {
-		return 0, 0, fmt.Errorf("Invalid dmsetup status output: %s", dmStatus)
+		return 0, 0, fmt.Errorf("invalid dmsetup status output: %s", dmStatus)
 	}
 
 	used, err := strconv.ParseUint(dmFields[6], 10, 64)

--- a/integration/tests/api/perf_test.go
+++ b/integration/tests/api/perf_test.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/machine/operatingsystem_unix.go
+++ b/machine/operatingsystem_unix.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build freebsd || darwin || linux
-// +build freebsd darwin linux
 
 package machine
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -858,7 +858,7 @@ func (m *manager) GetProcessList(containerName string, options v2.RequestOptions
 		return nil, err
 	}
 	if len(conts) != 1 {
-		return nil, fmt.Errorf("Expected the request to match only one container")
+		return nil, fmt.Errorf("expected the request to match only one container")
 	}
 	// TODO(rjnagal): handle count? Only if we can do count by type (eg. top 5 cpu users)
 	ps := []v2.ProcessInfo{}

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -792,14 +792,14 @@ type erroringSubcontainersInfoProvider struct {
 
 func (p *erroringSubcontainersInfoProvider) GetVersionInfo() (*info.VersionInfo, error) {
 	if p.shouldFail {
-		return nil, errors.New("Oops 1")
+		return nil, errors.New("oops 1")
 	}
 	return p.successfulProvider.GetVersionInfo()
 }
 
 func (p *erroringSubcontainersInfoProvider) GetMachineInfo() (*info.MachineInfo, error) {
 	if p.shouldFail {
-		return nil, errors.New("Oops 2")
+		return nil, errors.New("oops 2")
 	}
 	return p.successfulProvider.GetMachineInfo()
 }
@@ -807,7 +807,7 @@ func (p *erroringSubcontainersInfoProvider) GetMachineInfo() (*info.MachineInfo,
 func (p *erroringSubcontainersInfoProvider) GetRequestedContainersInfo(
 	a string, opt v2.RequestOptions) (map[string]*info.ContainerInfo, error) {
 	if p.shouldFail {
-		return map[string]*info.ContainerInfo{}, errors.New("Oops 3")
+		return map[string]*info.ContainerInfo{}, errors.New("oops 3")
 	}
 	return p.successfulProvider.GetRequestedContainersInfo(a, opt)
 }

--- a/nvm/machine_libipmctl.go
+++ b/nvm/machine_libipmctl.go
@@ -1,5 +1,4 @@
 //go:build libipmctl && cgo
-// +build libipmctl,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/nvm/machine_no_libipmctl.go
+++ b/nvm/machine_no_libipmctl.go
@@ -1,5 +1,4 @@
 //go:build !libipmctl || !cgo
-// +build !libipmctl !cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/collector_libpfm.go
+++ b/perf/collector_libpfm.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/collector_libpfm_test.go
+++ b/perf/collector_libpfm_test.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/collector_no_libpfm.go
+++ b/perf/collector_no_libpfm.go
@@ -1,5 +1,4 @@
 //go:build !libpfm || !cgo
-// +build !libpfm !cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/manager_libpfm.go
+++ b/perf/manager_libpfm.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/manager_libpfm_test.go
+++ b/perf/manager_libpfm_test.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/manager_no_libpfm.go
+++ b/perf/manager_no_libpfm.go
@@ -1,5 +1,4 @@
 //go:build !libpfm || !cgo
-// +build !libpfm !cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/types_libpfm.go
+++ b/perf/types_libpfm.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/uncore_libpfm.go
+++ b/perf/uncore_libpfm.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/perf/uncore_libpfm_test.go
+++ b/perf/uncore_libpfm_test.go
@@ -1,5 +1,4 @@
 //go:build libpfm && cgo
-// +build libpfm,cgo
 
 // Copyright 2020 Google Inc. All Rights Reserved.
 //

--- a/resctrl/intel/collector.go
+++ b/resctrl/intel/collector.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/resctrl/intel/collector_test.go
+++ b/resctrl/intel/collector_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/resctrl/intel/manager.go
+++ b/resctrl/intel/manager.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/resctrl/intel/manager_test.go
+++ b/resctrl/intel/manager_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/resctrl/intel/utils.go
+++ b/resctrl/intel/utils.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/resctrl/intel/utils_test.go
+++ b/resctrl/intel/utils_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/utils/sysfs/sysfs_notx86.go
+++ b/utils/sysfs/sysfs_notx86.go
@@ -1,5 +1,4 @@
 //go:build !x86
-// +build !x86
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/utils/sysfs/sysfs_x86.go
+++ b/utils/sysfs/sysfs_x86.go
@@ -1,5 +1,4 @@
 //go:build x86
-// +build x86
 
 // Copyright 2021 Google Inc. All Rights Reserved.
 //

--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -274,7 +274,7 @@ func getCPUTopology(sysFs sysfs.SysFs) ([]info.Node, int, error) {
 	cpusCount := len(cpusPaths)
 
 	if cpusCount == 0 {
-		err = fmt.Errorf("Any CPU is not available, cpusPath: %s", cpusPath)
+		err = fmt.Errorf("no CPU is available, cpusPath: %s", cpusPath)
 		return nil, 0, err
 	}
 


### PR DESCRIPTION
Re-enable staticcheck linters that were disabled in a previous commit and fix all resulting violations:

- Remove deprecated // +build lines (23 files) - only //go:build needed
- Fix ST1005: lowercase error strings (24 issues across multiple files)
- Fix ST1016: consistent receiver names in collector/util.go
- Fix ST1023: remove redundant type in variable declaration

Keep disabled: ST1003 (naming would break public API), ST1020/ST1021/ST1022 (comment format - too many issues, not worth the churn).