### PR TITLE
integration: adjust tests for containerd snapshotters

### DIFF
--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -58,7 +58,7 @@ function run_tests() {
     --privileged \
     --cap-add="sys_admin" \
     --entrypoint="" \
-    gcr.io/k8s-staging-test-infra/bootstrap:v20250702-52f5173c3a \
+    gcr.io/k8s-staging-test-infra/bootstrap \
     bash -c "export DEBIAN_FRONTEND=noninteractive && \
     apt update && \
     apt install -y $PACKAGES && \

--- a/integration/tests/api/docker_test.go
+++ b/integration/tests/api/docker_test.go
@@ -349,7 +349,7 @@ func TestDockerFilesystemStats(t *testing.T) {
 	}
 	needsBaseUsageCheck := false
 	switch storageDriver {
-	case framework.Aufs, framework.Overlay, framework.Overlay2, framework.DeviceMapper:
+	case framework.Aufs, framework.Overlay, framework.Overlay2, framework.OverlayFS:
 		needsBaseUsageCheck = true
 	}
 	pass := false


### PR DESCRIPTION
relates to https://github.com/google/cadvisor/pull/3761#issuecomment-3617404867

Attempt to adjust the tests to work with a docker daemon using the containerd snapshotters (which would have, e.g., "overlayfs" instead of "overlay2" as storage driver).