### PR TITLE
feat: add exit code in container deletion events

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -63,6 +63,11 @@ type ContainerHandler interface {
 	// Returns the container's ip address, if available
 	GetContainerIPAddress() string
 
+	// GetExitCode returns the container's exit code if available.
+	// Returns an error if the container has not exited, exit codes are not supported
+	// for this handler type, or the container information is unavailable.
+	GetExitCode() (int, error)
+
 	// Returns whether the container still exists.
 	Exists() bool
 

--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -23,9 +23,10 @@ import (
 )
 
 type containerdClientMock struct {
-	cntrs     map[string]*containers.Container
-	returnErr error
-	tasks     map[string]*task.Process
+	cntrs      map[string]*containers.Container
+	returnErr  error
+	tasks      map[string]*task.Process
+	exitStatus uint32
 }
 
 func (c *containerdClientMock) LoadContainer(ctx context.Context, id string) (*containers.Container, error) {
@@ -56,6 +57,13 @@ func (c *containerdClientMock) LoadTaskProcess(ctx context.Context, id string) (
 		return nil, fmt.Errorf("unable to find task for container %q", id)
 	}
 	return task, nil
+}
+
+func (c *containerdClientMock) TaskExitStatus(ctx context.Context, id string) (uint32, error) {
+	if c.returnErr != nil {
+		return 0, c.returnErr
+	}
+	return c.exitStatus, nil
 }
 
 func mockcontainerdClient(cntrs map[string]*containers.Container, returnErr error) ContainerdClient {

--- a/container/containerd/handler.go
+++ b/container/containerd/handler.go
@@ -50,6 +50,7 @@ type containerdContainerHandler struct {
 	includedMetrics container.MetricSet
 
 	libcontainerHandler *containerlibcontainer.Handler
+	client              ContainerdClient
 }
 
 var _ container.ContainerHandler = &containerdContainerHandler{}
@@ -143,6 +144,7 @@ func newContainerdContainerHandler(
 		includedMetrics:     metrics,
 		reference:           containerReference,
 		libcontainerHandler: libcontainerHandler,
+		client:              client,
 	}
 	// Add the name and bare ID as aliases of the container.
 	handler.image = cntr.Image
@@ -247,4 +249,13 @@ func (h *containerdContainerHandler) Cleanup() {
 func (h *containerdContainerHandler) GetContainerIPAddress() string {
 	// containerd doesnt take care of networking.So it doesnt maintain networking states
 	return ""
+}
+
+func (h *containerdContainerHandler) GetExitCode() (int, error) {
+	ctx := context.Background()
+	exitStatus, err := h.client.TaskExitStatus(ctx, h.reference.Id)
+	if err != nil {
+		return -1, err
+	}
+	return int(exitStatus), nil
 }

--- a/container/containerd/handler_test.go
+++ b/container/containerd/handler_test.go
@@ -140,3 +140,64 @@ func TestHandler(t *testing.T) {
 		}
 	}
 }
+
+func TestGetExitCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		exitStatus   uint32
+		returnErr    error
+		expectErr    bool
+		errContains  string
+		expectedCode int
+	}{
+		{
+			name:         "successful exit code 0",
+			exitStatus:   0,
+			returnErr:    nil,
+			expectErr:    false,
+			expectedCode: 0,
+		},
+		{
+			name:         "successful exit code 1",
+			exitStatus:   1,
+			returnErr:    nil,
+			expectErr:    false,
+			expectedCode: 1,
+		},
+		{
+			name:         "task not stopped",
+			exitStatus:   0,
+			returnErr:    assert.AnError,
+			expectErr:    true,
+			expectedCode: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as := assert.New(t)
+
+			mockClient := &containerdClientMock{
+				returnErr:  tt.returnErr,
+				exitStatus: tt.exitStatus,
+			}
+
+			h := &containerdContainerHandler{
+				client: mockClient,
+				reference: info.ContainerReference{
+					Id: "test-container-id",
+				},
+			}
+
+			code, err := h.GetExitCode()
+
+			if tt.expectErr {
+				as.Error(err)
+				as.Equal(tt.expectedCode, code)
+			} else {
+				as.NoError(err)
+				as.Equal(tt.expectedCode, code)
+			}
+		})
+	}
+}

