### PR TITLE
Fix healthcheck by respecting --url_base_prefix

### DIFF
--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -16,6 +16,7 @@
 
 # Default port
 PORT=8080
+BASE_URL=""
 
 # Extract port from the cadvisor process command line
 if [ -f /proc/1/cmdline ]; then
@@ -30,8 +31,14 @@ if [ -f /proc/1/cmdline ]; then
             --port=*)
                 PORT="${arg#--port=}"
                 ;;
+            -url_base_prefix=*)
+                BASE_URL="${arg#-url_base_prefix=}"
+                ;;
+            --url_base_prefix=*)
+                BASE_URL="${arg#--url_base_prefix=}"
+                ;;
         esac
     done
 fi
 
-wget --quiet --tries=1 --spider "http://localhost:${PORT}/healthz" || exit 1
+wget --quiet --tries=1 --spider "http://localhost:${PORT}${BASE_URL}/healthz" || exit 1


### PR DESCRIPTION
## Problem Statement

Healthchecks fail when using a custom `--url_base_prefix`.

## Root Cause

The healthcheck script does not account for custom URL prefixes. The `/healthz` endpoint is mounted on the root mux which does take it into account.

## Proposed solution

Using the same approach recently added for `--port` (see #3789), parse the cadvisor process' argument list to resolve the proper `--url_base_config.`

## Breaking Changes

None, fixes a regression.

## Test Case 1: Default Port (8080)

docker build -f deploy/Dockerfile -t cadvisor-test .
docker run -d --name cadvisor-default cadvisor-test
sleep 35
docker inspect cadvisor-custom --format='{{json .State.Health.Status}}' # Should show "healthy"

## Test Case 2: Custom URL prefix

docker run -d --name cadvisor-custom cadvisor-test --url_base_config=/cadvisor
sleep 35
docker inspect cadvisor-custom --format='{{json .State.Health.Status}}' # Should show "healthy"
