### PR TITLE
feat: support docker container allowlist

### DIFF
--- a/container/containerd/plugin.go
+++ b/container/containerd/plugin.go
@@ -34,7 +34,7 @@ func (p *plugin) InitializeFSContext(context *fs.Context) error {
 	return nil
 }
 
-func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet) (watcher.ContainerWatcher, error) {
+func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet, whiteList []string) (watcher.ContainerWatcher, error) {
 	err := Register(factory, fsInfo, includedMetrics)
 	return nil, err
 }

--- a/container/crio/plugin.go
+++ b/container/crio/plugin.go
@@ -47,7 +47,7 @@ func (p *plugin) InitializeFSContext(context *fs.Context) error {
 	return nil
 }
 
-func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet) (watcher.ContainerWatcher, error) {
+func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet, whiteList []string) (watcher.ContainerWatcher, error) {
 	err := Register(factory, fsInfo, includedMetrics)
 	return nil, err
 }

--- a/container/docker/plugin.go
+++ b/container/docker/plugin.go
@@ -49,8 +49,8 @@ func (p *plugin) InitializeFSContext(context *fs.Context) error {
 	return nil
 }
 
-func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet) (watcher.ContainerWatcher, error) {
-	err := Register(factory, fsInfo, includedMetrics)
+func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet, whiteList []string) (watcher.ContainerWatcher, error) {
+	err := Register(factory, fsInfo, includedMetrics, whiteList)
 	return nil, err
 }
 

--- a/container/factory.go
+++ b/container/factory.go
@@ -183,7 +183,7 @@ type Plugin interface {
 
 	// Register is invoked when starting a manager. It can optionally return a container watcher.
 	// A returned error is logged, but is not fatal.
-	Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics MetricSet) (watcher.ContainerWatcher, error)
+	Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics MetricSet, whiteList []string) (watcher.ContainerWatcher, error)
 }
 
 func RegisterPlugin(name string, plugin Plugin) error {
@@ -209,13 +209,13 @@ func InitializeFSContext(context *fs.Context) error {
 	return nil
 }
 
-func InitializePlugins(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics MetricSet) []watcher.ContainerWatcher {
+func InitializePlugins(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics MetricSet, whiteLists map[string][]string) []watcher.ContainerWatcher {
 	pluginsLock.Lock()
 	defer pluginsLock.Unlock()
 
 	containerWatchers := []watcher.ContainerWatcher{}
 	for name, plugin := range plugins {
-		watcher, err := plugin.Register(factory, fsInfo, includedMetrics)
+		watcher, err := plugin.Register(factory, fsInfo, includedMetrics, whiteLists[name])
 		if err != nil {
 			klog.Infof("Registration of the %s container factory failed: %v", name, err)
 		} else {

--- a/container/podman/plugin.go
+++ b/container/podman/plugin.go
@@ -49,7 +49,7 @@ func (p *plugin) InitializeFSContext(context *fs.Context) error {
 	return nil
 }
 
-func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet) (watcher.ContainerWatcher, error) {
+func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet, whiteList []string) (watcher.ContainerWatcher, error) {
 	return Register(factory, fsInfo, includedMetrics)
 }
 

--- a/container/systemd/plugin.go
+++ b/container/systemd/plugin.go
@@ -32,7 +32,7 @@ func (p *plugin) InitializeFSContext(context *fs.Context) error {
 	return nil
 }
 
-func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet) (watcher.ContainerWatcher, error) {
+func (p *plugin) Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics container.MetricSet, whiteList []string) (watcher.ContainerWatcher, error) {
 	err := Register(factory, fsInfo, includedMetrics)
 	return nil, err
 }


### PR DESCRIPTION
This PR adds a whitelist feature for docker containers similar to that supported by the `raw_cgroup_prefix_whitelist` flag. The code is written in a way such that the same feature can be later added to other plugins (e.g podman, containerd etc).

Example use with Docker container IDs: `--docker_id_prefix_whitelist=412a30bf29e6,82e3a4670a41,5f338e361e94`

Summary of changes:
- `cmd/cadvisor.go`: Added `docker_id_prefix_whitelist` flag. Create a `whiteLists` map that aggregates all whitelists and pass it to the manager constructor (`New()`).
- `manager/manager.go`: Updated `New()` and `manager{}` to store the `whiteLists` map and pass it to the plugin initializer and the raw cgroups whitelist to `raw.Register()`.
- `container/factory.go`: Updated `InitializePlugins()` to use `whiteLists` for every plugin registration function.
- `container/*/plugin.go`: Updated the plugin registration functions to receive the whitelists.
- `container/docker/factory.go`: Stored whitelist in `dockerFactory{}`, and updated `CanHandleAndAccept()` to filter based on the whitelist. The whitelist feature can be enabled for other plugins by modifying their `factory.go` files the same way.