### PR TITLE
Replace references to docker registry `gcr.io` with `ghcr.io`

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -18,7 +18,7 @@ kustomize build "https://github.com/google/cadvisor/deploy/kubernetes/base?ref=$
 
 To update the image version([reference](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/image.md)):
 ```
-cd deploy/kubernetes/base && kustomize edit set image gcr.io/cadvisor/cadvisor:${VERSION} && cd ../../..
+cd deploy/kubernetes/base && kustomize edit set image ghcr.io/google/cadvisor:${VERSION} && cd ../../..
 ```
 
 To generate the base daemonset:

--- a/docs/running.md
+++ b/docs/running.md
@@ -14,7 +14,7 @@ sudo docker run \
   --publish=8080:8080 \
   --detach=true \
   --name=cadvisor \
-  gcr.io/cadvisor/cadvisor:$VERSION
+  ghcr.io/google/cadvisor:$VERSION # for versions prior to v0.53.0, use gcr.io/cadvisor/cadvisor instead
 ```
 
 cAdvisor is now running (in the background) on `http://localhost:8080/`. The setup includes directories with Docker state cAdvisor needs to observe.
@@ -44,7 +44,7 @@ otherwise cAdvisor can not connect to docker daemon.
   --device=/dev/kmsg \
   --security-opt seccomp=default.json \
   --name=cadvisor \
-  gcr.io/cadvisor/cadvisor:<tag> -perf_events_config=/etc/configs/perf/perf.json
+  ghcr.io/google/cadvisor:<tag> -perf_events_config=/etc/configs/perf/perf.json
   ```
 
 ## With Boot2Docker


### PR DESCRIPTION
From release of [v0.54.0 - December 2th](https://github.com/google/cadvisor/releases/tag/v0.54.0) (3 weeks ago), newer docker images are pushed to ghcr instead of gcr. I simply updated the docs to reference the new docker registry.

At this moment, is `ghcr.io/google/cadvisor` the official image, or is `gcr.io/cadvisor/cadvisor` and we should expect that to change in the future?

Issue/comment refs:
 - https://github.com/google/cadvisor/issues/3712
 - https://github.com/google/cadvisor/issues/3749#issuecomment-3524798186
 - https://github.com/google/cadvisor/pull/3699