### PR TITLE
fix crio deadlock in getting crio sandbox containers

### DIFF
--- a/container/crio/client.go
+++ b/container/crio/client.go
@@ -45,6 +45,7 @@ type Info struct {
 	StorageDriver string `json:"storage_driver"`
 	StorageRoot   string `json:"storage_root"`
 	StorageImage  string `json:"storage_image"`
+	CgroupDriver  string `json:"cgroup_driver"`
 }
 
 // ContainerInfo represents a given container information

--- a/container/crio/factory.go
+++ b/container/crio/factory.go
@@ -18,11 +18,9 @@ package crio
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"regexp"
 	"strings"
-	"sync"
 
 	"github.com/google/cadvisor/container"
 	"github.com/google/cadvisor/container/libcontainer"
@@ -44,25 +42,6 @@ const SystemdNamespace = "system-systemd"
 
 // Regexp that identifies CRI-O cgroups
 var crioCgroupRegexp = regexp.MustCompile(`([a-z0-9]{64})`)
-
-var (
-	isRunningSystemdOnce sync.Once
-	isRunningSystemd     bool
-)
-
-// systemdCheck is the function used to detect if systemd is running.
-// Can be overridden in tests.
-var systemdCheck = detectSystemd
-
-// detectSystemd checks whether the host was booted with systemd as its init
-// system. This checks whether /run/systemd/system/ exists and is a directory.
-func detectSystemd() bool {
-	isRunningSystemdOnce.Do(func() {
-		fi, err := os.Lstat("/run/systemd/system")
-		isRunningSystemd = err == nil && fi.IsDir()
-	})
-	return isRunningSystemd
-}
 
 type storageDriver string
 
