### PR TITLE
fix: correct cgroup v2 swap memory calculation (#3823)

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -814,7 +814,8 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	if cgroups.IsCgroup2UnifiedMode() {
 		ret.Memory.Cache = s.MemoryStats.Stats["file"]
 		ret.Memory.RSS = s.MemoryStats.Stats["anon"]
-		ret.Memory.Swap = s.MemoryStats.SwapUsage.Usage - s.MemoryStats.Usage.Usage
+		// In v2, SwapUsage is already exclusively swap. No subtraction needed.
+		ret.Memory.Swap = s.MemoryStats.SwapUsage.Usage
 		ret.Memory.MappedFile = s.MemoryStats.Stats["file_mapped"]
 	} else if s.MemoryStats.UseHierarchy {
 		ret.Memory.Cache = s.MemoryStats.Stats["total_cache"]


### PR DESCRIPTION
**Fixes #3823**

**Problem:**
In cgroup v2 environments, `cAdvisor` is currently reporting zero swap metrics even when swap is active. This is due to `handler.go` applying legacy cgroup v1 math (`SwapUsage - Usage`). In v2, `memory.swap.current` is decoupled from RAM usage, so subtracting `Usage` incorrectly zeroes out the metric.

**Solution:**
Updated the `IsCgroup2UnifiedMode()` block to assign `SwapUsage.Usage` directly to `ret.Memory.Swap` without the legacy subtraction.

**Notes:**
- Syntax verified with `go fmt`.
- Shoutout to @AkshatDudeja77 for the initial investigation and identifying the regression point in `handler.go`.