--- a/container/crio/handler.go
+++ b/container/crio/handler.go
@@ -360,3 +360,7 @@ func (h *crioContainerHandler) Exists() bool {
 func (h *crioContainerHandler) Type() container.ContainerType {
 	return container.ContainerTypeCrio
 }
+
+func (h *crioContainerHandler) GetExitCode() (int, error) {
+	return -1, fmt.Errorf("exit code not available from CRI-O API")
+}

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -386,3 +386,16 @@ func (h *containerHandler) Start() {
 func (h *containerHandler) Type() container.ContainerType {
 	return container.ContainerTypeDocker
 }
+
+func (h *containerHandler) GetExitCode() (int, error) {
+	ctnr, err := h.client.ContainerInspect(context.Background(), h.reference.Id)
+	if err != nil {
+		return -1, fmt.Errorf("failed to inspect container %s: %w", h.reference.Id, err)
+	}
+
+	if ctnr.State.Running {
+		return -1, fmt.Errorf("container %s is still running", h.reference.Id)
+	}
+
+	return ctnr.State.ExitCode, nil
+}

--- a/container/podman/handler.go
+++ b/container/podman/handler.go
@@ -323,3 +323,20 @@ func (h *containerHandler) Start() {
 func (h *containerHandler) Type() container.ContainerType {
 	return container.ContainerTypePodman
 }
+
+func (h *containerHandler) GetExitCode() (int, error) {
+	ctnr, err := InspectContainer(h.reference.Id)
+	if err != nil {
+		return -1, fmt.Errorf("failed to inspect container %s: %w", h.reference.Id, err)
+	}
+
+	if ctnr.State == nil {
+		return -1, fmt.Errorf("container state not available for %s", h.reference.Id)
+	}
+
+	if ctnr.State.Running {
+		return -1, fmt.Errorf("container %s is still running", h.reference.Id)
+	}
+
+	return ctnr.State.ExitCode, nil
+}

--- a/container/raw/handler.go
+++ b/container/raw/handler.go
@@ -281,6 +281,10 @@ func (h *rawContainerHandler) Type() container.ContainerType {
 	return container.ContainerTypeRaw
 }
 
+func (h *rawContainerHandler) GetExitCode() (int, error) {
+	return -1, fmt.Errorf("exit codes not applicable for raw cgroup containers")
+}
+
 type fsNamer struct {
 	fs      []fs.Fs
 	factory info.MachineInfoFactory

--- a/container/testing/mock_handler.go
+++ b/container/testing/mock_handler.go
@@ -101,6 +101,11 @@ func (h *MockContainerHandler) GetContainerIPAddress() string {
 	return args.Get(0).(string)
 }
 
+func (h *MockContainerHandler) GetExitCode() (int, error) {
+	args := h.Called()
+	return args.Int(0), args.Error(1)
+}
+
 type FactoryForMockContainerHandler struct {
 	Name                        string
 	PrepareContainerHandlerFunc func(name string, handler *MockContainerHandler)

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -1104,6 +1104,9 @@ const (
 type EventData struct {
 	// Information about an OOM kill event.
 	OomKill *OomKillEventData `json:"oom,omitempty"`
+
+	// Information about a container deletion event.
+	ContainerDeletion *ContainerDeletionEventData `json:"container_deletion,omitempty"`
 }
 
 // Information related to an OOM kill instance
@@ -1113,4 +1116,11 @@ type OomKillEventData struct {
 
 	// The name of the killed process
 	ProcessName string `json:"process_name"`
+}
+
+// Information related to a container deletion event
+type ContainerDeletionEventData struct {
+	// ExitCode is the exit code of the container.
+	// A value of -1 indicates the exit code was not available or not applicable.
+	ExitCode int `json:"exit_code"`
 }


### PR DESCRIPTION
## What

Container deletion events now include the container's exit code in the event data.
Fixes: #3722 

  ## Why

Users need to understand why containers terminated (success vs error vs signal). Exit codes provide critical debugging information for container lifecycle management and monitoring.

 ## How

  - Added `GetExitCode()` method to ContainerHandler interface
  - Added `ContainerDeletionEventData` struct with ExitCode field to event system
  - Modified `destroyContainer()` to retrieve exit code before calling `Stop()`
  - Implemented for docker, containerd, and podman (uses runtime inspect APIs)
  - CRI-O and Raw handlers return errors (not supported by those runtimes)
  - Exit code defaults to -1 if unavailable (container still running, retrieval fails, etc.)

  ### Testing

  - Unit tests for docker, containerd, and manager
  - Integration test validates end-to-end flow

  ### API Example
```
  {
    "event_type": "containerDeletion",
    "container_name": "/docker/abc123",
    "event_data": {
      "container_deletion": {
        "exit_code": 1
      }
    }
  }
```