### PR TITLE
fs: introduce pluggable filesystem architecture

### DIFF
--- a/cmd/internal/container/install/install.go
+++ b/cmd/internal/container/install/install.go
@@ -22,4 +22,13 @@ import (
 	_ "github.com/google/cadvisor/container/docker/install"
 	_ "github.com/google/cadvisor/container/podman/install"
 	_ "github.com/google/cadvisor/container/systemd/install"
+
+	// Register all filesystem plugins.
+	_ "github.com/google/cadvisor/fs/btrfs/install"
+	_ "github.com/google/cadvisor/fs/devicemapper/install"
+	_ "github.com/google/cadvisor/fs/nfs/install"
+	_ "github.com/google/cadvisor/fs/overlay/install"
+	_ "github.com/google/cadvisor/fs/tmpfs/install"
+	_ "github.com/google/cadvisor/fs/vfs/install"
+	_ "github.com/google/cadvisor/fs/zfs/install"
 )

--- a/fs/btrfs/install/install.go
+++ b/fs/btrfs/install/install.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/btrfs"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("btrfs", btrfs.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register btrfs fs plugin: %v", err)
+	}
+}

--- a/fs/btrfs/mount.go
+++ b/fs/btrfs/mount.go
@@ -1,0 +1,63 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package btrfs
+
+import (
+	"fmt"
+	"syscall"
+
+	mount "github.com/moby/sys/mountinfo"
+	"k8s.io/klog/v2"
+)
+
+// major extracts the major device number from a device number.
+func major(devNumber uint64) uint {
+	return uint((devNumber >> 8) & 0xfff)
+}
+
+// minor extracts the minor device number from a device number.
+func minor(devNumber uint64) uint {
+	return uint((devNumber & 0xff) | ((devNumber >> 12) & 0xfff00))
+}
+
+// GetBtrfsMajorMinorIds gets the major and minor device IDs for a btrfs mount point.
+// This is a workaround for wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
+// Instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point.
+func GetBtrfsMajorMinorIds(mnt *mount.Info) (int, int, error) {
+	buf := new(syscall.Stat_t)
+	err := syscall.Stat(mnt.Source, buf)
+	if err != nil {
+		err = fmt.Errorf("stat failed on %s with error: %s", mnt.Source, err)
+		return 0, 0, err
+	}
+
+	klog.V(4).Infof("btrfs mount %#v", mnt)
+	if buf.Mode&syscall.S_IFMT == syscall.S_IFBLK {
+		err := syscall.Stat(mnt.Mountpoint, buf)
+		if err != nil {
+			err = fmt.Errorf("stat failed on %s with error: %s", mnt.Mountpoint, err)
+			return 0, 0, err
+		}
+
+		// The type Dev and Rdev in Stat_t are 32bit on mips.
+		klog.V(4).Infof("btrfs dev major:minor %d:%d\n", int(major(uint64(buf.Dev))), int(minor(uint64(buf.Dev))))    // nolint: unconvert
+		klog.V(4).Infof("btrfs rdev major:minor %d:%d\n", int(major(uint64(buf.Rdev))), int(minor(uint64(buf.Rdev)))) // nolint: unconvert
+
+		return int(major(uint64(buf.Dev))), int(minor(uint64(buf.Dev))), nil // nolint: unconvert
+	}
+	return 0, 0, fmt.Errorf("%s is not a block device", mnt.Source)
+}

--- a/fs/btrfs/plugin.go
+++ b/fs/btrfs/plugin.go
@@ -1,0 +1,87 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package btrfs
+
+import (
+	"strings"
+
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	mount "github.com/moby/sys/mountinfo"
+	"k8s.io/klog/v2"
+)
+
+type btrfsPlugin struct{}
+
+// NewPlugin creates a new Btrfs filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &btrfsPlugin{}
+}
+
+func (p *btrfsPlugin) Name() string {
+	return "btrfs"
+}
+
+// CanHandle returns true if the filesystem type is btrfs.
+func (p *btrfsPlugin) CanHandle(fsType string) bool {
+	return fsType == "btrfs"
+}
+
+// Priority returns 100 - Btrfs has higher priority than VFS.
+func (p *btrfsPlugin) Priority() int {
+	return 100
+}
+
+// GetStats returns filesystem statistics for Btrfs.
+// Btrfs delegates to VFS for stats collection.
+func (p *btrfsPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	// Btrfs uses VFS stats
+	capacity, free, avail, inodes, inodesFree, err := vfs.GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles Btrfs mount processing.
+// Btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
+// Instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point.
+func (p *btrfsPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	// Only apply fix if Major is 0 and Source starts with /dev/
+	if mnt.Major == 0 && strings.HasPrefix(mnt.Source, "/dev/") {
+		major, minor, err := GetBtrfsMajorMinorIds(mnt)
+		if err != nil {
+			klog.Warningf("%s", err)
+		} else {
+			// Create a copy with corrected values
+			correctedMnt := *mnt
+			correctedMnt.Major = major
+			correctedMnt.Minor = minor
+			return true, &correctedMnt, nil
+		}
+	}
+	return true, mnt, nil
+}

--- a/fs/devicemapper/install/install.go
+++ b/fs/devicemapper/install/install.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/devicemapper"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("devicemapper", devicemapper.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register devicemapper fs plugin: %v", err)
+	}
+}

--- a/fs/devicemapper/plugin.go
+++ b/fs/devicemapper/plugin.go
@@ -1,0 +1,66 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicemapper
+
+import (
+	"github.com/google/cadvisor/fs"
+
+	mount "github.com/moby/sys/mountinfo"
+	"k8s.io/klog/v2"
+)
+
+type dmPlugin struct{}
+
+// NewPlugin creates a new DeviceMapper filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &dmPlugin{}
+}
+
+func (p *dmPlugin) Name() string {
+	return "devicemapper"
+}
+
+// CanHandle returns true if the filesystem type is devicemapper.
+func (p *dmPlugin) CanHandle(fsType string) bool {
+	return fsType == "devicemapper"
+}
+
+// Priority returns 100 - DeviceMapper has higher priority than VFS.
+func (p *dmPlugin) Priority() int {
+	return 100
+}
+
+// GetStats returns filesystem statistics for DeviceMapper thin provisioning.
+func (p *dmPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	capacity, free, avail, err := GetDMStats(device, partition.BlockSize)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.V(5).Infof("got devicemapper fs capacity stats: capacity: %v free: %v available: %v", capacity, free, avail)
+
+	return &fs.FsStats{
+		Capacity:  capacity,
+		Free:      free,
+		Available: avail,
+		Type:      fs.DeviceMapper,
+	}, nil
+}
+
+// ProcessMount handles DeviceMapper mount processing.
+// For DeviceMapper, no special processing is needed.
+func (p *dmPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	return true, mnt, nil
+}

