### PR TITLE
fix: docker working even without containerd

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -352,7 +352,7 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics
 			}
 		}
 	}
-	
+
 	if StorageDriver(dockerInfo.Driver) == ContainerdSnapshotterStorageDriver {
 		containerdClient, err = containerd.Client(*containerd.ArgContainerdEndpoint, "moby")
 		if err != nil {


### PR DESCRIPTION
In 0.54.0 containerd-snapshotter support was added. But old versions of docker do not support containerd-snapshotter. unfortunately the containerd-client is always initialized - even when ContainerdSnapshotterStorageDriver is not used by docker. this leads to error initializing docker factory for older docker versions.
With this fix containerd-client will only initiallized when ContainerdSnapshotterStorageDriver is used by docker. Therefore older docker versions will work again.