### PR TITLE
feat(summary): add standard deviation in derived metrics

### DIFF
--- a/container/containerd/client_test.go
+++ b/container/containerd/client_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/api/types/task"
+
 	"github.com/google/cadvisor/container/containerd/containers"
 )
 

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -192,6 +192,8 @@ type Percentiles struct {
 	Present bool `json:"present"`
 	// Average over the collected sample.
 	Mean uint64 `json:"mean"`
+	// Standard deviation of the collected sample.
+	Std uint64 `json:"std"`
 	// Max seen over the collected sample.
 	Max uint64 `json:"max"`
 	// 50th percentile over the collected sample.

--- a/summary/percentiles.go
+++ b/summary/percentiles.go
@@ -105,6 +105,7 @@ func (r *resource) AddSample(val uint64) {
 	sample := info.Percentiles{
 		Present:    true,
 		Mean:       val,
+		Std:        0,
 		Max:        val,
 		Fifty:      val,
 		Ninety:     val,
@@ -118,6 +119,7 @@ func (r *resource) AddSample(val uint64) {
 func (r *resource) GetAllPercentiles() info.Percentiles {
 	p := info.Percentiles{}
 	p.Mean = uint64(r.mean.Mean)
+	p.Std = uint64(r.samples.getStandardDeviation(r.mean.Mean))
 	p.Max = r.max
 	p.Fifty = r.samples.GetPercentile(0.5)
 	p.Ninety = r.samples.GetPercentile(0.9)
@@ -161,6 +163,21 @@ func getPercentComplete(stats []*secondSample) (percent int32) {
 		}
 	}
 	return
+}
+
+func (s Uint64Slice) getStandardDeviation(mean float64) float64 {
+	n := len(s)
+	if n <= 1 {
+		return 0
+	}
+	var ss float64
+	for _, v := range s {
+		d := float64(v) - mean
+		ss += d * d
+	}
+	// Use Bessel's correction (n-1) to calculate sample standard deviation.
+	// This provides an unbiased estimate of population variance from sample data.
+	return math.Sqrt(ss / float64(n-1))
 }
 
 // Calculate cpurate from two consecutive total cpu usage samples.


### PR DESCRIPTION
## What?

  Adds standard deviation calculation to the Percentiles struct in the summary package, providing
  variability metrics alongside existing percentile data.

 ## Why?

  Standard deviation helps quantify the variability/spread of container resource usage (CPU, memory).
This enables in  better anomaly detection (high std indicates unstable resource usage)

  ## How?

  1. Added Std field to info.Percentiles struct 
  2. Implemented `getStandardDeviation()` using sample standard deviation formula with Bessel's correction
  (n-1 divisor)