--- a/fs/devicemapper/stats.go
+++ b/fs/devicemapper/stats.go
@@ -1,0 +1,113 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicemapper
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	dm "github.com/google/cadvisor/devicemapper"
+)
+
+// GetDMStats returns devicemapper thin provisioning stats.
+func GetDMStats(poolName string, dataBlkSize uint) (uint64, uint64, uint64, error) {
+	out, err := exec.Command("dmsetup", "status", poolName).Output()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	used, total, err := parseDMStatus(string(out))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	used *= 512 * uint64(dataBlkSize)
+	total *= 512 * uint64(dataBlkSize)
+	free := total - used
+
+	return total, free, free, nil
+}
+
+// parseDMStatus parses the output of `dmsetup status`.
+func parseDMStatus(dmStatus string) (uint64, uint64, error) {
+	dmStatus = strings.Replace(dmStatus, "/", " ", -1)
+	dmFields := strings.Fields(dmStatus)
+
+	if len(dmFields) < 8 {
+		return 0, 0, fmt.Errorf("invalid dmsetup status output: %s", dmStatus)
+	}
+
+	used, err := strconv.ParseUint(dmFields[6], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	total, err := strconv.ParseUint(dmFields[7], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return used, total, nil
+}
+
+// parseDMTable parses a single line of `dmsetup table` output and returns the
+// major device, minor device, block size, and an error.
+func ParseDMTable(dmTable string) (uint, uint, uint, error) {
+	dmTable = strings.Replace(dmTable, ":", " ", -1)
+	dmFields := strings.Fields(dmTable)
+
+	if len(dmFields) < 8 {
+		return 0, 0, 0, fmt.Errorf("invalid dmsetup status output: %s", dmTable)
+	}
+
+	major, err := strconv.ParseUint(dmFields[5], 10, 32)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	minor, err := strconv.ParseUint(dmFields[6], 10, 32)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	dataBlkSize, err := strconv.ParseUint(dmFields[7], 10, 32)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return uint(major), uint(minor), uint(dataBlkSize), nil
+}
+
+// DockerDMDevice returns information about the devicemapper device and "partition" if
+// docker is using devicemapper for its storage driver.
+func DockerDMDevice(driverStatus map[string]string, dmsetup dm.DmsetupClient) (string, uint, uint, uint, error) {
+	const driverStatusPoolName = "Pool Name"
+
+	poolName, ok := driverStatus[driverStatusPoolName]
+	if !ok || len(poolName) == 0 {
+		return "", 0, 0, 0, fmt.Errorf("could not get dm pool name")
+	}
+
+	out, err := dmsetup.Table(poolName)
+	if err != nil {
+		return "", 0, 0, 0, err
+	}
+
+	major, minor, dataBlkSize, err := ParseDMTable(string(out))
+	if err != nil {
+		return "", 0, 0, 0, err
+	}
+
+	return poolName, major, minor, dataBlkSize, nil
+}

--- a/fs/devicemapper/stats_test.go
+++ b/fs/devicemapper/stats_test.go
@@ -1,0 +1,75 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicemapper
+
+import (
+	"testing"
+)
+
+var dmStatusTests = []struct {
+	dmStatus    string
+	used        uint64
+	total       uint64
+	errExpected bool
+}{
+	{`0 409534464 thin-pool 64085 3705/4161600 88106/3199488 - rw no_discard_passdown queue_if_no_space -`, 88106, 3199488, false},
+	{`0 209715200 thin-pool 707 1215/524288 30282/1638400 - rw discard_passdown`, 30282, 1638400, false},
+	{`Invalid status line`, 0, 0, false},
+}
+
+func TestParseDMStatus(t *testing.T) {
+	for _, tt := range dmStatusTests {
+		used, total, err := parseDMStatus(tt.dmStatus)
+		if tt.errExpected && err != nil {
+			t.Errorf("parseDMStatus(%q) expected error", tt.dmStatus)
+		}
+		if used != tt.used {
+			t.Errorf("parseDMStatus(%q) wrong used value => %q, want %q", tt.dmStatus, used, tt.used)
+		}
+		if total != tt.total {
+			t.Errorf("parseDMStatus(%q) wrong total value => %q, want %q", tt.dmStatus, total, tt.total)
+		}
+	}
+}
+
+var dmTableTests = []struct {
+	dmTable     string
+	major       uint
+	minor       uint
+	dataBlkSize uint
+	errExpected bool
+}{
+	{`0 409534464 thin-pool 253:6 253:7 128 32768 1 skip_block_zeroing`, 253, 7, 128, false},
+	{`0 409534464 thin-pool 253:6 258:9 512 32768 1 skip_block_zeroing otherstuff`, 258, 9, 512, false},
+	{`Invalid status line`, 0, 0, 0, false},
+}
+
+func TestParseDMTable(t *testing.T) {
+	for _, tt := range dmTableTests {
+		major, minor, dataBlkSize, err := ParseDMTable(tt.dmTable)
+		if tt.errExpected && err != nil {
+			t.Errorf("ParseDMTable(%q) expected error", tt.dmTable)
+		}
+		if major != tt.major {
+			t.Errorf("ParseDMTable(%q) wrong major value => %q, want %q", tt.dmTable, major, tt.major)
+		}
+		if minor != tt.minor {
+			t.Errorf("ParseDMTable(%q) wrong minor value => %q, want %q", tt.dmTable, minor, tt.minor)
+		}
+		if dataBlkSize != tt.dataBlkSize {
+			t.Errorf("ParseDMTable(%q) wrong dataBlkSize value => %q, want %q", tt.dmTable, dataBlkSize, tt.dataBlkSize)
+		}
+	}
+}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -19,23 +19,19 @@ package fs
 
 import (
 	"bufio"
-	"context"
+	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
-	zfs "github.com/mistifyio/go-zfs"
 	mount "github.com/moby/sys/mountinfo"
 
 	"github.com/google/cadvisor/devicemapper"
-	"github.com/google/cadvisor/utils"
 
 	"k8s.io/klog/v2"
 )
@@ -172,28 +168,21 @@ func getFsUUIDToDeviceNameMap() (map[string]string, error) {
 func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) map[string]partition {
 	partitions := make(map[string]partition)
 
-	supportedFsType := map[string]bool{
-		// all ext and nfs systems are checked through prefix
-		// because there are a number of families (e.g., ext3, ext4, nfs3, nfs4...)
-		"btrfs":   true,
-		"overlay": true,
-		"tmpfs":   true,
-		"xfs":     true,
-		"zfs":     true,
-	}
-
 	for _, mnt := range mounts {
-		if !strings.HasPrefix(mnt.FSType, "ext") && !strings.HasPrefix(mnt.FSType, "nfs") &&
-			!supportedFsType[mnt.FSType] {
+		// Use plugin system to determine if filesystem is supported
+		plugin := GetPluginForFsType(mnt.FSType)
+		if plugin == nil {
 			continue
 		}
-		// Avoid bind mounts, exclude tmpfs.
+
+		// Avoid bind mounts, but allow tmpfs duplicates (handled by plugin's ProcessMount)
 		if _, ok := partitions[mnt.Source]; ok {
 			if mnt.FSType != "tmpfs" {
 				continue
 			}
 		}
 
+		// Check for excluded mountpoint prefixes
 		hasPrefix := false
 		for _, prefix := range excludedMountpointPrefixes {
 			if strings.HasPrefix(mnt.Mountpoint, prefix) {
@@ -205,32 +194,21 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 			continue
 		}
 
-		// using mountpoint to replace device once fstype it tmpfs
-		if mnt.FSType == "tmpfs" {
-			mnt.Source = mnt.Mountpoint
+		// Let plugin process the mount (handles filesystem-specific modifications)
+		include, processedMnt, err := plugin.ProcessMount(mnt)
+		if err != nil {
+			klog.Warningf("error processing mount for %s: %v", mnt.FSType, err)
+			continue
 		}
-		// btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
-		// instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point
-		if mnt.FSType == "btrfs" && mnt.Major == 0 && strings.HasPrefix(mnt.Source, "/dev/") {
-			major, minor, err := getBtrfsMajorMinorIds(mnt)
-			if err != nil {
-				klog.Warningf("%s", err)
-			} else {
-				mnt.Major = major
-				mnt.Minor = minor
-			}
+		if !include {
+			continue
 		}
 
-		// overlay fix: Making mount source unique for all overlay mounts, using the mount's major and minor ids.
-		if mnt.FSType == "overlay" {
-			mnt.Source = fmt.Sprintf("%s_%d-%d", mnt.Source, mnt.Major, mnt.Minor)
-		}
-
-		partitions[mnt.Source] = partition{
-			fsType:     mnt.FSType,
-			mountpoint: mnt.Mountpoint,
-			major:      uint(mnt.Major),
-			minor:      uint(mnt.Minor),
+		partitions[processedMnt.Source] = partition{
+			fsType:     processedMnt.FSType,
+			mountpoint: processedMnt.Mountpoint,
+			major:      uint(processedMnt.Major),
+			minor:      uint(processedMnt.Minor),
 		}
 	}
 
@@ -411,81 +389,112 @@ func (i *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error
 	if err != nil {
 		return nil, err
 	}
-	nfsInfo := make(map[string]Fs, 0)
+	// statsCache stores cached filesystem stats by cache key for plugins that implement FsCachingPlugin
+	statsCache := make(map[string]Fs)
 	for device, partition := range i.partitions {
 		_, hasMount := mountSet[partition.mountpoint]
 		_, hasDevice := deviceSet[device]
 		if mountSet == nil || (hasMount && !hasDevice) {
 			var (
-				err error
-				fs  Fs
+				statsErr error
+				fs       Fs
 			)
-			fsType := partition.fsType
-			if strings.HasPrefix(partition.fsType, "nfs") {
-				fsType = "nfs"
-			}
-			switch fsType {
-			case DeviceMapper.String():
-				fs.Capacity, fs.Free, fs.Available, err = getDMStats(device, partition.blockSize)
-				klog.V(5).Infof("got devicemapper fs capacity stats: capacity: %v free: %v available: %v:", fs.Capacity, fs.Free, fs.Available)
-				fs.Type = DeviceMapper
-			case ZFS.String():
-				if _, devzfs := os.Stat("/dev/zfs"); os.IsExist(devzfs) {
-					fs.Capacity, fs.Free, fs.Available, err = getZfstats(device)
-					fs.Type = ZFS
-					break
-				}
-				// if /dev/zfs is not present default to VFS
-				fallthrough
-			case NFS.String():
-				devId := fmt.Sprintf("%d:%d", partition.major, partition.minor)
-				if v, ok := nfsInfo[devId]; ok {
-					fs = v
-					break
-				}
-				var inodes, inodesFree uint64
-				fs.Capacity, fs.Free, fs.Available, inodes, inodesFree, err = getVfsStats(partition.mountpoint)
-				if err != nil {
-					klog.V(4).Infof("the file system type is %s, partition mountpoint does not exist: %v, error: %v", partition.fsType, partition.mountpoint, err)
-					break
-				}
-				fs.Inodes = &inodes
-				fs.InodesFree = &inodesFree
-				fs.Type = VFS
-				nfsInfo[devId] = fs
-			default:
-				var inodes, inodesFree uint64
-				if utils.FileExists(partition.mountpoint) {
-					fs.Capacity, fs.Free, fs.Available, inodes, inodesFree, err = getVfsStats(partition.mountpoint)
-					fs.Inodes = &inodes
-					fs.InodesFree = &inodesFree
-					fs.Type = VFS
-				} else {
-					klog.V(4).Infof("unable to determine file system type, partition mountpoint does not exist: %v", partition.mountpoint)
-				}
-			}
-			if err != nil {
-				klog.V(4).Infof("Stat fs failed. Error: %v", err)
-			} else {
-				deviceSet[device] = struct{}{}
-				fs.DeviceInfo = DeviceInfo{
-					Device: device,
-					Major:  uint(partition.major),
-					Minor:  uint(partition.minor),
-				}
 
-				if val, ok := diskStatsMap[device]; ok {
-					fs.DiskStats = val
-				} else {
-					for k, v := range diskStatsMap {
-						if v.MajorNum == uint64(partition.major) && v.MinorNum == uint64(partition.minor) {
-							fs.DiskStats = diskStatsMap[k]
-							break
+			// Use plugin system to get filesystem stats
+			plugin := GetPluginForFsType(partition.fsType)
+			if plugin == nil {
+				klog.V(4).Infof("no plugin found for filesystem type: %v", partition.fsType)
+				continue
+			}
+
+			partInfo := PartitionInfo{
+				Mountpoint: partition.mountpoint,
+				Major:      partition.major,
+				Minor:      partition.minor,
+				FsType:     partition.fsType,
+				BlockSize:  partition.blockSize,
+			}
+
+			// Check if plugin supports caching and if we have a cached value
+			var cacheKey string
+			if cachingPlugin, ok := plugin.(FsCachingPlugin); ok {
+				cacheKey = cachingPlugin.CacheKey(partInfo)
+				if cacheKey != "" {
+					if cachedFs, found := statsCache[cacheKey]; found {
+						fs = cachedFs
+						// Skip stats fetching, use cached value
+						deviceSet[device] = struct{}{}
+						fs.DeviceInfo = DeviceInfo{
+							Device: device,
+							Major:  uint(partition.major),
+							Minor:  uint(partition.minor),
 						}
+						if val, ok := diskStatsMap[device]; ok {
+							fs.DiskStats = val
+						} else {
+							for k, v := range diskStatsMap {
+								if v.MajorNum == uint64(partition.major) && v.MinorNum == uint64(partition.minor) {
+									fs.DiskStats = diskStatsMap[k]
+									break
+								}
+							}
+						}
+						filesystems = append(filesystems, fs)
+						continue
 					}
 				}
-				filesystems = append(filesystems, fs)
 			}
+
+			stats, statsErr := plugin.GetStats(device, partInfo)
+			if statsErr != nil {
+				// Handle fallback to VFS for plugins that request it
+				if errors.Is(statsErr, ErrFallbackToVFS) {
+					vfsPlugin := GetPluginForFsType("ext4") // VFS handles ext*
+					if vfsPlugin != nil {
+						stats, statsErr = vfsPlugin.GetStats(device, partInfo)
+					}
+				}
+				if statsErr != nil {
+					klog.V(4).Infof("Stat fs failed for %s. Error: %v", partition.fsType, statsErr)
+					continue
+				}
+			}
+
+			if stats == nil {
+				klog.V(4).Infof("no stats returned for %s at %s", partition.fsType, partition.mountpoint)
+				continue
+			}
+
+			fs.Capacity = stats.Capacity
+			fs.Free = stats.Free
+			fs.Available = stats.Available
+			fs.Inodes = stats.Inodes
+			fs.InodesFree = stats.InodesFree
+			fs.Type = stats.Type
+
+			// Store in cache if plugin supports caching
+			if cacheKey != "" {
+				statsCache[cacheKey] = fs
+			}
+
+			deviceSet[device] = struct{}{}
+			fs.DeviceInfo = DeviceInfo{
+				Device: device,
+				Major:  uint(partition.major),
+				Minor:  uint(partition.minor),
+			}
+
+			if val, ok := diskStatsMap[device]; ok {
+				fs.DiskStats = val
+			} else {
+				for k, v := range diskStatsMap {
+					if v.MajorNum == uint64(partition.major) && v.MinorNum == uint64(partition.minor) {
+						fs.DiskStats = diskStatsMap[k]
+						break
+					}
+				}
+			}
+			filesystems = append(filesystems, fs)
 		}
 	}
 	return filesystems, nil
@@ -716,44 +725,6 @@ func (i *RealFsInfo) GetDirUsage(dir string) (UsageInfo, error) {
 	return GetDirUsage(dir)
 }
 
-func getVfsStats(path string) (total uint64, free uint64, avail uint64, inodes uint64, inodesFree uint64, err error) {
-	// timeout the context with, default is 2sec
-	timeout := 2
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-	defer cancel()
-
-	type result struct {
-		total      uint64
-		free       uint64
-		avail      uint64
-		inodes     uint64
-		inodesFree uint64
-		err        error
-	}
-
-	resultChan := make(chan result, 1)
-
-	go func() {
-		var s syscall.Statfs_t
-		if err = syscall.Statfs(path, &s); err != nil {
-			total, free, avail, inodes, inodesFree = 0, 0, 0, 0, 0
-		}
-		total = uint64(s.Frsize) * s.Blocks
-		free = uint64(s.Frsize) * s.Bfree
-		avail = uint64(s.Frsize) * s.Bavail
-		inodes = uint64(s.Files)
-		inodesFree = uint64(s.Ffree)
-		resultChan <- result{total: total, free: free, avail: avail, inodes: inodes, inodesFree: inodesFree, err: err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return 0, 0, 0, 0, 0, ctx.Err()
-	case res := <-resultChan:
-		return res.total, res.free, res.avail, res.inodes, res.inodesFree, res.err
-	}
-}
-
 // Devicemapper thin provisioning is detailed at
 // https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
 func dockerDMDevice(driverStatus map[string]string, dmsetup devicemapper.DmsetupClient) (string, uint, uint, uint, error) {
@@ -799,56 +770,6 @@ func parseDMTable(dmTable string) (uint, uint, uint, error) {
 	}
 
 	return uint(major), uint(minor), uint(dataBlkSize), nil
-}
-
-func getDMStats(poolName string, dataBlkSize uint) (uint64, uint64, uint64, error) {
-	out, err := exec.Command("dmsetup", "status", poolName).Output()
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	used, total, err := parseDMStatus(string(out))
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	used *= 512 * uint64(dataBlkSize)
-	total *= 512 * uint64(dataBlkSize)
-	free := total - used
-
-	return total, free, free, nil
-}
-
-func parseDMStatus(dmStatus string) (uint64, uint64, error) {
-	dmStatus = strings.Replace(dmStatus, "/", " ", -1)
-	dmFields := strings.Fields(dmStatus)
-
-	if len(dmFields) < 8 {
-		return 0, 0, fmt.Errorf("invalid dmsetup status output: %s", dmStatus)
-	}
-
-	used, err := strconv.ParseUint(dmFields[6], 10, 64)
-	if err != nil {
-		return 0, 0, err
-	}
-	total, err := strconv.ParseUint(dmFields[7], 10, 64)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return used, total, nil
-}
-
-// getZfstats returns ZFS mount stats using zfsutils
-func getZfstats(poolName string) (uint64, uint64, uint64, error) {
-	dataset, err := zfs.GetDataset(poolName)
-	if err != nil {
-		return 0, 0, 0, err
-	}
-
-	total := dataset.Used + dataset.Avail + dataset.Usedbydataset
-
-	return total, dataset.Avail, dataset.Avail, nil
 }
 
 // Get major and minor Ids for a mount point using btrfs as filesystem.

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -16,14 +16,98 @@ package fs
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	mount "github.com/moby/sys/mountinfo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testPlugin is a minimal plugin implementation for testing processMounts.
+type testPlugin struct {
+	name             string
+	canHandle        func(string) bool
+	priority         int
+	processMountFunc func(*mount.Info) (bool, *mount.Info, error)
+}
+
+func (p *testPlugin) Name() string                 { return p.name }
+func (p *testPlugin) CanHandle(fsType string) bool { return p.canHandle(fsType) }
+func (p *testPlugin) Priority() int                { return p.priority }
+func (p *testPlugin) GetStats(device string, partition PartitionInfo) (*FsStats, error) {
+	return nil, nil
+}
+func (p *testPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	if p.processMountFunc != nil {
+		return p.processMountFunc(mnt)
+	}
+	return true, mnt, nil
+}
+
+func init() {
+	// Register test plugins for processMounts tests
+
+	// VFS plugin - handles ext*, xfs
+	RegisterPlugin("test-vfs", &testPlugin{
+		name: "test-vfs",
+		canHandle: func(fsType string) bool {
+			if strings.HasPrefix(fsType, "ext") {
+				return true
+			}
+			return fsType == "xfs"
+		},
+		priority: 0,
+	})
+
+	// ZFS plugin
+	RegisterPlugin("test-zfs", &testPlugin{
+		name:      "test-zfs",
+		canHandle: func(fsType string) bool { return fsType == "zfs" },
+		priority:  100,
+	})
+
+	// Btrfs plugin
+	RegisterPlugin("test-btrfs", &testPlugin{
+		name:      "test-btrfs",
+		canHandle: func(fsType string) bool { return fsType == "btrfs" },
+		priority:  100,
+	})
+
+	// Overlay plugin - makes source unique with major/minor
+	RegisterPlugin("test-overlay", &testPlugin{
+		name:      "test-overlay",
+		canHandle: func(fsType string) bool { return fsType == "overlay" },
+		priority:  100,
+		processMountFunc: func(mnt *mount.Info) (bool, *mount.Info, error) {
+			correctedMnt := *mnt
+			correctedMnt.Source = fmt.Sprintf("%s_%d-%d", mnt.Source, mnt.Major, mnt.Minor)
+			return true, &correctedMnt, nil
+		},
+	})
+
+	// NFS plugin
+	RegisterPlugin("test-nfs", &testPlugin{
+		name:      "test-nfs",
+		canHandle: func(fsType string) bool { return strings.HasPrefix(fsType, "nfs") },
+		priority:  50,
+	})
+
+	// tmpfs plugin - uses mountpoint as source
+	RegisterPlugin("test-tmpfs", &testPlugin{
+		name:      "test-tmpfs",
+		canHandle: func(fsType string) bool { return fsType == "tmpfs" },
+		priority:  100,
+		processMountFunc: func(mnt *mount.Info) (bool, *mount.Info, error) {
+			correctedMnt := *mnt
+			correctedMnt.Source = mnt.Mountpoint
+			return true, &correctedMnt, nil
+		},
+	})
+}
 
 func TestMountInfoFromDir(t *testing.T) {
 	as := assert.New(t)
@@ -149,62 +233,6 @@ func TestDirInodeUsage(t *testing.T) {
 	as.NoError(err)
 	// We should get numFiles+1 inodes, since we get 1 inode for each file, plus 1 for the directory
 	as.True(uint64(numFiles+1) == usage.Inodes, "expected inodes in dir to be %d; got inodes: %d", numFiles+1, usage.Inodes)
-}
-
-var dmStatusTests = []struct {
-	dmStatus    string
-	used        uint64
-	total       uint64
-	errExpected bool
-}{
-	{`0 409534464 thin-pool 64085 3705/4161600 88106/3199488 - rw no_discard_passdown queue_if_no_space -`, 88106, 3199488, false},
-	{`0 209715200 thin-pool 707 1215/524288 30282/1638400 - rw discard_passdown`, 30282, 1638400, false},
-	{`Invalid status line`, 0, 0, false},
-}
-
-func TestParseDMStatus(t *testing.T) {
-	for _, tt := range dmStatusTests {
-		used, total, err := parseDMStatus(tt.dmStatus)
-		if tt.errExpected && err != nil {
-			t.Errorf("parseDMStatus(%q) expected error", tt.dmStatus)
-		}
-		if used != tt.used {
-			t.Errorf("parseDMStatus(%q) wrong used value => %q, want %q", tt.dmStatus, used, tt.used)
-		}
-		if total != tt.total {
-			t.Errorf("parseDMStatus(%q) wrong total value => %q, want %q", tt.dmStatus, total, tt.total)
-		}
-	}
-}
-
-var dmTableTests = []struct {
-	dmTable     string
-	major       uint
-	minor       uint
-	dataBlkSize uint
-	errExpected bool
-}{
-	{`0 409534464 thin-pool 253:6 253:7 128 32768 1 skip_block_zeroing`, 253, 7, 128, false},
-	{`0 409534464 thin-pool 253:6 258:9 512 32768 1 skip_block_zeroing otherstuff`, 258, 9, 512, false},
-	{`Invalid status line`, 0, 0, 0, false},
-}
-
-func TestParseDMTable(t *testing.T) {
-	for _, tt := range dmTableTests {
-		major, minor, dataBlkSize, err := parseDMTable(tt.dmTable)
-		if tt.errExpected && err != nil {
-			t.Errorf("parseDMTable(%q) expected error", tt.dmTable)
-		}
-		if major != tt.major {
-			t.Errorf("parseDMTable(%q) wrong major value => %q, want %q", tt.dmTable, major, tt.major)
-		}
-		if minor != tt.minor {
-			t.Errorf("parseDMTable(%q) wrong minor value => %q, want %q", tt.dmTable, minor, tt.minor)
-		}
-		if dataBlkSize != tt.dataBlkSize {
-			t.Errorf("parseDMTable(%q) wrong dataBlkSize value => %q, want %q", tt.dmTable, dataBlkSize, tt.dataBlkSize)
-		}
-	}
 }
 
 func TestAddSystemRootLabel(t *testing.T) {

--- a/fs/nfs/install/install.go
+++ b/fs/nfs/install/install.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/nfs"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("nfs", nfs.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register nfs fs plugin: %v", err)
+	}
+}

--- a/fs/nfs/plugin.go
+++ b/fs/nfs/plugin.go
@@ -1,0 +1,85 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package nfs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	mount "github.com/moby/sys/mountinfo"
+	"k8s.io/klog/v2"
+)
+
+type nfsPlugin struct{}
+
+// Ensure nfsPlugin implements FsCachingPlugin
+var _ fs.FsCachingPlugin = &nfsPlugin{}
+
+// NewPlugin creates a new NFS filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &nfsPlugin{}
+}
+
+func (p *nfsPlugin) Name() string {
+	return "nfs"
+}
+
+// CanHandle returns true if the filesystem type is NFS (nfs, nfs3, nfs4, etc.).
+func (p *nfsPlugin) CanHandle(fsType string) bool {
+	return strings.HasPrefix(fsType, "nfs")
+}
+
+// Priority returns 50 - NFS has medium priority (higher than VFS but lower than specific plugins).
+func (p *nfsPlugin) Priority() int {
+	return 50
+}
+
+// GetStats returns filesystem statistics for NFS.
+// NFS uses VFS stats.
+func (p *nfsPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	capacity, free, avail, inodes, inodesFree, err := vfs.GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		klog.V(4).Infof("the file system type is %s, partition mountpoint does not exist: %v, error: %v",
+			partition.FsType, partition.Mountpoint, err)
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles NFS mount processing.
+// For NFS, no special processing is needed.
+func (p *nfsPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	return true, mnt, nil
+}
+
+// CacheKey returns a cache key based on device ID (major:minor).
+// NFS mounts with the same device ID share the same underlying filesystem,
+// so we can cache stats to avoid redundant statfs calls.
+func (p *nfsPlugin) CacheKey(partition fs.PartitionInfo) string {
+	return fmt.Sprintf("%d:%d", partition.Major, partition.Minor)
+}

--- a/fs/overlay/install/install.go
+++ b/fs/overlay/install/install.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/overlay"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("overlay", overlay.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register overlay fs plugin: %v", err)
+	}
+}

--- a/fs/overlay/plugin.go
+++ b/fs/overlay/plugin.go
@@ -1,0 +1,76 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package overlay
+
+import (
+	"fmt"
+
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	mount "github.com/moby/sys/mountinfo"
+)
+
+type overlayPlugin struct{}
+
+// NewPlugin creates a new Overlay filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &overlayPlugin{}
+}
+
+func (p *overlayPlugin) Name() string {
+	return "overlay"
+}
+
+// CanHandle returns true if the filesystem type is overlay or overlay2.
+func (p *overlayPlugin) CanHandle(fsType string) bool {
+	return fsType == "overlay"
+}
+
+// Priority returns 100 - Overlay has higher priority than VFS.
+func (p *overlayPlugin) Priority() int {
+	return 100
+}
+
+// GetStats returns filesystem statistics for Overlay.
+// Overlay delegates to VFS for stats collection.
+func (p *overlayPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	// Overlay uses VFS stats
+	capacity, free, avail, inodes, inodesFree, err := vfs.GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles Overlay mount processing.
+// Overlay fix: Making mount source unique for all overlay mounts, using the mount's major and minor ids.
+// This is needed because multiple overlay mounts can have the same source.
+func (p *overlayPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	// Create a copy with unique source
+	correctedMnt := *mnt
+	correctedMnt.Source = fmt.Sprintf("%s_%d-%d", mnt.Source, mnt.Major, mnt.Minor)
+	return true, &correctedMnt, nil
+}

--- a/fs/plugin.go
+++ b/fs/plugin.go
@@ -1,0 +1,179 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	mount "github.com/moby/sys/mountinfo"
+	"k8s.io/klog/v2"
+)
+
+// FsPlugin provides filesystem-specific statistics collection.
+type FsPlugin interface {
+	// Name returns the plugin identifier (e.g., "zfs", "devicemapper", "vfs").
+	Name() string
+
+	// CanHandle returns true if this plugin handles the given filesystem type.
+	CanHandle(fsType string) bool
+
+	// Priority returns the plugin priority (higher = checked first).
+	// Allows specific plugins (zfs, btrfs) to override generic (vfs).
+	Priority() int
+
+	// GetStats returns filesystem statistics for a partition.
+	GetStats(device string, partition PartitionInfo) (*FsStats, error)
+
+	// ProcessMount optionally modifies mount info during processing.
+	// Returns (shouldInclude bool, modifiedMount *mount.Info, error).
+	ProcessMount(mnt *mount.Info) (bool, *mount.Info, error)
+}
+
+// FsCachingPlugin is an optional interface for plugins that want to cache
+// stats by a key (e.g., device ID) to avoid redundant stat calls.
+// This is useful for network filesystems like NFS where multiple mounts
+// may point to the same underlying device.
+type FsCachingPlugin interface {
+	FsPlugin
+
+	// CacheKey returns a cache key for the given partition.
+	// Stats will be cached by this key and reused for partitions with the same key.
+	// Return empty string to disable caching for a specific partition.
+	CacheKey(partition PartitionInfo) string
+}
+
+// FsWatcherPlugin is an optional interface for plugins that provide
+// background monitoring (e.g., ZFS watcher, ThinPool watcher).
+type FsWatcherPlugin interface {
+	FsPlugin
+
+	// StartWatcher starts background monitoring.
+	// Returns a Watcher that can be used to get container-level usage.
+	StartWatcher() (FsWatcher, error)
+}
+
+// FsWatcher provides container-level filesystem usage from background monitoring.
+type FsWatcher interface {
+	// GetUsage returns filesystem usage for a specific container/path.
+	GetUsage(containerID string, deviceID string) (uint64, error)
+
+	// Stop stops the background monitoring.
+	Stop()
+}
+
+// PartitionInfo contains information needed for stats collection.
+type PartitionInfo struct {
+	Mountpoint string
+	Major      uint
+	Minor      uint
+	FsType     string
+	BlockSize  uint
+}
+
+// FsStats contains filesystem statistics returned by plugins.
+type FsStats struct {
+	Capacity   uint64
+	Free       uint64
+	Available  uint64
+	Inodes     *uint64
+	InodesFree *uint64
+	Type       FsType
+}
+
+// ErrFallbackToVFS signals that a specialized plugin cannot handle
+// this filesystem and VFS should be used instead.
+var ErrFallbackToVFS = errors.New("fallback to VFS")
+
+// Plugin registry (init-time registration only).
+var (
+	pluginsLock sync.RWMutex
+	plugins     = make(map[string]FsPlugin)
+)
+
+// RegisterPlugin registers a filesystem plugin.
+// This should be called from init() functions.
+func RegisterPlugin(name string, plugin FsPlugin) error {
+	pluginsLock.Lock()
+	defer pluginsLock.Unlock()
+	if _, found := plugins[name]; found {
+		return fmt.Errorf("FsPlugin %q was registered twice", name)
+	}
+	klog.V(4).Infof("Registered FsPlugin %q", name)
+	plugins[name] = plugin
+	return nil
+}
+
+// GetPluginForFsType returns the appropriate plugin for the filesystem type.
+// Returns nil if no plugin can handle the filesystem type.
+func GetPluginForFsType(fsType string) FsPlugin {
+	pluginsLock.RLock()
+	defer pluginsLock.RUnlock()
+
+	var best FsPlugin
+	for _, p := range plugins {
+		if p.CanHandle(fsType) {
+			if best == nil || p.Priority() > best.Priority() {
+				best = p
+			}
+		}
+	}
+	return best
+}
+
+// GetAllPlugins returns all registered plugins.
+func GetAllPlugins() []FsPlugin {
+	pluginsLock.RLock()
+	defer pluginsLock.RUnlock()
+
+	result := make([]FsPlugin, 0, len(plugins))
+	for _, p := range plugins {
+		result = append(result, p)
+	}
+	return result
+}
+
+// InitializeWatchers starts all plugin watchers and returns them.
+func InitializeWatchers() map[string]FsWatcher {
+	pluginsLock.RLock()
+	defer pluginsLock.RUnlock()
+
+	watchers := make(map[string]FsWatcher)
+	for name, plugin := range plugins {
+		if wp, ok := plugin.(FsWatcherPlugin); ok {
+			watcher, err := wp.StartWatcher()
+			if err != nil {
+				klog.V(4).Infof("Failed to start watcher for plugin %s: %v", name, err)
+				continue
+			}
+			if watcher != nil {
+				watchers[name] = watcher
+				klog.V(4).Infof("Started watcher for FsPlugin %q", name)
+			}
+		}
+	}
+	return watchers
+}
+
+// StopWatchers stops all provided watchers.
+func StopWatchers(watchers map[string]FsWatcher) {
+	for name, watcher := range watchers {
+		if watcher != nil {
+			watcher.Stop()
+			klog.V(4).Infof("Stopped watcher for FsPlugin %q", name)
+		}
+	}
+}

--- a/fs/tmpfs/install/install.go
+++ b/fs/tmpfs/install/install.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/tmpfs"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("tmpfs", tmpfs.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register tmpfs fs plugin: %v", err)
+	}
+}

--- a/fs/tmpfs/plugin.go
+++ b/fs/tmpfs/plugin.go
@@ -1,0 +1,80 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package tmpfs
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	mount "github.com/moby/sys/mountinfo"
+)
+
+type tmpfsPlugin struct{}
+
+// NewPlugin creates a new tmpfs filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &tmpfsPlugin{}
+}
+
+func (p *tmpfsPlugin) Name() string {
+	return "tmpfs"
+}
+
+// CanHandle returns true if the filesystem type is tmpfs.
+func (p *tmpfsPlugin) CanHandle(fsType string) bool {
+	return fsType == "tmpfs"
+}
+
+// Priority returns 100 - tmpfs has higher priority than VFS.
+func (p *tmpfsPlugin) Priority() int {
+	return 100
+}
+
+// GetStats returns filesystem statistics for tmpfs.
+// tmpfs delegates to VFS for stats collection.
+func (p *tmpfsPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	// tmpfs uses VFS stats
+	capacity, free, avail, inodes, inodesFree, err := vfs.GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles tmpfs mount processing.
+// For tmpfs, we use the mountpoint as the source to make each mount unique.
+// This allows multiple tmpfs mounts with the same "tmpfs" source to coexist.
+func (p *tmpfsPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	// Use mountpoint as source to make each tmpfs mount unique
+	correctedMnt := *mnt
+	correctedMnt.Source = mnt.Mountpoint
+	return true, &correctedMnt, nil
+}
+
+// AllowDuplicateSource returns true for tmpfs since multiple tmpfs mounts
+// should be tracked separately even if they appear to have the same source.
+func (p *tmpfsPlugin) AllowDuplicateSource() bool {
+	return true
+}

--- a/fs/vfs/install/install.go
+++ b/fs/vfs/install/install.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/vfs"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("vfs", vfs.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register vfs fs plugin: %v", err)
+	}
+}

--- a/fs/vfs/plugin.go
+++ b/fs/vfs/plugin.go
@@ -1,0 +1,97 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package vfs
+
+import (
+	"strings"
+
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/utils"
+
+	mount "github.com/moby/sys/mountinfo"
+	"k8s.io/klog/v2"
+)
+
+type vfsPlugin struct{}
+
+// NewPlugin creates a new VFS filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &vfsPlugin{}
+}
+
+func (p *vfsPlugin) Name() string {
+	return "vfs"
+}
+
+// CanHandle returns true for standard filesystems that use VFS stats.
+// This includes ext2/3/4, xfs, and similar block-based filesystems.
+// Virtual/pseudo filesystems (proc, sysfs, cgroup, etc.) are excluded.
+func (p *vfsPlugin) CanHandle(fsType string) bool {
+	// Exclude virtual/pseudo filesystems that don't have real disk backing
+	switch fsType {
+	case "cgroup", "cgroup2", "cpuset", "mqueue", "proc", "sysfs",
+		"devtmpfs", "devpts", "securityfs", "debugfs", "tracefs",
+		"pstore", "configfs", "fusectl", "hugetlbfs", "autofs",
+		"binfmt_misc", "efivarfs", "rpc_pipefs", "nsfs":
+		return false
+	}
+
+	// VFS can handle most standard Linux filesystems
+	if strings.HasPrefix(fsType, "ext") {
+		return true
+	}
+	switch fsType {
+	case "xfs", "squashfs", "f2fs", "jfs", "reiserfs", "hfs", "hfsplus",
+		"ntfs", "vfat", "fat", "msdos", "exfat", "udf", "iso9660":
+		return true
+	}
+	// Don't act as a general fallback - only handle known filesystem types
+	return false
+}
+
+// Priority returns 0 - VFS is the lowest priority fallback plugin.
+func (p *vfsPlugin) Priority() int {
+	return 0
+}
+
+// GetStats returns filesystem statistics using the statfs syscall.
+func (p *vfsPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	if !utils.FileExists(partition.Mountpoint) {
+		klog.V(4).Infof("VFS: mountpoint does not exist: %v", partition.Mountpoint)
+		return nil, nil
+	}
+
+	capacity, free, avail, inodes, inodesFree, err := GetVfsStats(partition.Mountpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:   capacity,
+		Free:       free,
+		Available:  avail,
+		Inodes:     &inodes,
+		InodesFree: &inodesFree,
+		Type:       fs.VFS,
+	}, nil
+}
+
+// ProcessMount handles standard mount processing.
+// For VFS, no special processing is needed.
+func (p *vfsPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	return true, mnt, nil
+}

