### PR TITLE
docker: fix nil pointer dereference when GraphDriver is nil

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,25 @@ jobs:
   test-integration:
     strategy:
       matrix:
-        go-versions: ['1.25']
-        platform: [ubuntu-24.04]
-        environment-variables: [build/config/plain.sh, build/config/libpfm4.sh, build/config/libipmctl.sh]
+        include:
+          # bookworm: all environment configs
+          - go-versions: '1.25'
+            platform: ubuntu-24.04
+            environment-variables: build/config/plain.sh
+            debian-version: bookworm
+          - go-versions: '1.25'
+            platform: ubuntu-24.04
+            environment-variables: build/config/libpfm4.sh
+            debian-version: bookworm
+          - go-versions: '1.25'
+            platform: ubuntu-24.04
+            environment-variables: build/config/libipmctl.sh
+            debian-version: bookworm
+          # trixie: only plain config
+          - go-versions: '1.25'
+            platform: ubuntu-24.04
+            environment-variables: build/config/plain.sh
+            debian-version: trixie
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
     steps:
@@ -42,6 +58,7 @@ jobs:
     - name: Run integration tests
       env:
         GOLANG_VERSION: ${{ matrix.go-versions }}
+        DEBIAN_VERSION: ${{ matrix.debian-version }}
       run: |
         set -ex
         source ${{ matrix.environment-variables }}
@@ -50,7 +67,7 @@ jobs:
       uses: actions/upload-artifact@v6
       if: failure()
       with:
-        name: cadvisor.log
+        name: cadvisor-${{ matrix.debian-version }}.log
         path: ${{ github.workspace }}/go/src/github.com/google/cadvisor/cadvisor.log
   test-integration-crio:
     strategy:

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -40,9 +40,10 @@ function run_tests() {
     $BUILD_CMD"
   fi
   docker run --rm \
+    --platform linux/amd64 \
     -w /go/src/github.com/google/cadvisor \
     -v ${PWD}:/go/src/github.com/google/cadvisor \
-    golang:"$GOLANG_VERSION-bookworm" \
+    golang:"$GOLANG_VERSION-$DEBIAN_VERSION" \
     bash -c "$BUILD_CMD"
 
   EXTRA_DOCKER_OPTS="-e DOCKER_IN_DOCKER_ENABLED=true"
@@ -52,6 +53,7 @@ function run_tests() {
 
   mkdir ${TMPDIR}/docker-graph
   docker run --rm \
+    --platform linux/amd64 \
     -w /go/src/github.com/google/cadvisor \
     -v ${ROOT}:/go/src/github.com/google/cadvisor \
     ${EXTRA_DOCKER_OPTS} \
@@ -70,4 +72,5 @@ PACKAGES=${PACKAGES:-"sudo"}
 BUILD_PACKAGES=${BUILD_PACKAGES:-}
 CADVISOR_ARGS=${CADVISOR_ARGS:-}
 GOLANG_VERSION=${GOLANG_VERSION:-"1.25"}
+DEBIAN_VERSION=${DEBIAN_VERSION:-"trixie"}
 run_tests

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -41,6 +41,8 @@ import (
 	"github.com/google/cadvisor/fs"
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/zfs"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -250,11 +252,17 @@ func newContainerHandler(
 	}
 
 	if includedMetrics.Has(container.DiskUsageMetrics) {
+		var deviceID string
+		if ctnr.GraphDriver != nil {
+			deviceID = ctnr.GraphDriver.Data["DeviceId"]
+		} else {
+			klog.V(4).Infof("GraphDriver not found for container %q", id)
+		}
 		handler.fsHandler = &FsHandler{
 			FsHandler:       common.NewFsHandler(common.DefaultPeriod, rootfsStorageDir, otherStorageDir, fsInfo),
 			ThinPoolWatcher: thinPoolWatcher,
 			ZfsWatcher:      zfsWatcher,
-			DeviceID:        ctnr.GraphDriver.Data["DeviceId"],
+			DeviceID:        deviceID,
 			ZfsFilesystem:   zfsFilesystem,
 		}
 	}


### PR DESCRIPTION
The migration to github.com/moby/moby modules in b20bcf14 changed GraphDriver from a value type to a pointer type. This causes a nil pointer dereference when Docker doesn't include GraphDriver in the container inspect response (which can happen with certain storage drivers or container configurations).

Add a nil check before accessing GraphDriver.Data and log a warning at V(4) verbosity level when GraphDriver is not found.

Fixes #3815