### PR TITLE
feat: add CRI-O integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,26 @@ jobs:
       with:
         name: cadvisor.log
         path: ${{ github.workspace }}/go/src/github.com/google/cadvisor/cadvisor.log
+  test-integration-crio:
+    strategy:
+      matrix:
+        go-versions: ['1.25']
+        platform: [ubuntu-24.04]
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Run CRI-O integration tests
+      env:
+        GOLANG_VERSION: ${{ matrix.go-versions }}
+      run: |
+        set -ex
+        source build/config/crio.sh
+        make docker-test-integration-crio
+    - name: Upload cAdvisor log file
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: cadvisor-crio.log
+        path: ${{ github.workspace }}/go/src/github.com/google/cadvisor/cadvisor.log

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,14 @@ test-integration:
 docker-test-integration:
 	@./build/integration-in-docker.sh
 
+docker-test-integration-crio:
+	@./build/integration-in-docker-crio.sh
+
+test-integration-crio:
+	GO_FLAGS=$(or $(GO_FLAGS),-race) ./build/build.sh
+	$(GO_TEST) -c github.com/google/cadvisor/integration/tests/crio
+	@./build/integration-crio.sh
+
 test-runner:
 	@$(GO) build github.com/google/cadvisor/integration/runner
 
@@ -100,4 +108,4 @@ clean:
 	@rm -f *.test cadvisor
 	@rm -rf _output/
 
-.PHONY: all build docker format release test test-integration lint presubmit tidy
+.PHONY: all build docker format release test test-integration test-integration-crio lint presubmit tidy

--- a/build/config/crio.sh
+++ b/build/config/crio.sh
@@ -1,0 +1,19 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CRI-O plain configuration - no special build flags
+unset GO_FLAGS
+unset PACKAGES
+unset BUILD_PACKAGES
+unset CADVISOR_ARGS

