### PR TITLE
collector: restrict appmetrics endpoint to container ip

### DIFF
--- a/collector/generic_collector.go
+++ b/collector/generic_collector.go
@@ -62,7 +62,9 @@ func NewCollector(collectorName string, configFile []byte, metricCountLimit int,
 		return nil, err
 	}
 
-	configInJSON.Endpoint.configure(containerHandler)
+	if err := configInJSON.Endpoint.configure(containerHandler); err != nil {
+		return nil, err
+	}
 
 	// TODO : Add checks for validity of config file (eg : Accurate JSON fields)
 

--- a/collector/generic_collector_test.go
+++ b/collector/generic_collector_test.go
@@ -45,6 +45,9 @@ func TestEmptyConfig(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
 	_, err = NewCollector("tempCollector", configFile, 100, containerHandler, http.DefaultClient)
 	assert.Error(err)
 
@@ -76,6 +79,9 @@ func TestConfigWithErrors(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
 	_, err = NewCollector("tempCollector", configFile, 100, containerHandler, http.DefaultClient)
 	assert.Error(err)
 
@@ -115,6 +121,9 @@ func TestConfigWithRegexErrors(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
 	_, err = NewCollector("tempCollector", configFile, 100, containerHandler, http.DefaultClient)
 	assert.Error(err)
 
@@ -129,10 +138,13 @@ func TestConfig(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
 	collector, err := NewCollector("nginx", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "nginx")
-	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8000/nginx_status")
+	assert.Equal(collector.configFile.Endpoint.URL, "http://111.111.111.111:8000/nginx_status")
 	assert.Equal(collector.configFile.MetricsConfig[0].Name, "activeConnections")
 }
 
@@ -153,6 +165,33 @@ func TestEndpointConfig(t *testing.T) {
 	assert.Equal(collector.configFile.MetricsConfig[0].Name, "activeConnections")
 }
 
+func TestEndpointURLRejectsRemoteHost(t *testing.T) {
+	assert := assert.New(t)
+
+	config := `
+	{
+		"endpoint" : "http://example.com:8000/nginx_status",
+		"metrics_config" : [
+			{
+				"name" : "activeConnections",
+				"metric_type" : "gauge",
+				"data_type" : "int",
+				"polling_frequency" : 10,
+				"regex" : "Active connections: ([0-9]+)"
+			}
+		]
+	}
+	`
+
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
+
+	_, err := NewCollector("nginx", []byte(config), 100, containerHandler, http.DefaultClient)
+	assert.Error(err)
+}
+
 func TestMetricCollection(t *testing.T) {
 	assert := assert.New(t)
 
@@ -161,6 +200,9 @@ func TestMetricCollection(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
 	fakeCollector, err := NewCollector("nginx", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 
@@ -197,6 +239,9 @@ func TestMetricCollectionLimit(t *testing.T) {
 	assert.NoError(err)
 
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"111.111.111.111",
+	)
 	_, err = NewCollector("nginx", configFile, 1, containerHandler, http.DefaultClient)
 	assert.Error(err)
 }

--- a/collector/prometheus_collector.go
+++ b/collector/prometheus_collector.go
@@ -60,7 +60,9 @@ func NewPrometheusCollector(collectorName string, configFile []byte, metricCount
 		return nil, err
 	}
 
-	configInJSON.Endpoint.configure(containerHandler)
+	if err := configInJSON.Endpoint.configure(containerHandler); err != nil {
+		return nil, err
+	}
 
 	minPollingFrequency := configInJSON.PollingFrequency
 

--- a/collector/prometheus_collector_test.go
+++ b/collector/prometheus_collector_test.go
@@ -35,10 +35,13 @@ func TestPrometheus(t *testing.T) {
 	configFile, err := os.ReadFile("config/sample_config_prometheus.json")
 	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"222.222.222.222",
+	)
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal("Prometheus", collector.name)
-	assert.Equal("http://localhost:8080/metrics", collector.configFile.Endpoint.URL)
+	assert.Equal("http://222.222.222.222:8080/metrics", collector.configFile.Endpoint.URL)
 
 	tempServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -129,6 +132,24 @@ func TestPrometheusEndpointConfig(t *testing.T) {
 	assert.Equal(collector.configFile.Endpoint.URL, "http://222.222.222.222:8081/METRICS")
 }
 
+func TestPrometheusEndpointURLRejectsRemoteHost(t *testing.T) {
+	assert := assert.New(t)
+
+	config := `
+	{
+		"endpoint" : "http://example.com:9100/metrics"
+	}
+	`
+
+	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"222.222.222.222",
+	)
+
+	_, err := NewPrometheusCollector("Prometheus", []byte(config), 100, containerHandler, http.DefaultClient)
+	assert.Error(err)
+}
+
 func TestPrometheusShortResponse(t *testing.T) {
 	assert := assert.New(t)
 
@@ -136,10 +157,13 @@ func TestPrometheusShortResponse(t *testing.T) {
 	configFile, err := os.ReadFile("config/sample_config_prometheus.json")
 	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"222.222.222.222",
+	)
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
-	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8080/metrics")
+	assert.Equal(collector.configFile.Endpoint.URL, "http://222.222.222.222:8080/metrics")
 
 	tempServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		text := "# HELP empty_metric A metric without any values"
@@ -160,10 +184,13 @@ func TestPrometheusMetricCountLimit(t *testing.T) {
 	configFile, err := os.ReadFile("config/sample_config_prometheus.json")
 	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"222.222.222.222",
+	)
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 10, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
-	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8080/metrics")
+	assert.Equal(collector.configFile.Endpoint.URL, "http://222.222.222.222:8080/metrics")
 
 	tempServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for i := 0; i < 30; i++ {
@@ -190,10 +217,13 @@ func TestPrometheusFiltersMetrics(t *testing.T) {
 	configFile, err := os.ReadFile("config/sample_config_prometheus_filtered.json")
 	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"222.222.222.222",
+	)
 	collector, err := NewPrometheusCollector("Prometheus", configFile, 100, containerHandler, http.DefaultClient)
 	assert.NoError(err)
 	assert.Equal(collector.name, "Prometheus")
-	assert.Equal(collector.configFile.Endpoint.URL, "http://localhost:8080/metrics")
+	assert.Equal(collector.configFile.Endpoint.URL, "http://222.222.222.222:8080/metrics")
 
 	tempServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -230,6 +260,9 @@ func TestPrometheusFiltersMetricsCountLimit(t *testing.T) {
 	configFile, err := os.ReadFile("config/sample_config_prometheus_filtered.json")
 	assert.NoError(err)
 	containerHandler := containertest.NewMockContainerHandler("mockContainer")
+	containerHandler.On("GetContainerIPAddress").Return(
+		"222.222.222.222",
+	)
 	_, err = NewPrometheusCollector("Prometheus", configFile, 1, containerHandler, http.DefaultClient)
 	assert.Error(err)
 }

--- a/collector/util.go
+++ b/collector/util.go
@@ -14,12 +14,69 @@
 
 package collector
 
-import "github.com/google/cadvisor/container"
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
 
-func (ec *EndpointConfig) configure(containerHandler container.ContainerHandler) {
+	"github.com/google/cadvisor/container"
+)
+
+func (ec *EndpointConfig) configure(containerHandler container.ContainerHandler) error {
+	containerIPAddress := containerHandler.GetContainerIPAddress()
+
 	// If the exact URL was not specified, generate it based on the ip address of the container.
 	if ec.URL == "" {
-		ipAddress := containerHandler.GetContainerIPAddress()
-		ec.URL = ec.URLConfig.Protocol + "://" + ipAddress + ":" + ec.URLConfig.Port.String() + ec.URLConfig.Path
+		protocol := strings.ToLower(ec.URLConfig.Protocol)
+		if protocol != "http" && protocol != "https" {
+			return fmt.Errorf("unsupported endpoint protocol %q", ec.URLConfig.Protocol)
+		}
+		if containerIPAddress == "" {
+			return fmt.Errorf("container ip address is empty")
+		}
+		ec.URL = protocol + "://" + net.JoinHostPort(containerIPAddress, ec.URLConfig.Port.String()) + ec.URLConfig.Path
+		return nil
 	}
+
+	parsed, err := url.Parse(ec.URL)
+	if err != nil {
+		return fmt.Errorf("invalid endpoint url %q: %w", ec.URL, err)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("unsupported endpoint url scheme %q", parsed.Scheme)
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("endpoint url must include a host: %q", ec.URL)
+	}
+	if containerIPAddress == "" {
+		return fmt.Errorf("container ip address is empty")
+	}
+
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		if port := parsed.Port(); port != "" {
+			parsed.Host = net.JoinHostPort(containerIPAddress, port)
+		} else {
+			parsed.Host = containerIPAddress
+		}
+		ec.URL = parsed.String()
+		return nil
+	}
+
+	// Only allow explicit container ip address as a destination, otherwise an
+	// attacker-controlled config can turn cAdvisor into a cross-network fetcher.
+	if host == containerIPAddress {
+		return nil
+	}
+	hostIP := net.ParseIP(host)
+	containerIP := net.ParseIP(containerIPAddress)
+	if hostIP != nil && containerIP != nil && hostIP.Equal(containerIP) {
+		return nil
+	}
+
+	return fmt.Errorf("endpoint url host %q is not allowed; only localhost or the container ip address is supported", parsed.Hostname())
 }

--- a/docs/application_metrics.md
+++ b/docs/application_metrics.md
@@ -76,6 +76,8 @@ Prometheus metrics endpoint.
 
 The configuration file can either be part of the container image or can be added on at runtime with a volume. This makes sure that there is no connection between the host where the container is running and the application metrics configuration. A container is self-contained for its metric information.
 
+Security note: cAdvisor treats application metrics endpoints as container-local. If the config uses `localhost` / `127.0.0.1` / `::1`, cAdvisor rewrites the host to the container IP before scraping. To avoid turning cAdvisor into a cross-network fetcher via workload-controlled config, endpoints with any other host are rejected.
+
 So a sample configuration for redis would look like:
 
 Dockerfile (or runtime):


### PR DESCRIPTION
# appmetrics: restrict endpoint url to container-local

this hardens application metrics scraping against workload-controlled config (for example, docker labels `io.cadvisor.metric.*`) turning cAdvisor into a cross-network fetcher.

## change

- validate endpoint scheme is HTTP/HTTPS
- if endpoint host is `localhost` / `127.0.0.1` / `::1`, rewrite it to the container ip from the container handler
- allow explicit container ip destinations; reject any other host
- add unit tests for allow/deny behavior
- document the container-local behavior in `docs/application_metrics.md`

## compatibility

this is a behavior change for configs that pointed `endpoint` at remote hosts. `docs/application_metrics.md` already describes the config as self-contained within the container; this change makes the implementation match that model.

## testing

```bash
go test ./collector
go test $(go list ./... | grep -v '^github.com/google/cadvisor/integration')
```
