### PR TITLE
Downgrade warning for NUMA nodes without CPU directories

### DIFF
--- a/utils/sysinfo/sysinfo.go
+++ b/utils/sysinfo/sysinfo.go
@@ -224,7 +224,7 @@ func GetNodesInfo(sysFs sysfs.SysFs) ([]info.Node, int, error) {
 
 		cpuDirs, err := sysFs.GetCPUsPaths(nodeDir)
 		if len(cpuDirs) == 0 {
-			klog.Warningf("Found node without any CPU, nodeDir: %s, number of cpuDirs %d, err: %v", nodeDir, len(cpuDirs), err)
+			klog.V(4).Infof("Found node without any CPU, nodeDir: %s, number of cpuDirs %d, err: %v", nodeDir, len(cpuDirs), err)
 		} else {
 			cores, err := getCoresInfo(sysFs, cpuDirs)
 			if err != nil {


### PR DESCRIPTION
On some systems, NUMA node directories may exist without per-CPU subdirectories.
This has been observed on ARM/SBC systems.

This change downgrades the log level to avoid persistent warnings for a condition
that does not appear to require operator action.


Fixes #3828