### PR TITLE
Add container_creation_time_seconds (previously: container_start_time_seconds); use runtime start time for container_start_time_seconds (podman & docker)

### DIFF
--- a/container/containerd/client.go
+++ b/container/containerd/client.go
@@ -168,12 +168,16 @@ func (c *client) Version(ctx context.Context) (string, error) {
 
 func containerFromProto(containerpb *containersapi.Container) *containers.Container {
 	var runtime containers.RuntimeInfo
+	var createdAt time.Time
 	// TODO: is nil check required for containerpb
 	if containerpb.Runtime != nil {
 		runtime = containers.RuntimeInfo{
 			Name:    containerpb.Runtime.Name,
 			Options: containerpb.Runtime.Options,
 		}
+	}
+	if containerpb.GetCreatedAt() != nil {
+		createdAt = containerpb.GetCreatedAt().AsTime()
 	}
 	return &containers.Container{
 		ID:          containerpb.ID,
@@ -184,5 +188,6 @@ func containerFromProto(containerpb *containersapi.Container) *containers.Contai
 		Snapshotter: containerpb.Snapshotter,
 		SnapshotKey: containerpb.SnapshotKey,
 		Extensions:  containerpb.Extensions,
+		CreatedAt:   createdAt,
 	}
 }

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -71,6 +71,9 @@ type containerHandler struct {
 	// Time at which this container was created.
 	creationTime time.Time
 
+	// Time at which this container was started.
+	startTime time.Time
+
 	// Metadata associated with the container.
 	envs   map[string]string
 	labels map[string]string
@@ -247,6 +250,13 @@ func newContainerHandler(
 		return nil, fmt.Errorf("failed to parse the create timestamp %q for container %q: %v", ctnr.Created, id, err)
 	}
 
+	// StartedAt may be unset for containers that never started.
+	if startedAt := ctnr.State.StartedAt; startedAt != "" {
+		if t, err := time.Parse(time.RFC3339Nano, startedAt); err == nil && !t.Before(time.Unix(0, 0)) {
+			handler.startTime = t
+		}
+	}
+
 	if ctnr.RestartCount > 0 {
 		handler.labels["restartcount"] = strconv.Itoa(ctnr.RestartCount)
 	}
@@ -326,6 +336,7 @@ func (h *containerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec.Envs = h.envs
 	spec.Image = h.image
 	spec.CreationTime = h.creationTime
+	spec.StartTime = h.startTime
 
 	return spec, nil
 }

--- a/container/podman/handler.go
+++ b/container/podman/handler.go
@@ -55,6 +55,9 @@ type containerHandler struct {
 	// Time at which this container was created.
 	creationTime time.Time
 
+	// Time at which this container was started.
+	startTime time.Time
+
 	// Metadata associated with the container.
 	envs   map[string]string
 	labels map[string]string
@@ -190,6 +193,15 @@ func newContainerHandler(
 		return nil, fmt.Errorf("failed to parse the create timestamp %q for container %q: %v", ctnr.Created, id, err)
 	}
 
+	// StartedAt may be unset for containers that never started.
+	if startedAt := ctnr.State.StartedAt; startedAt != "" {
+		if t, err := time.Parse(time.RFC3339Nano, startedAt); err == nil && !t.Before(time.Unix(0, 0)) {
+			handler.startTime = t
+		} else if t, err := time.Parse(time.RFC3339, startedAt); err == nil && !t.Before(time.Unix(0, 0)) {
+			handler.startTime = t
+		}
+	}
+
 	if ctnr.RestartCount > 0 {
 		handler.labels["restartcount"] = strconv.Itoa(ctnr.RestartCount)
 	}
@@ -259,6 +271,7 @@ func (h *containerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec.Envs = h.envs
 	spec.Image = h.image
 	spec.CreationTime = h.creationTime
+	spec.StartTime = h.startTime
 
 	return spec, nil
 }

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -49,6 +49,10 @@ type ContainerSpec struct {
 	// Time at which the container was created.
 	CreationTime time.Time `json:"creation_time,omitempty"`
 
+	// Time at which the container was started.
+	// This may be unset if the runtime does not provide it.
+	StartTime time.Time `json:"start_time,omitempty"`
+
 	// Metadata labels associated with this container.
 	Labels map[string]string `json:"labels,omitempty"`
 	// Metadata envs associated with this container. Only whitelisted envs are added.
@@ -187,6 +191,12 @@ func (s *ContainerSpec) Eq(b *ContainerSpec) bool {
 	// Creation within 1s of each other.
 	diff := s.CreationTime.Sub(b.CreationTime)
 	if (diff > time.Second) || (diff < -time.Second) {
+		return false
+	}
+
+	// Start time within 1s of each other.
+	startDiff := s.StartTime.Sub(b.StartTime)
+	if (startDiff > time.Second) || (startDiff < -time.Second) {
 		return false
 	}
 

--- a/info/v2/container.go
+++ b/info/v2/container.go
@@ -69,6 +69,10 @@ type ContainerSpec struct {
 	// Time at which the container was created.
 	CreationTime time.Time `json:"creation_time,omitempty"`
 
+	// Time at which the container was started.
+	// This may be unset if the runtime does not provide it.
+	StartTime time.Time `json:"start_time,omitempty"`
+
 	// Other names by which the container is known within a certain namespace.
 	// This is unique within that namespace.
 	Aliases []string `json:"aliases,omitempty"`

--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -285,6 +285,7 @@ func InstCpuStats(last, cur *v1.ContainerStats) (*CpuInstStats, error) {
 func ContainerSpecFromV1(specV1 *v1.ContainerSpec, aliases []string, namespace string) ContainerSpec {
 	specV2 := ContainerSpec{
 		CreationTime:     specV1.CreationTime,
+		StartTime:        specV1.StartTime,
 		HasCpu:           specV1.HasCpu,
 		HasMemory:        specV1.HasMemory,
 		HasHugetlb:       specV1.HasHugetlb,

--- a/info/v2/conversion_test.go
+++ b/info/v2/conversion_test.go
@@ -31,8 +31,10 @@ var (
 )
 
 func TestContainerSpecFromV1(t *testing.T) {
+	startTime := timestamp.Add(1 * time.Hour)
 	v1Spec := v1.ContainerSpec{
 		CreationTime: timestamp,
+		StartTime:    startTime,
 		Labels:       labels,
 		Envs:         envs,
 		HasCpu:       true,
@@ -67,6 +69,7 @@ func TestContainerSpecFromV1(t *testing.T) {
 
 	expectedV2Spec := ContainerSpec{
 		CreationTime: timestamp,
+		StartTime:    startTime,
 		Labels:       labels,
 		Envs:         envs,
 		HasCpu:       true,

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -299,6 +299,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 					Limit: 100,
 				},
 				CreationTime: time.Unix(1257894000, 0),
+				StartTime:    time.Unix(1257895000, 0),
 				Labels: map[string]string{
 					"foo.label": "bar",
 				},

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -441,9 +441,12 @@ container_spec_cpu_quota{container_env_foo_env="prod",container_label_foo_label=
 # HELP container_spec_cpu_shares CPU share of the container.
 # TYPE container_spec_cpu_shares gauge
 container_spec_cpu_shares{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1000
+# HELP container_creation_time_seconds Container creation time since unix epoch in seconds.
+# TYPE container_creation_time_seconds gauge
+container_creation_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
 # HELP container_start_time_seconds Start time of the container since unix epoch in seconds.
 # TYPE container_start_time_seconds gauge
-container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
+container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257895e+09
 # HELP container_tasks_state Number of tasks in given state
 # TYPE container_tasks_state gauge
 container_tasks_state{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",state="iowaiting",zone_name="hello"} 54 1395066363000

--- a/metrics/testdata/prometheus_metrics_perf_aggregated
+++ b/metrics/testdata/prometheus_metrics_perf_aggregated
@@ -35,6 +35,9 @@ container_spec_cpu_quota{container_env_foo_env="prod",container_label_foo_label=
 # HELP container_spec_cpu_shares CPU share of the container.
 # TYPE container_spec_cpu_shares gauge
 container_spec_cpu_shares{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1000
+# HELP container_creation_time_seconds Container creation time since unix epoch in seconds.
+# TYPE container_creation_time_seconds gauge
+container_creation_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
 # HELP container_start_time_seconds Start time of the container since unix epoch in seconds.
 # TYPE container_start_time_seconds gauge
-container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
+container_start_time_seconds{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257895e+09

--- a/metrics/testdata/prometheus_metrics_whitelist_filtered
+++ b/metrics/testdata/prometheus_metrics_whitelist_filtered
@@ -441,9 +441,12 @@ container_spec_cpu_quota{container_env_foo_env="prod",id="testcontainer",image="
 # HELP container_spec_cpu_shares CPU share of the container.
 # TYPE container_spec_cpu_shares gauge
 container_spec_cpu_shares{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1000
+# HELP container_creation_time_seconds Container creation time since unix epoch in seconds.
+# TYPE container_creation_time_seconds gauge
+container_creation_time_seconds{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
 # HELP container_start_time_seconds Start time of the container since unix epoch in seconds.
 # TYPE container_start_time_seconds gauge
-container_start_time_seconds{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257894e+09
+container_start_time_seconds{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1.257895e+09
 # HELP container_tasks_state Number of tasks in given state
 # TYPE container_tasks_state gauge
 container_tasks_state{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",state="iowaiting",zone_name="hello"} 54 1395066363000


### PR DESCRIPTION
fixes #3688