--- a/fs/vfs/stats.go
+++ b/fs/vfs/stats.go
@@ -1,0 +1,63 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package vfs
+
+import (
+	"context"
+	"syscall"
+	"time"
+)
+
+// GetVfsStats returns filesystem statistics using the statfs syscall.
+// It has a timeout to prevent hanging on unresponsive filesystems.
+func GetVfsStats(path string) (total uint64, free uint64, avail uint64, inodes uint64, inodesFree uint64, err error) {
+	// timeout the context with, default is 2sec
+	timeout := 2
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	type result struct {
+		total      uint64
+		free       uint64
+		avail      uint64
+		inodes     uint64
+		inodesFree uint64
+		err        error
+	}
+
+	resultChan := make(chan result, 1)
+
+	go func() {
+		var s syscall.Statfs_t
+		if err = syscall.Statfs(path, &s); err != nil {
+			total, free, avail, inodes, inodesFree = 0, 0, 0, 0, 0
+		}
+		total = uint64(s.Frsize) * s.Blocks
+		free = uint64(s.Frsize) * s.Bfree
+		avail = uint64(s.Frsize) * s.Bavail
+		inodes = uint64(s.Files)
+		inodesFree = uint64(s.Ffree)
+		resultChan <- result{total: total, free: free, avail: avail, inodes: inodes, inodesFree: inodesFree, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return 0, 0, 0, 0, 0, ctx.Err()
+	case res := <-resultChan:
+		return res.total, res.free, res.avail, res.inodes, res.inodesFree, res.err
+	}
+}

--- a/fs/zfs/install/install.go
+++ b/fs/zfs/install/install.go
@@ -1,0 +1,29 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/google/cadvisor/fs"
+	"github.com/google/cadvisor/fs/zfs"
+
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	err := fs.RegisterPlugin("zfs", zfs.NewPlugin())
+	if err != nil {
+		klog.Fatalf("Failed to register zfs fs plugin: %v", err)
+	}
+}

