### PR TITLE
devicemapper: use atomic.Value for lock-free cache reads

### DIFF
--- a/devicemapper/thin_pool_watcher_test.go
+++ b/devicemapper/thin_pool_watcher_test.go
@@ -16,7 +16,6 @@ package devicemapper
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -132,7 +131,6 @@ func TestRefresh(t *testing.T) {
 		watcher := &ThinPoolWatcher{
 			poolName:       "test pool name",
 			metadataDevice: "/dev/mapper/metadata-device",
-			lock:           &sync.RWMutex{},
 			period:         15 * time.Second,
 			stopChan:       make(chan struct{}),
 			dmsetup:        dmsetup,


### PR DESCRIPTION
The ThinPoolWatcher cache is read frequently by container housekeeping goroutines (via GetUsage) while being updated every 15 seconds by Refresh(). Using atomic.Value allows lock-free reads, eliminating potential contention between the many readers and the single writer.