@@ -87,6 +66,8 @@ type crioFactory struct {
 	includedMetrics container.MetricSet
 
 	client CrioClient
+
+	cgroupDriver string
 }
 
 func (f *crioFactory) String() string {
@@ -157,7 +138,7 @@ func (f *crioFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 	// 404 errors and can lead to deadlocks during kubelet restart.
 	// See: https://github.com/cri-o/cri-o/issues/8748
 	// See: https://github.com/google/cadvisor/pull/3457
-	if systemdCheck() {
+	if f.cgroupDriver == "systemd" {
 		if !strings.HasSuffix(path.Base(name), CrioNamespaceSuffix) {
 			// This is a sandbox container when using systemd
 			return true, false, nil
@@ -198,6 +179,7 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics
 		storageDriver:      storageDriver(info.StorageDriver),
 		storageDir:         info.StorageRoot,
 		includedMetrics:    includedMetrics,
+		cgroupDriver:       info.CgroupDriver,
 	}
 
 	container.RegisterContainerHandlerFactory(f, []watcher.ContainerWatchSource{watcher.Raw})

--- a/container/crio/factory_test.go
+++ b/container/crio/factory_test.go
@@ -22,27 +22,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// mockSystemd allows overriding systemd detection in tests
-func mockSystemd(isSystemd bool) func() {
-	original := systemdCheck
-	systemdCheck = func() bool { return isSystemd }
-	return func() { systemdCheck = original }
-}
-
 func TestCanHandleAndAccept(t *testing.T) {
-	f := &crioFactory{
-		client:             nil,
-		cgroupSubsystems:   nil,
-		fsInfo:             nil,
-		machineInfoFactory: nil,
-		storageDriver:      "",
-		storageDir:         "",
-		includedMetrics:    nil,
-	}
-
 	tests := []struct {
 		name          string
-		isSystemd     bool
+		cgroupDriver  string
 		path          string
 		wantCanHandle bool
 		wantCanAccept bool
@@ -50,14 +33,14 @@ func TestCanHandleAndAccept(t *testing.T) {
 		// Systemd behavior - sandbox containers (without .scope) are filtered
 		{
 			name:          "systemd: sandbox container without .scope",
-			isSystemd:     true,
+			cgroupDriver:  "systemd",
 			path:          "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f",
 			wantCanHandle: true,
 			wantCanAccept: false,
 		},
 		{
 			name:          "systemd: regular container with .scope",
-			isSystemd:     true,
+			cgroupDriver:  "systemd",
 			path:          "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.scope",
 			wantCanHandle: true,
 			wantCanAccept: true,
@@ -65,14 +48,14 @@ func TestCanHandleAndAccept(t *testing.T) {
 		// Non-systemd (cgroupfs) behavior - all valid containers accepted
 		{
 			name:          "cgroupfs: container without .scope",
-			isSystemd:     false,
+			cgroupDriver:  "cgroupfs",
 			path:          "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f",
 			wantCanHandle: true,
 			wantCanAccept: true,
 		},
 		{
 			name:          "cgroupfs: container with .scope",
-			isSystemd:     false,
+			cgroupDriver:  "cgroupfs",
 			path:          "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.scope",
 			wantCanHandle: true,
 			wantCanAccept: true,
@@ -80,28 +63,28 @@ func TestCanHandleAndAccept(t *testing.T) {
 		// Common cases (same behavior for both systemd and cgroupfs)
 		{
 			name:          "system-systemd component",
-			isSystemd:     true,
-			path:          "/system.slice/system-systemd\\\\x2dcoredump.slice",
+			cgroupDriver:  "systemd",
+			path:          "/system.slice/system-systemd\\x2dcoredump.slice",
 			wantCanHandle: true,
 			wantCanAccept: false,
 		},
 		{
 			name:          "mount cgroup",
-			isSystemd:     true,
+			cgroupDriver:  "systemd",
 			path:          "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f.mount",
 			wantCanHandle: false,
 			wantCanAccept: false,
 		},
 		{
 			name:          "crio-conmon container",
-			isSystemd:     true,
+			cgroupDriver:  "systemd",
 			path:          "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-conmon-81e5c2990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75d5f",
 			wantCanHandle: false,
 			wantCanAccept: false,
 		},
 		{
 			name:          "invalid container ID",
-			isSystemd:     true,
+			cgroupDriver:  "systemd",
 			path:          "/kubepods/pod068e8fa0-9213-11e7-a01f-507b9d4141fa/crio-990803c383229c9680ce964738d5e566d97f5bd436ac34808d2ec75",
 			wantCanHandle: false,
 			wantCanAccept: false,
@@ -110,9 +93,9 @@ func TestCanHandleAndAccept(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock systemd detection
-			restore := mockSystemd(tt.isSystemd)
-			defer restore()
+			f := &crioFactory{
+				cgroupDriver: tt.cgroupDriver,
+			}
 
 			canHandle, canAccept, err := f.CanHandleAndAccept(tt.path)
 			assert.NoError(t, err)


### PR DESCRIPTION
In https://github.com/cri-o/cri-o/issues/8748, I found that cadvisor v0.48.1 had a bug that caused crio to essentially deadlock if there was a long-terminating container and a kubelet restart. However, with cadvisor v0.49.0 this was fixed. With 0.52.1 it was bugged again. 

I found that https://github.com/google/cadvisor/pull/3457 was the fix, which was then later reverted: https://github.com/google/cadvisor/pull/3565

1.27 has cadvisor v0.47.2 (working)
1.29 has cadvisor v0.48.1 (broken)
1.30 has cadvisor v0.49.0 (working)
1.31 has cadvisor v0.49.0 (working)
1.33 has cadvisor 0.52.1 (broken)

What happens here is that cadvisor finds sandbox containers in cgroups (they exist as cgroup directories), calls cri-o, cri-o returns 404 because sandbox containers aren't returned by the inspect endpoint, and then I suspect something ends up holding a mutex that prevents anything else to go through, which causes kubelet to fail to start because crio/cadvisor are stuck.

This re-does the original PR (https://github.com/google/cadvisor/pull/3457) but addresses the systemd/cgroupfs issue