### PR TITLE
refactor(container): Migrate to std lib context package

### DIFF
--- a/container/containerd/factory.go
+++ b/container/containerd/factory.go
@@ -15,13 +15,13 @@
 package containerd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"path"
 	"regexp"
 	"strings"
 
-	"golang.org/x/net/context"
 	"k8s.io/klog/v2"
 
 	"github.com/google/cadvisor/container"

--- a/container/containerd/grpc.go
+++ b/container/containerd/grpc.go
@@ -16,9 +16,11 @@
 package containerd
 
 import (
-	"github.com/google/cadvisor/container/containerd/namespaces"
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/grpc"
+
+	"github.com/google/cadvisor/container/containerd/namespaces"
 )
 
 type namespaceInterceptor struct {

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -16,6 +16,7 @@
 package containerd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,7 +26,6 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/opencontainers/cgroups"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/net/context"
 
 	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/common"

--- a/container/docker/docker.go
+++ b/container/docker/docker.go
@@ -16,6 +16,7 @@
 package docker
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -23,7 +24,6 @@ import (
 
 	dockerimage "github.com/docker/docker/api/types/image"
 	dockersystem "github.com/docker/docker/api/types/system"
-	"golang.org/x/net/context"
 
 	"github.com/google/cadvisor/container/docker/utils"
 	v1 "github.com/google/cadvisor/info/v1"
@@ -32,17 +32,14 @@ import (
 
 var dockerTimeout = 10 * time.Second
 
-func defaultContext() context.Context {
-	ctx, _ := context.WithTimeout(context.Background(), dockerTimeout)
-	return ctx
-}
-
 func SetTimeout(timeout time.Duration) {
 	dockerTimeout = timeout
 }
 
 func Status() (v1.DockerStatus, error) {
-	return StatusWithContext(defaultContext())
+	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	defer cancel()
+	return StatusWithContext(ctx)
 }
 
 func StatusWithContext(ctx context.Context) (v1.DockerStatus, error) {
@@ -89,7 +86,9 @@ func Images() ([]v1.DockerImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to communicate with docker daemon: %v", err)
 	}
-	summaries, err := client.ImageList(defaultContext(), dockerimage.ListOptions{All: false})
+	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	defer cancel()
+	summaries, err := client.ImageList(ctx, dockerimage.ListOptions{All: false})
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +134,9 @@ func Info() (*dockersystem.Info, error) {
 		return nil, fmt.Errorf("unable to communicate with docker daemon: %v", err)
 	}
 
-	dockerInfo, err := client.Info(defaultContext())
+	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	defer cancel()
+	dockerInfo, err := client.Info(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect Docker info: %v", err)
 	}
@@ -155,7 +156,9 @@ func VersionString() (string, error) {
 	dockerVersion := "Unknown"
 	client, err := Client()
 	if err == nil {
-		version, err := client.ServerVersion(defaultContext())
+		ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+		defer cancel()
+		version, err := client.ServerVersion(ctx)
 		if err == nil {
 			dockerVersion = version.Version
 		}
@@ -167,7 +170,9 @@ func APIVersionString() (string, error) {
 	apiVersion := "Unknown"
 	client, err := Client()
 	if err == nil {
-		version, err := client.ServerVersion(defaultContext())
+		ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+		defer cancel()
+		version, err := client.ServerVersion(ctx)
 		if err == nil {
 			apiVersion = version.APIVersion
 		}

--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -15,6 +15,7 @@
 package docker
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"regexp"
@@ -26,7 +27,6 @@ import (
 	"github.com/blang/semver/v4"
 	dockersystem "github.com/docker/docker/api/types/system"
 	dclient "github.com/docker/docker/client"
-	"golang.org/x/net/context"
 	"k8s.io/klog/v2"
 
 	"github.com/google/cadvisor/container"

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -16,6 +16,7 @@
 package docker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -27,7 +28,6 @@ import (
 	dclient "github.com/docker/docker/client"
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/net/context"
 
 	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/common"

--- a/container/docker/plugin.go
+++ b/container/docker/plugin.go
@@ -15,9 +15,9 @@
 package docker
 
 import (
+	"context"
 	"time"
 
-	"golang.org/x/net/context"
 	"k8s.io/klog/v2"
 
 	"github.com/google/cadvisor/container"
@@ -56,7 +56,8 @@ func retryDockerStatus() info.DockerStatus {
 	startupTimeout := dockerClientTimeout
 	maxTimeout := 4 * startupTimeout
 	for {
-		ctx, _ := context.WithTimeout(context.Background(), startupTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), startupTimeout)
+		defer cancel()
 		dockerStatus, err := StatusWithContext(ctx)
 		if err == nil {
 			return dockerStatus

--- a/container/docker/utils/docker.go
+++ b/container/docker/utils/docker.go
@@ -23,6 +23,7 @@ import (
 
 	dockerimage "github.com/docker/docker/api/types/image"
 	dockersystem "github.com/docker/docker/api/types/system"
+
 	v1 "github.com/google/cadvisor/info/v1"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.64.0
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/net v0.40.0
 	golang.org/x/sys v0.33.0
 	google.golang.org/grpc v1.72.2
 	google.golang.org/protobuf v1.36.6
@@ -81,6 +80,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
+	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect

--- a/integration/tests/api/machinestats_test.go
+++ b/integration/tests/api/machinestats_test.go
@@ -21,8 +21,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/google/cadvisor/integration/framework"
 	"github.com/opencontainers/cgroups"
+
+	"github.com/google/cadvisor/integration/framework"
 )
 
 func TestMachineStatsIsReturned(t *testing.T) {

--- a/resctrl/intel/manager_test.go
+++ b/resctrl/intel/manager_test.go
@@ -21,8 +21,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/cadvisor/resctrl"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/google/cadvisor/resctrl"
 )
 
 func TestNewManager(t *testing.T) {


### PR DESCRIPTION
- replaced the deprecated `golang.org/x/net/context` with the standard library `context` package
- removed defaultContext() and fixed context leaks
- make format, tidy, test checked