--- a/build/integration-crio.sh
+++ b/build/integration-crio.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+# When running this script locally, you may need to run cadvisor with sudo
+# permissions if cadvisor can't find containers.
+# USE_SUDO=true make test-integration-crio
+USE_SUDO=${USE_SUDO:-false}
+cadvisor_bin=${CADVISOR_BIN:-"./_output/cadvisor"}
+
+if ! [ -f "$cadvisor_bin" ]; then
+  echo Failed to find cadvisor binary for integration test at path $cadvisor_bin
+  exit 1
+fi
+
+log_file="cadvisor.log"
+if [ "$#" -gt 0 ]; then
+  log_file="$1"
+fi
+
+TEST_PID=$$
+printf "" # Refresh sudo credentials if necessary.
+
+# Check if CRI-O is available and start it if not running
+CRIO_SOCK="/var/run/crio/crio.sock"
+
+# Function to start CRI-O if not running (for CI environments)
+start_crio_if_needed() {
+  if [ -S "$CRIO_SOCK" ]; then
+    echo ">> CRI-O already running"
+    return 0
+  fi
+
+  echo ">> CRI-O not running, attempting to start..."
+
+  # Check if crio binary exists
+  CRIO_BIN=""
+  if command -v crio >/dev/null 2>&1; then
+    CRIO_BIN="crio"
+  elif [ -x /usr/local/bin/crio ]; then
+    CRIO_BIN="/usr/local/bin/crio"
+  fi
+
+  if [ -z "$CRIO_BIN" ]; then
+    echo "!! crio binary not found"
+    return 1
+  fi
+
+  # Create required directories
+  mkdir -p /var/run/crio /var/lib/containers/storage /var/log/crio/pods /run/containers/storage /etc/crio
+
+  # Install conmon if not available (CRI-O requires it)
+  if ! command -v conmon >/dev/null 2>&1 && [ ! -x /usr/local/bin/conmon ]; then
+    echo ">> Installing conmon..."
+    CONMON_VERSION=v2.1.8
+    curl -L https://github.com/containers/conmon/releases/download/${CONMON_VERSION}/conmon.amd64 -o /usr/local/bin/conmon 2>/dev/null && \
+    chmod +x /usr/local/bin/conmon
+  fi
+
+  # Ensure conmon is in PATH
+  if [ -x /usr/local/bin/conmon ]; then
+    export PATH=/usr/local/bin:$PATH
+  fi
+
+  # Install CNI plugins if not available
+  if [ ! -d /opt/cni/bin ] || [ -z "$(ls -A /opt/cni/bin 2>/dev/null)" ]; then
+    echo ">> Installing CNI plugins..."
+    CNI_VERSION=v1.3.0
+    mkdir -p /opt/cni/bin
+    curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" | tar -xz -C /opt/cni/bin
+  fi
+
+  # Create CNI config for bridge networking
+  mkdir -p /etc/cni/net.d
+  if [ ! -f /etc/cni/net.d/10-bridge.conf ]; then
+    echo '{"cniVersion":"0.4.0","name":"bridge","type":"bridge","bridge":"cni0","isGateway":true,"ipMasq":true,"ipam":{"type":"host-local","subnet":"10.88.0.0/16","routes":[{"dst":"0.0.0.0/0"}]}}' > /etc/cni/net.d/10-bridge.conf
+    echo '{"cniVersion":"0.4.0","name":"loopback","type":"loopback"}' > /etc/cni/net.d/99-loopback.conf
+  fi
+
+  # Create CRI-O config (always recreate to ensure correct settings)
+  echo ">> Creating CRI-O config..."
+  # Use vfs storage driver for Docker-in-Docker (overlay on overlay doesn't work)
+  cat > /etc/crio/crio.conf << 'EOF'
+[crio]
+root = "/var/lib/containers/storage"
+runroot = "/var/run/containers/storage"
+log_dir = "/var/log/crio/pods"
+version_file = "/var/run/crio/version"
+storage_driver = "vfs"
+
+[crio.api]
+listen = "/var/run/crio/crio.sock"
+
+[crio.runtime]
+default_runtime = "crun"
+[crio.runtime.runtimes.crun]
+runtime_path = "/usr/bin/crun"
+runtime_type = "oci"
+runtime_root = "/run/crun"
+
+[crio.image]
+pause_image = "registry.k8s.io/pause:3.9"
+EOF
+
+  # Also configure containers storage
+  mkdir -p /etc/containers
+  cat > /etc/containers/storage.conf << 'EOF'
+[storage]
+driver = "vfs"
+runroot = "/var/run/containers/storage"
+graphroot = "/var/lib/containers/storage"
+EOF
+
+  # Create containers policy (allow all images) if it doesn't exist
+  if [ ! -f /etc/containers/policy.json ]; then
+    echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json
+  fi
+
+  # Verify policy.json exists and is valid
+  echo ">> Verifying /etc/containers/policy.json..."
+  cat /etc/containers/policy.json
+
+  # Start CRI-O
+  echo ">> Starting CRI-O daemon..."
+  $CRIO_BIN --log-level debug &
+  CRIO_PID=$!
+  sleep 2
+
+  # Wait for CRI-O to be ready
+  echo ">> Waiting for CRI-O to start..."
+  CRICTL_BIN="crictl"
+  if [ -x /usr/local/bin/crictl ]; then
+    CRICTL_BIN="/usr/local/bin/crictl"
+  fi
+
+  for i in $(seq 1 60); do
+    if $CRICTL_BIN info >/dev/null 2>&1; then
+      echo ">> CRI-O is ready"
+      return 0
+    fi
+    echo "Waiting for CRI-O... attempt $i"
+    sleep 1
+  done
+
+  echo "!! CRI-O failed to start"
+  return 1
+}
+
+# Try to start CRI-O if in Docker-in-Docker environment
+if [[ "${DOCKER_IN_DOCKER_ENABLED:-}" == "true" ]]; then
+  start_crio_if_needed
+fi
+
+# Diagnostic logging for CRI-O debugging
+echo ">> Diagnostic information:"
+echo "=== CRI-O version ==="
+crio --version 2>/dev/null || /usr/local/bin/crio --version 2>/dev/null || echo "crio --version failed"
+echo "=== crictl version ==="
+crictl version 2>/dev/null || /usr/local/bin/crictl version 2>/dev/null || echo "crictl version failed"
+echo "=== CRI-O socket check ==="
+ls -la /var/run/crio/ 2>/dev/null || echo "/var/run/crio/ not found"
+ls -la /run/crio/ 2>/dev/null || echo "/run/crio/ not found"
+echo "=== CRI-O info ==="
+crictl info 2>/dev/null || /usr/local/bin/crictl info 2>/dev/null || echo "crictl info failed"
+echo "=== Running processes (crio) ==="
+ps aux | grep -E "crio" | grep -v grep || echo "No crio processes found"
+echo "=== Kernel version ==="
+uname -r
+echo "=== End diagnostic information ==="
+
+# CRI-O socket is hardcoded in cAdvisor to /var/run/crio/crio.sock
+if [ -S "$CRIO_SOCK" ]; then
+  echo ">> CRI-O socket found at: $CRIO_SOCK"
+else
+  echo "!! CRI-O socket not found at: $CRIO_SOCK"
+  echo "!! CRI-O may not be running"
+fi
+
+function start {
+  set +e  # We want to handle errors if cAdvisor crashes.
+  echo ">> starting cAdvisor locally"
+  cadvisor_prereqs=""
+  if [ $USE_SUDO = true ]; then
+    cadvisor_prereqs=sudo
+  fi
+  # cpu, cpuset, percpu, memory, disk, diskIO, network metrics should be enabled.
+  GORACE="halt_on_error=1" $cadvisor_prereqs $cadvisor_bin --enable_metrics="cpu,cpuset,percpu,memory,disk,diskIO,network" --env_metadata_whitelist=TEST_VAR --v=6 --logtostderr $CADVISOR_ARGS &> "$log_file"
+  exit_code=$?
+  if [ $exit_code != 0 ]; then
+    echo "!! cAdvisor exited unexpectedly with Exit $exit_code"
+    cat $log_file
+    kill $TEST_PID # cAdvisor crashed: abort testing.
+  fi
+}
+start &
+RUNNER_PID=$!
+
+function cleanup {
+  if pgrep cadvisor > /dev/null; then
+    echo ">> stopping cAdvisor"
+    pkill -SIGINT cadvisor
+    wait $RUNNER_PID
+  fi
+}
+trap cleanup EXIT SIGINT TERM
+
+readonly TIMEOUT=30 # Timeout to wait for cAdvisor, in seconds.
+START=$(date +%s)
+while [ "$(curl -Gs http://localhost:8080/healthz)" != "ok" ]; do
+  if (( $(date +%s) - $START > $TIMEOUT )); then
+    echo "Timed out waiting for cAdvisor to start"
+    exit 1
+  fi
+  echo "Waiting for cAdvisor to start ..."
+  sleep 1
+done
+
+if [[ "${DOCKER_IN_DOCKER_ENABLED:-}" == "true" ]]; then
+  # see https://github.com/moby/moby/blob/master/hack/dind
+  # cgroup v2: enable nesting
+  if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    echo ">> configuring cgroupsv2 for crio in container..."
+    # move the processes from the root group to the /init group,
+    # otherwise writing subtree_control fails with EBUSY.
+    # An error during moving non-existent process (i.e., "cat") is ignored.
+    mkdir -p /sys/fs/cgroup/init
+    xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+    # enable controllers
+    sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+      > /sys/fs/cgroup/cgroup.subtree_control
+  fi
+fi
+
+echo ">> running CRI-O integration tests against local cAdvisor"
+if ! [ -f ./crio.test ]; then
+  echo You must compile the ./crio.test binary before
+  echo running the integration tests.
+  exit 1
+fi
+./crio.test --vmodule=*=2 -test.v