--- a/fs/zfs/plugin.go
+++ b/fs/zfs/plugin.go
@@ -1,0 +1,70 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zfs
+
+import (
+	"os"
+
+	"github.com/google/cadvisor/fs"
+
+	mount "github.com/moby/sys/mountinfo"
+)
+
+type zfsPlugin struct{}
+
+// NewPlugin creates a new ZFS filesystem plugin.
+func NewPlugin() fs.FsPlugin {
+	return &zfsPlugin{}
+}
+
+func (p *zfsPlugin) Name() string {
+	return "zfs"
+}
+
+// CanHandle returns true if the filesystem type is zfs.
+func (p *zfsPlugin) CanHandle(fsType string) bool {
+	return fsType == "zfs"
+}
+
+// Priority returns 100 - ZFS has higher priority than VFS.
+func (p *zfsPlugin) Priority() int {
+	return 100
+}
+
+// GetStats returns filesystem statistics for ZFS.
+func (p *zfsPlugin) GetStats(device string, partition fs.PartitionInfo) (*fs.FsStats, error) {
+	// Check if ZFS is available - if /dev/zfs doesn't exist, fall back to VFS
+	if _, err := os.Stat("/dev/zfs"); os.IsNotExist(err) {
+		return nil, fs.ErrFallbackToVFS
+	}
+
+	capacity, free, avail, err := GetZfsStats(device)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FsStats{
+		Capacity:  capacity,
+		Free:      free,
+		Available: avail,
+		Type:      fs.ZFS,
+	}, nil
+}
+
+// ProcessMount handles ZFS mount processing.
+// For ZFS, no special processing is needed.
+func (p *zfsPlugin) ProcessMount(mnt *mount.Info) (bool, *mount.Info, error) {
+	return true, mnt, nil
+}

