### PR TITLE
Support f2fs filesystem

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -180,7 +180,7 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 		"tmpfs":   true,
 		"xfs":     true,
 		"zfs":     true,
-                "f2fs":    true,
+		"f2fs":    true,
 	}
 
 	for _, mnt := range mounts {

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -678,6 +678,7 @@ func TestProcessMounts(t *testing.T) {
 				{Root: "/", Mountpoint: "/g", Source: "127.0.0.1:/nfs", FSType: "nfs4", Major: 253, Minor: 6},
 				{Root: "/", Mountpoint: "/test1", Source: "tmpfs", FSType: "tmpfs", Major: 253, Minor: 4},
 				{Root: "/", Mountpoint: "/test2", Source: "tmpfs", FSType: "tmpfs", Major: 253, Minor: 4},
+				{Root: "/", Mountpoint: "/h", Source: "/dev/sdh", FSType: "f2fs", Major: 253, Minor: 7},
 			},
 			expected: map[string]partition{
 				"/dev/sda":       {fsType: "ext3", mountpoint: "/a", major: 253, minor: 0},
@@ -689,6 +690,7 @@ func TestProcessMounts(t *testing.T) {
 				"127.0.0.1:/nfs": {fsType: "nfs4", mountpoint: "/g", major: 253, minor: 6},
 				"/test1":         {fsType: "tmpfs", mountpoint: "/test1", major: 253, minor: 4},
 				"/test2":         {fsType: "tmpfs", mountpoint: "/test2", major: 253, minor: 4},
+				"/dev/sdh":       {fsType: "f2fs", mountpoint: "/h", major: 253, minor: 7},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Add support for f2fs (Flash-Friendly File System) filesystem to cAdvisor.

This is a rebase of #3604 by @tomaszduda23 onto the latest master branch, with a minor indentation fix.

## Changes

- Add `f2fs` to the list of supported filesystem types in `fs/fs.go`
- Add test case for f2fs filesystem in `fs/fs_test.go`

## Background

f2fs is a flash-friendly file system designed for NAND-based storage devices. It is commonly used on Android devices and embedded systems with flash storage.

## Test plan

- [x] Added unit test for f2fs filesystem detection
- [ ] CI passes

Original PR: #3604
Co-authored-by: Tomasz Duda <tomaszduda23@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)