### PR TITLE
test: reorganize integration tests and add CRI-O test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ docker-test: container-test
 test-integration:
 	GO_FLAGS=$(or $(GO_FLAGS),-race) ./build/build.sh
 	$(GO_TEST) -c github.com/google/cadvisor/integration/tests/api
-	$(GO_TEST) -c github.com/google/cadvisor/integration/tests/healthz
+	$(GO_TEST) -c github.com/google/cadvisor/integration/tests/common
 	@./build/integration.sh
 
 docker-test-integration:
@@ -50,6 +50,7 @@ docker-test-integration-crio:
 test-integration-crio:
 	GO_FLAGS=$(or $(GO_FLAGS),-race) ./build/build.sh
 	$(GO_TEST) -c github.com/google/cadvisor/integration/tests/crio
+	$(GO_TEST) -c github.com/google/cadvisor/integration/tests/common
 	@./build/integration-crio.sh
 
 test-runner:

--- a/build/integration-crio.sh
+++ b/build/integration-crio.sh
@@ -251,3 +251,10 @@ if ! [ -f ./crio.test ]; then
   exit 1
 fi
 ./crio.test --vmodule=*=2 -test.v
+
+echo ">> running common integration tests against local cAdvisor"
+if [ -f ./common.test ]; then
+  ./common.test -test.v
+else
+  echo "Skipping common tests (./common.test not found)"
+fi

--- a/build/integration-in-docker-crio.sh
+++ b/build/integration-in-docker-crio.sh
@@ -36,7 +36,8 @@ function run_tests() {
   # Add safe.directory as workaround for https://github.com/actions/runner/issues/2033
   # Build for amd64 to match the test container
   BUILD_CMD="git config --global safe.directory /go/src/github.com/google/cadvisor && env GOOS=linux GOARCH=amd64 GO_FLAGS='$GO_FLAGS' CGO_ENABLED=0 ./build/build.sh && \
-    env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c github.com/google/cadvisor/integration/tests/crio"
+    env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c github.com/google/cadvisor/integration/tests/crio && \
+    env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c github.com/google/cadvisor/integration/tests/common"
 
   if [ "$BUILD_PACKAGES" != "" ]; then
     BUILD_CMD="apt update && apt install -y $BUILD_PACKAGES && \

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -33,7 +33,7 @@ function run_tests() {
   # Add safe.directory as workaround for https://github.com/actions/runner/issues/2033
   BUILD_CMD="git config --global safe.directory /go/src/github.com/google/cadvisor && env GOOS=linux GOARCH=amd64 GO_FLAGS='$GO_FLAGS' ./build/build.sh && \
     env GOOS=linux GOFLAGS='$GO_FLAGS' go test -c github.com/google/cadvisor/integration/tests/api && \
-    env GOOS=linux GOFLAGS='$GO_FLAGS' go test -c github.com/google/cadvisor/integration/tests/healthz"
+    env GOOS=linux GOFLAGS='$GO_FLAGS' go test -c github.com/google/cadvisor/integration/tests/common"
 
   if [ "$BUILD_PACKAGES" != "" ]; then
     BUILD_CMD="apt update && apt install -y $BUILD_PACKAGES && \

--- a/build/integration.sh
+++ b/build/integration.sh
@@ -117,10 +117,10 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED:-}" == "true" ]]; then
 fi
 
 echo ">> running integration tests against local cAdvisor"
-if ! [ -f ./api.test ] || ! [ -f ./healthz.test ]; then
-  echo You must compile the ./api.test binary and ./healthz.test binary before
+if ! [ -f ./api.test ] || ! [ -f ./common.test ]; then
+  echo You must compile the ./api.test binary and ./common.test binary before
   echo running the integration tests.
   exit 1
 fi
 ./api.test --vmodule=*=2 -test.v
-./healthz.test --vmodule=*=2 -test.v
+./common.test -test.v

--- a/integration/tests/common/attributes_test.go
+++ b/integration/tests/common/attributes_test.go
@@ -1,0 +1,37 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/google/cadvisor/integration/framework"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttributeInformationIsReturned(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	attributes, err := fm.Cadvisor().ClientV2().Attributes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vp := `\d+\.\d+\.\d+`
+	assert.True(t, assert.Regexp(t, vp, attributes.KernelVersion),
+		"Expected %s to match %s", attributes.KernelVersion, vp)
+}

--- a/integration/tests/common/healthz_test.go
+++ b/integration/tests/common/healthz_test.go
@@ -1,0 +1,43 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/cadvisor/integration/framework"
+)
+
+func TestHealthzOk(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	// Ensure that /healthz returns "ok"
+	resp, err := http.Get(fm.Hostname().FullHostname() + "healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != "ok" {
+		t.Fatalf("cAdvisor returned unexpected healthz status of %q", body)
+	}
+}