--- a/build/integration-in-docker-crio.sh
+++ b/build/integration-in-docker-crio.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE}")/.." && pwd -P)"
+TMPDIR=$(mktemp -d)
+function delete() {
+  echo "Deleting ${TMPDIR}..."
+  if [[ $EUID -ne 0 ]]; then
+    sudo rm -rf "${TMPDIR}"
+  else
+    rm -rf "${TMPDIR}"
+  fi
+}
+trap delete EXIT INT TERM
+
+function run_tests() {
+
+  # Detect architecture - the bootstrap image is amd64-only
+  DOCKER_PLATFORM="linux/amd64"
+
+  # Add safe.directory as workaround for https://github.com/actions/runner/issues/2033
+  # Build for amd64 to match the test container
+  BUILD_CMD="git config --global safe.directory /go/src/github.com/google/cadvisor && env GOOS=linux GOARCH=amd64 GO_FLAGS='$GO_FLAGS' CGO_ENABLED=0 ./build/build.sh && \
+    env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c github.com/google/cadvisor/integration/tests/crio"
+
+  if [ "$BUILD_PACKAGES" != "" ]; then
+    BUILD_CMD="apt update && apt install -y $BUILD_PACKAGES && \
+    $BUILD_CMD"
+  fi
+
+  # Build in amd64 container to match test environment
+  docker run --rm \
+    --platform ${DOCKER_PLATFORM} \
+    -w /go/src/github.com/google/cadvisor \
+    -v ${PWD}:/go/src/github.com/google/cadvisor \
+    golang:"$GOLANG_VERSION-bookworm" \
+    bash -c "$BUILD_CMD"
+
+  EXTRA_DOCKER_OPTS="-e DOCKER_IN_DOCKER_ENABLED=true"
+  if [[ "${OSTYPE}" == "linux"* ]]; then
+    EXTRA_DOCKER_OPTS+=" -v ${TMPDIR}/crio-graph:/var/lib/containers"
+  fi
+
+  mkdir -p ${TMPDIR}/crio-graph
+
+  # Run tests in a privileged container with CRI-O
+  # Use --platform to ensure consistent architecture
+  # Use --cgroupns=host and --pid=host to share host namespaces (required for systemd cgroup manager)
+  # Mount host's systemd and dbus sockets so CRI-O can use systemd cgroup manager
+  docker run --rm \
+    --platform ${DOCKER_PLATFORM} \
+    -w /go/src/github.com/google/cadvisor \
+    -v ${ROOT}:/go/src/github.com/google/cadvisor \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    -v /run/systemd:/run/systemd:ro \
+    -v /run/dbus:/run/dbus:ro \
+    ${EXTRA_DOCKER_OPTS} \
+    --privileged \
+    --cap-add="sys_admin" \
+    --cgroupns=host \
+    --pid=host \
+    --entrypoint="" \
+    gcr.io/k8s-staging-test-infra/bootstrap:v20250702-52f5173c3a \
+    bash -c "export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y $PACKAGES curl conntrack iptables dbus && \
+
+    # Check if host systemd and dbus are available
+    echo 'Checking host systemd and dbus...' && \
+    ls -la /run/systemd/ || true && \
+    ls -la /run/dbus/ || true && \
+    systemctl --version || true && \
+
+    # Install CRI-O and crictl from static binaries (more reliable than apt)
+    CRIO_VERSION=v1.28.0 && \
+    CRICTL_VERSION=v1.28.0 && \
+
+    # Download and install crictl
+    echo 'Installing crictl...' && \
+    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/\${CRICTL_VERSION}/crictl-\${CRICTL_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xz && \
+    chmod +x /usr/local/bin/crictl && \
+
+    # Download and install CRI-O from Google Cloud Storage
+    echo 'Installing CRI-O...' && \
+    mkdir -p /tmp/crio-install && \
+    curl -L https://storage.googleapis.com/cri-o/artifacts/cri-o.amd64.\${CRIO_VERSION}.tar.gz | tar -xz -C /tmp/crio-install && \
+    mkdir -p /usr/local/bin /etc/crio /etc/containers && \
+    ls -la /tmp/crio-install/cri-o/bin/ && \
+    cp /tmp/crio-install/cri-o/bin/crio /usr/local/bin/ && \
+    cp /tmp/crio-install/cri-o/bin/crio-status /usr/local/bin/ 2>/dev/null || true && \
+    cp /tmp/crio-install/cri-o/bin/pinns /usr/local/bin/ 2>/dev/null || true && \
+    cp /tmp/crio-install/cri-o/bin/conmon /usr/local/bin/ 2>/dev/null || true && \
+    cp /tmp/crio-install/cri-o/bin/conmonrs /usr/local/bin/ 2>/dev/null || true && \
+    chmod +x /usr/local/bin/crio* /usr/local/bin/pinns /usr/local/bin/conmon* 2>/dev/null || true && \
+    ls -la /usr/local/bin/crio* /usr/local/bin/conmon* /usr/local/bin/pinns 2>/dev/null && \
+
+    # Create CRI-O config with systemd cgroup manager (using host systemd via mounted socket)
+    mkdir -p /etc/crio/crio.conf.d && \
+    cat > /etc/crio/crio.conf <<CRIOEOF
+[crio]
+root = \"/var/lib/containers/storage\"
+runroot = \"/var/run/containers/storage\"
+log_dir = \"/var/log/crio/pods\"
+version_file = \"/var/run/crio/version\"
+
+[crio.api]
+listen = \"/var/run/crio/crio.sock\"
+
+[crio.runtime]
+cgroup_manager = \"systemd\"
+conmon_cgroup = \"pod\"
+default_runtime = \"crun\"
+[crio.runtime.runtimes.crun]
+runtime_path = \"/usr/bin/crun\"
+runtime_type = \"oci\"
+runtime_root = \"/run/crun\"
+
+[crio.image]
+pause_image = \"registry.k8s.io/pause:3.9\"
+CRIOEOF
+
+    # Install crun as the runtime
+    apt-get install -y crun && \
+
+    # Create containers policy (required for image pulling)
+    mkdir -p /etc/containers && \
+    echo '{\"default\":[{\"type\":\"insecureAcceptAnything\"}]}' > /etc/containers/policy.json && \
+    echo 'Created /etc/containers/policy.json:' && \
+    cat /etc/containers/policy.json && \
+
+    # Install CNI plugins
+    echo 'Installing CNI plugins...' && \
+    CNI_VERSION=v1.3.0 && \
+    mkdir -p /opt/cni/bin && \
+    curl -L \"https://github.com/containernetworking/plugins/releases/download/\${CNI_VERSION}/cni-plugins-linux-amd64-\${CNI_VERSION}.tgz\" | tar -xz -C /opt/cni/bin && \
+    ls -la /opt/cni/bin/ && \
+
+    # Create CNI config for bridge networking
+    mkdir -p /etc/cni/net.d && \
+    echo '{\"cniVersion\":\"0.4.0\",\"name\":\"bridge\",\"type\":\"bridge\",\"bridge\":\"cni0\",\"isGateway\":true,\"ipMasq\":true,\"ipam\":{\"type\":\"host-local\",\"subnet\":\"10.88.0.0/16\",\"routes\":[{\"dst\":\"0.0.0.0/0\"}]}}' > /etc/cni/net.d/10-bridge.conf && \
+    echo '{\"cniVersion\":\"0.4.0\",\"name\":\"loopback\",\"type\":\"loopback\"}' > /etc/cni/net.d/99-loopback.conf && \
+    echo 'CNI config created:' && \
+    cat /etc/cni/net.d/10-bridge.conf && \
+
+    # Configure crictl to use CRI-O socket
+    cat > /etc/crictl.yaml <<EOF
+runtime-endpoint: unix:///var/run/crio/crio.sock
+image-endpoint: unix:///var/run/crio/crio.sock
+timeout: 30
+debug: true
+EOF
+
+    # Start CRI-O daemon in background
+    mkdir -p /var/run/crio /var/lib/containers/storage /var/log/crio/pods /run/containers/storage && \
+    echo 'Starting CRI-O...' && \
+    /usr/local/bin/crio --log-level debug &
+    CRIO_PID=\$! && \
+    sleep 2 && \
+
+    # Wait for CRI-O to be ready
+    echo 'Waiting for CRI-O to start...' && \
+    for i in \$(seq 1 60); do \
+      if /usr/local/bin/crictl info >/dev/null 2>&1; then \
+        echo 'CRI-O is ready'; \
+        break; \
+      fi; \
+      echo \"Waiting for CRI-O... attempt \$i\"; \
+      sleep 1; \
+    done && \
+
+    # Verify CRI-O is running
+    /usr/local/bin/crictl info && \
+
+    # Pull required images
+    echo 'Pulling test images...' && \
+    /usr/local/bin/crictl pull registry.k8s.io/pause:3.9 || true && \
+    /usr/local/bin/crictl pull registry.k8s.io/busybox:1.27 || true && \
+
+    # Add /usr/local/bin to PATH for the test runner
+    export PATH=/usr/local/bin:\$PATH && \
+
+    # Run the integration tests
+    CADVISOR_ARGS='$CADVISOR_ARGS' /usr/local/bin/runner.sh build/integration-crio.sh"
+}
+
+# Note: -race requires CGO, but cross-compilation with CGO is problematic
+# So we use -tags=netgo without -race for cross-platform compatibility
+GO_FLAGS=${GO_FLAGS:-"-tags=netgo"}
+PACKAGES=${PACKAGES:-"sudo"}
+BUILD_PACKAGES=${BUILD_PACKAGES:-}
+CADVISOR_ARGS=${CADVISOR_ARGS:-}
+GOLANG_VERSION=${GOLANG_VERSION:-"1.25"}
+run_tests

--- a/integration/tests/crio/crio_test.go
+++ b/integration/tests/crio/crio_test.go
@@ -1,0 +1,267 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crio
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	info "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/integration/framework"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Waits up to 10s for a CRI-O container with the specified ID to appear in cAdvisor.
+// CRI-O containers may take longer to appear due to the pod sandbox model.
+func waitForCrioContainer(containerID string, fm framework.Framework) {
+	err := framework.RetryForDuration(func() error {
+		// Query all containers via SubcontainersInfo - CRI-O containers are in "crio" namespace,
+		// not "docker" namespace, so AllDockerContainers won't find them.
+		allInfo, err := fm.Cadvisor().Client().SubcontainersInfo("/", &info.ContainerInfoRequest{
+			NumStats: 1,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Look for container by ID (CRI-O containers appear with crio- prefix in cgroup)
+		for _, container := range allInfo {
+			for _, alias := range container.Aliases {
+				if alias == containerID {
+					return nil
+				}
+			}
+			// Also check if the container name contains the ID
+			if len(container.Name) > 0 && contains(container.Name, containerID) {
+				return nil
+			}
+		}
+		return fmt.Errorf("container %q not found in cAdvisor", containerID)
+	}, 10*time.Second)
+	require.NoError(fm.T(), err, "Timed out waiting for CRI-O container %q to be available in cAdvisor", containerID)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// Sanity check the container by:
+// - Checking that the specified ID is associated with this container.
+// - Verifying that stats are not empty.
+func sanityCheck(containerID string, containerInfo info.ContainerInfo, t *testing.T) {
+	// Check that the container has stats
+	assert.NotEmpty(t, containerInfo.Stats, "Expected container to have stats")
+}
+
+// TestCrioContainerById tests that cAdvisor can find a CRI-O container by its ID.
+func TestCrioContainerById(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	containerID := fm.Crio().RunPause()
+
+	// Wait for the container to show up in cAdvisor
+	waitForCrioContainer(containerID, fm)
+
+	// Query all containers via SubcontainersInfo - CRI-O containers are in "crio" namespace
+	allInfo, err := fm.Cadvisor().Client().SubcontainersInfo("/", &info.ContainerInfoRequest{
+		NumStats: 1,
+	})
+	require.NoError(t, err)
+
+	// Find our container
+	var found bool
+	for _, container := range allInfo {
+		for _, alias := range container.Aliases {
+			if alias == containerID {
+				sanityCheck(containerID, container, t)
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+	assert.True(t, found, "Container %q should be found in cAdvisor", containerID)
+}
+
+// TestCrioContainerByName tests that cAdvisor can find a CRI-O container by a custom name.
+func TestCrioContainerByName(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	containerName := fmt.Sprintf("test-crio-container-by-name-%d", os.Getpid())
+	containerID := fm.Crio().Run(framework.CrioRunArgs{
+		Image: "registry.k8s.io/pause:3.9",
+		Name:  containerName,
+	})
+
+	// Wait for the container to show up
+	waitForCrioContainer(containerID, fm)
+
+	// Query all containers via SubcontainersInfo - CRI-O containers are in "crio" namespace
+	allInfo, err := fm.Cadvisor().Client().SubcontainersInfo("/", &info.ContainerInfoRequest{
+		NumStats: 1,
+	})
+	require.NoError(t, err)
+
+	// Find our container by ID
+	var found bool
+	for _, container := range allInfo {
+		for _, alias := range container.Aliases {
+			if alias == containerID {
+				sanityCheck(containerID, container, t)
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+	assert.True(t, found, "Container with ID %q should be found in cAdvisor", containerID)
+}
+
+// TestBasicCrioContainer tests basic container properties.
+func TestBasicCrioContainer(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	containerID := fm.Crio().RunPause()
+
+	// Wait for the container to show up
+	waitForCrioContainer(containerID, fm)
+
+	// Query all containers via SubcontainersInfo - CRI-O containers are in "crio" namespace
+	allInfo, err := fm.Cadvisor().Client().SubcontainersInfo("/", &info.ContainerInfoRequest{
+		NumStats: 1,
+	})
+	require.NoError(t, err)
+
+	// Find our container
+	var containerInfo *info.ContainerInfo
+	for i, container := range allInfo {
+		for _, alias := range container.Aliases {
+			if alias == containerID {
+				containerInfo = &allInfo[i]
+				break
+			}
+		}
+		if containerInfo != nil {
+			break
+		}
+	}
+
+	require.NotNil(t, containerInfo, "Container %q should be found", containerID)
+	assert.NotEmpty(t, containerInfo.Stats, "Should have at least one stat")
+}
+
+// TestCrioContainerCpuStats tests CPU statistics collection for CRI-O containers.
+func TestCrioContainerCpuStats(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	// Run a busybox container that does some work
+	containerID := fm.Crio().RunBusybox("sh", "-c", "while true; do echo hello; sleep 1; done")
+
+	// Wait for the container to show up
+	waitForCrioContainer(containerID, fm)
+
+	// Give the container some time to generate CPU usage
+	time.Sleep(2 * time.Second)
+
+	// Query all containers via SubcontainersInfo - CRI-O containers are in "crio" namespace
+	allInfo, err := fm.Cadvisor().Client().SubcontainersInfo("/", &info.ContainerInfoRequest{
+		NumStats: 1,
+	})
+	require.NoError(t, err)
+
+	// Find our container
+	var containerInfo *info.ContainerInfo
+	for i, container := range allInfo {
+		for _, alias := range container.Aliases {
+			if alias == containerID {
+				containerInfo = &allInfo[i]
+				break
+			}
+		}
+		if containerInfo != nil {
+			break
+		}
+	}
+
+	require.NotNil(t, containerInfo, "Container %q should be found", containerID)
+	require.NotEmpty(t, containerInfo.Stats, "Should have stats")
+
+	// Check CPU stats
+	stat := containerInfo.Stats[0]
+	checkCPUStats(t, stat.Cpu)
+}
+
+// TestCrioContainerMemoryStats tests memory statistics collection for CRI-O containers.
+func TestCrioContainerMemoryStats(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	// Run a busybox container
+	containerID := fm.Crio().RunBusybox("sh", "-c", "while true; do echo hello; sleep 1; done")
+
+	// Wait for the container to show up
+	waitForCrioContainer(containerID, fm)
+
+	// Give the container some time to use memory
+	time.Sleep(2 * time.Second)
+
+	// Query all containers via SubcontainersInfo - CRI-O containers are in "crio" namespace
+	allInfo, err := fm.Cadvisor().Client().SubcontainersInfo("/", &info.ContainerInfoRequest{
+		NumStats: 1,
+	})
+	require.NoError(t, err)
+
+	// Find our container
+	var containerInfo *info.ContainerInfo
+	for i, container := range allInfo {
+		for _, alias := range container.Aliases {
+			if alias == containerID {
+				containerInfo = &allInfo[i]
+				break
+			}
+		}
+		if containerInfo != nil {
+			break
+		}
+	}
+
+	require.NotNil(t, containerInfo, "Container %q should be found", containerID)
+	require.NotEmpty(t, containerInfo.Stats, "Should have stats")
+
+	// Check memory stats
+	stat := containerInfo.Stats[0]
+	checkMemoryStats(t, stat.Memory)
+}

--- a/integration/tests/crio/test_utils.go
+++ b/integration/tests/crio/test_utils.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crio
+
+import (
+	"testing"
+	"time"
+
+	info "github.com/google/cadvisor/info/v1"
+
+	"github.com/opencontainers/cgroups"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+// Checks that expected and actual are within delta of each other.
+func inDelta(t *testing.T, expected, actual, delta uint64, description string) {
+	var diff uint64
+	if expected > actual {
+		diff = expected - actual
+	} else {
+		diff = actual - expected
+	}
+	if diff > delta {
+		t.Errorf("%s (%d and %d) are not within %d of each other", description, expected, actual, delta)
+	}
+}
+
+// Checks that CPU stats are valid.
+func checkCPUStats(t *testing.T, stat info.CpuStats) {
+	assert := assert.New(t)
+
+	assert.NotEqual(0, stat.Usage.Total, "Total CPU usage should not be zero")
+
+	// PerCPU CPU usage is not supported in cgroupv2 (cpuacct.usage_percpu)
+	// https://github.com/google/cadvisor/issues/3065
+	if !cgroups.IsCgroup2UnifiedMode() {
+		assert.NotEmpty(stat.Usage.PerCpu, "Per-core usage should not be empty")
+
+		totalUsage := uint64(0)
+		for _, usage := range stat.Usage.PerCpu {
+			totalUsage += usage
+		}
+		inDelta(t, stat.Usage.Total, totalUsage, uint64((5 * time.Millisecond).Nanoseconds()), "Per-core CPU usage")
+	}
+
+	inDelta(t, stat.Usage.Total, stat.Usage.User+stat.Usage.System, uint64((500 * time.Millisecond).Nanoseconds()), "User + system CPU usage")
+}
+
+func checkMemoryStats(t *testing.T, stat info.MemoryStats) {
+	assert := assert.New(t)
+
+	assert.NotEqual(0, stat.Usage, "Memory usage should not be zero")
+	assert.NotEqual(0, stat.WorkingSet, "Memory working set should not be zero")
+	if stat.WorkingSet > stat.Usage {
+		t.Errorf("Memory working set (%d) should be at most equal to memory usage (%d)", stat.WorkingSet, stat.Usage)
+	}
+}


### PR DESCRIPTION
Add integration tests for CRI-O container runtime, similar to the existing Docker integration tests. This includes:

- CrioActions interface in the test framework for managing CRI-O containers via crictl CLI
- Test cases for container discovery by ID and name, basic container stats, CPU stats, and memory stats
- Build scripts for running CRI-O tests locally and in Docker
- GitHub Actions workflow job for CI

The CRI-O tests use the pod sandbox model required by CRI-O, where containers run inside pods. The test harness handles pod lifecycle management and cleanup automatically.