--- a/fs/zfs/stats.go
+++ b/fs/zfs/stats.go
@@ -1,0 +1,31 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zfs
+
+import (
+	zfslib "github.com/mistifyio/go-zfs"
+)
+
+// GetZfsStats returns ZFS mount stats using zfsutils.
+func GetZfsStats(poolName string) (uint64, uint64, uint64, error) {
+	dataset, err := zfslib.GetDataset(poolName)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	total := dataset.Used + dataset.Avail + dataset.Usedbydataset
+
+	return total, dataset.Avail, dataset.Avail, nil
+}

--- a/fs/zfs/watcher.go
+++ b/fs/zfs/watcher.go
@@ -1,0 +1,123 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zfs
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	zfslib "github.com/mistifyio/go-zfs"
+	"k8s.io/klog/v2"
+)
+
+// usageCache is a typed wrapper around atomic.Value that eliminates the need
+// for type assertions at every call site. It stores filesystem name strings
+// mapped to usage values (uint64).
+type usageCache struct {
+	v atomic.Value
+}
+
+// Load retrieves the current cache map.
+func (c *usageCache) Load() map[string]uint64 {
+	return c.v.Load().(map[string]uint64)
+}
+
+// Store saves a new cache map.
+func (c *usageCache) Store(m map[string]uint64) {
+	c.v.Store(m)
+}
+
+// ZfsWatcher maintains a cache of filesystem -> usage stats for a
+// zfs filesystem
+type ZfsWatcher struct {
+	filesystem string
+	cache      usageCache
+	period     time.Duration
+	stopChan   chan struct{}
+}
+
+// NewZfsWatcher returns a new ZfsWatcher for the given zfs filesystem.
+func NewZfsWatcher(filesystem string) (*ZfsWatcher, error) {
+	w := &ZfsWatcher{
+		filesystem: filesystem,
+		period:     15 * time.Second,
+		stopChan:   make(chan struct{}),
+	}
+	w.cache.Store(map[string]uint64{})
+	return w, nil
+}
+
+// Start starts the ZfsWatcher.
+func (w *ZfsWatcher) Start() {
+	err := w.Refresh()
+	if err != nil {
+		klog.Errorf("encountered error refreshing zfs watcher: %v", err)
+	}
+
+	for {
+		select {
+		case <-w.stopChan:
+			return
+		case <-time.After(w.period):
+			start := time.Now()
+			err = w.Refresh()
+			if err != nil {
+				klog.Errorf("encountered error refreshing zfs watcher: %v", err)
+			}
+
+			// print latency for refresh
+			duration := time.Since(start)
+			klog.V(5).Infof("zfs(%d) took %s", start.Unix(), duration)
+		}
+	}
+}
+
+// Stop stops the ZfsWatcher.
+func (w *ZfsWatcher) Stop() {
+	close(w.stopChan)
+}
+
+// GetUsage gets the cached usage value of the given filesystem.
+func (w *ZfsWatcher) GetUsage(filesystem string) (uint64, error) {
+	cache := w.cache.Load()
+	v, ok := cache[filesystem]
+	if !ok {
+		return 0, fmt.Errorf("no cached value for usage of filesystem %v", filesystem)
+	}
+	return v, nil
+}
+
+// Refresh performs a zfs get
+func (w *ZfsWatcher) Refresh() error {
+	parent, err := zfslib.GetDataset(w.filesystem)
+	if err != nil {
+		klog.Errorf("encountered error getting zfs filesystem: %s: %v", w.filesystem, err)
+		return err
+	}
+	children, err := parent.Children(0)
+	if err != nil {
+		klog.Errorf("encountered error getting children of zfs filesystem: %s: %v", w.filesystem, err)
+		return err
+	}
+
+	newCache := make(map[string]uint64)
+	for _, ds := range children {
+		newCache[ds.Name] = ds.Used
+	}
+
+	w.cache.Store(newCache)
+	return nil
+}


### PR DESCRIPTION
This change replaces hardcoded filesystem type handling in fs/fs.go
with a pluggable system where each filesystem type is handled by
a dedicated plugin.

New plugin interfaces (fs/plugin.go):
- FsPlugin: core interface for filesystem stats and mount processing
- FsCachingPlugin: optional interface for plugins that cache stats
   by device ID (e.g., NFS with multiple mounts to same device)
- FsWatcherPlugin: optional interface for background monitoring
   (e.g., ZFS watcher, ThinPool watcher)

Filesystem plugins implemented:
- fs/vfs: handles ext2/3/4, xfs, and standard block filesystems
- fs/zfs: ZFS with optional watcher for container-level usage
- fs/devicemapper: DeviceMapper thin pool support
- fs/btrfs: btrfs with major/minor ID correction
- fs/overlay: overlay with source uniqueness via device ID
- fs/nfs: NFS with device-based caching
- fs/tmpfs: tmpfs with per-mount tracking