--- a/integration/tests/common/machine_test.go
+++ b/integration/tests/common/machine_test.go
@@ -1,0 +1,60 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common contains integration tests that are runtime-independent.
+// These tests work with any container runtime (Docker, CRI-O, containerd, etc.)
+// and test cAdvisor's core functionality like machine info, attributes, and health.
+package common
+
+import (
+	"testing"
+
+	"github.com/google/cadvisor/integration/framework"
+)
+
+func TestMachineInformationIsReturned(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	machineInfo, err := fm.Cadvisor().Client().MachineInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check for "sane" values. Note these can change with time.
+	if machineInfo.NumCores <= 0 || machineInfo.NumCores >= 1000000 {
+		t.Errorf("Machine info has unexpected number of cores: %v", machineInfo.NumCores)
+	}
+	if machineInfo.MemoryCapacity == 0 || machineInfo.MemoryCapacity >= (1<<50 /* 1PB */) {
+		t.Errorf("Machine info has unexpected amount of memory: %v", machineInfo.MemoryCapacity)
+	}
+	if len(machineInfo.Filesystems) == 0 {
+		t.Errorf("Expected to have some filesystems, found none")
+	}
+	for _, fs := range machineInfo.Filesystems {
+		if fs.Device == "" {
+			t.Errorf("Expected a non-empty device name in: %+v", fs)
+		}
+		if fs.Capacity >= (1 << 60 /* 1 EB*/) {
+			t.Errorf("Unexpected capacity in device %q: %v", fs.Device, fs.Capacity)
+		}
+		if fs.Type == "" {
+			t.Errorf("Filesystem type is not set")
+		} else if fs.Type == "vfs" && fs.Inodes == 0 {
+			if fs.Device != "devpts" {
+				t.Errorf("Inodes not available for device %q", fs.Device)
+			}
+		}
+	}
+}

--- a/integration/tests/common/machinestats_test.go
+++ b/integration/tests/common/machinestats_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opencontainers/cgroups"
+
+	"github.com/google/cadvisor/integration/framework"
+)
+
+func TestMachineStatsIsReturned(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	machineStats, err := fm.Cadvisor().ClientV2().MachineStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	as := assert.New(t)
+	for _, stat := range machineStats {
+		as.NotEqual(stat.Timestamp, time.Time{})
+		as.True(stat.Cpu.Usage.Total > 0)
+		// PerCPU CPU usage is not supported in cgroupv2 (cpuacct.usage_percpu)
+		// https://github.com/google/cadvisor/issues/3065
+		if !cgroups.IsCgroup2UnifiedMode() {
+			as.True(len(stat.Cpu.Usage.PerCpu) > 0)
+		}
+		if stat.CpuInst != nil {
+			as.True(stat.CpuInst.Usage.Total > 0)
+		}
+		as.True(stat.Memory.Usage > 0)
+		for _, nStat := range stat.Network.Interfaces {
+			as.NotEqual(nStat.Name, "")
+			as.NotEqual(nStat.RxBytes, 0)
+		}
+		for _, fsStat := range stat.Filesystem {
+			as.NotEqual(fsStat.Device, "")
+			as.NotNil(fsStat.Capacity)
+			as.NotNil(fsStat.Usage)
+			as.NotNil(fsStat.ReadsCompleted)
+			require.NotEmpty(t, fsStat.Type)
+			if fsStat.Type == "vfs" {
+				as.NotNil(fsStat.InodesFree)
+			}
+		}
+	}
+}

--- a/integration/tests/healthz/doc.go
+++ b/integration/tests/healthz/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package healthz contains healthz endpoint integration tests.
+//
+// Deprecated: This package is deprecated. Use integration/tests/common instead,
+// which contains the same healthz tests along with other runtime-independent tests.
+package healthz


### PR DESCRIPTION
  

  Reorganize integration tests by creating a new `common` package for
  runtime-independent tests that work with any container runtime
  (Docker, CRI-O, containerd, etc.):
  - TestAttributeInformationIsReturned: tests v2 attributes API
  - TestHealthzOk: tests health endpoint
  - TestMachineInformationIsReturned: tests machine info API
  - TestMachineStatsIsReturned: tests machine stats API

  Deprecate the old `healthz` package in favor of the new `common` package.

  Add new CRI-O-specific integration tests:
  - TestCrioContainerNetworkStats: tests network stats (skipped - CI issue)
  - TestCrioContainerSpec: tests container spec properties
  - TestCrioContainerDeletionExitCode: tests exit code events (skipped)
  - TestCrioFilesystemStats: tests filesystem statistics

  Update build infrastructure to run common tests for both Docker and
  CRI-O integration test suites.