### PR TITLE
plugin factory: remove useless RegisterPlugin log output

### DIFF
--- a/container/factory.go
+++ b/container/factory.go
@@ -192,7 +192,6 @@ func RegisterPlugin(name string, plugin Plugin) error {
 	if _, found := plugins[name]; found {
 		return fmt.Errorf("Plugin %q was registered twice", name)
 	}
-	klog.V(4).Infof("Registered Plugin %q", name)
 	plugins[name] = plugin
 	return nil
 }


### PR DESCRIPTION
RegisterPlugin gets called during the init phase of programs using this package. During init, klog verbosity is usually zero (making the log call redundant because it doesn't print anything).

This could be ignored, but it gets worse when some package increases verbosity during init:

- plugin "systemd" gets registered: no output
- verbosity gets changed
- plugin "containerd" gets registered:

    I1210 14:05:15.799869  126449 factory.go:195] Registered Plugin "containerd"

As a general rule, init code should not log because logging cannot be properly initialized until after the program had a chance to parse command line parameters.

Fixes: #3707