### PR TITLE
disable CGO for fully static binaries - abandoned due to CLA issues

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -50,7 +50,7 @@ jobs:
           docker run --rm -v ${PWD}:/go/src/github.com/google/cadvisor \
             --platform linux/${{ matrix.arch }} \
             golang:1.25 \
-            /bin/bash -c "cd /go/src/github.com/google/cadvisor && GOARCH=${{ matrix.arch }} OUTPUT_NAME_WITH_ARCH=true VERSION=${{ env.VERSION }} GO_FLAGS='-buildvcs=false -tags=netgo' ./build/build.sh"
+            /bin/bash -c "cd /go/src/github.com/google/cadvisor && GOARCH=${{ matrix.arch }} OUTPUT_NAME_WITH_ARCH=true VERSION=${{ env.VERSION }} GO_FLAGS='-buildvcs=false -tags=netgo' GO_CGO_ENABLED=0 ./build/build.sh"
 
       - name: Generate SHA256 checksums
         run: |


### PR DESCRIPTION
fixes #3706 and #3704 .