### PR TITLE
container/docker: GetStats: prevent nil-pointer

### DIFF
--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -325,15 +325,13 @@ func (h *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	return spec, err
 }
 
-// TODO(vmarmol): Get from libcontainer API instead of cgroup manager when we don't have to support older Dockers.
 func (h *dockerContainerHandler) GetStats() (*info.ContainerStats, error) {
+	// TODO(vmarmol): Get from libcontainer API instead of cgroup manager when we don't have to support older Dockers.
 	stats, err := h.libcontainerHandler.GetStats()
-
-	stats.Health.Status = h.healthStatus
-
 	if err != nil {
 		return stats, err
 	}
+	stats.Health.Status = h.healthStatus
 
 	// Get filesystem stats.
 	err = FsStats(stats, h.machineInfoFactory, h.includedMetrics, h.storageDriver,


### PR DESCRIPTION
- fixes https://github.com/google/cadvisor/issues/3758

stats can be nil if an error occurs during collecting