### PR TITLE
container/(docker|podman): rewrite obtaining IP-address

### DIFF
--- a/container/podman/handler.go
+++ b/container/podman/handler.go
@@ -124,6 +124,24 @@ func newContainerHandler(
 		return nil, err
 	}
 
+	// Obtain the IP address for the container.
+	var ipAddress string
+	if ctnr.NetworkSettings != nil && ctnr.HostConfig != nil {
+		c := ctnr
+		if ctnr.HostConfig.NetworkMode.IsContainer() {
+			// If the NetworkMode starts with 'container:' then we need to use the IP address of the container specified.
+			// This happens in cases such as kubernetes where the containers doesn't have an IP address itself and we need to use the pod's address
+			containerID := ctnr.HostConfig.NetworkMode.ConnectedContainer()
+			c, err = InspectContainer(containerID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to inspect container %q: %v", containerID, err)
+			}
+		}
+		if nw, ok := c.NetworkSettings.Networks[c.HostConfig.NetworkMode.NetworkName()]; ok {
+			ipAddress = nw.IPAddress
+		}
+	}
+
 	layerID, err := rwLayerID(storageDriver, storageDir, id)
 	if err != nil {
 		return nil, err
@@ -144,6 +162,7 @@ func newContainerHandler(
 		storageDriver:      storageDriver,
 		fsInfo:             fsInfo,
 		rootfsStorageDir:   rootfsStorageDir,
+		ipAddress:          ipAddress,
 		envs:               make(map[string]string),
 		labels:             ctnr.Config.Labels,
 		image:              ctnr.Config.Image,
@@ -170,21 +189,6 @@ func newContainerHandler(
 	if ctnr.RestartCount > 0 {
 		handler.labels["restartcount"] = strconv.Itoa(ctnr.RestartCount)
 	}
-
-	// Obtain the IP address for the container.
-	// If the NetworkMode starts with 'container:' then we need to use the IP address of the container specified.
-	// This happens in cases such as kubernetes where the containers doesn't have an IP address itself and we need to use the pod's address
-	ipAddress := ctnr.NetworkSettings.IPAddress
-	networkMode := string(ctnr.HostConfig.NetworkMode)
-	if ipAddress == "" && strings.HasPrefix(networkMode, "container:") {
-		containerID := strings.TrimPrefix(networkMode, "container:")
-		c, err := InspectContainer(containerID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to inspect container %q: %v", containerID, err)
-		}
-		ipAddress = c.NetworkSettings.IPAddress
-	}
-	handler.ipAddress = ipAddress
 
 	if metrics.Has(container.DiskUsageMetrics) {
 		handler.fsHandler = &docker.FsHandler{


### PR DESCRIPTION
- relates to https://github.com/google/cadvisor/pull/3757

The top-level IPAddress field is deprecated in the API, so instead, the IP-address should be obtained from the container's primary network.