### PR TITLE
Instrument counter metrics with CreatedTimestamp

### DIFF
--- a/integration/framework/metrics.go
+++ b/integration/framework/metrics.go
@@ -89,6 +89,41 @@ func (m *MetricsClient) FetchAndParse() (map[string]*dto.MetricFamily, error) {
 	return m.Parse(text)
 }
 
+// FetchAndParseProtobuf fetches metrics using PrometheusProtobuf exposition format
+func (m *MetricsClient) FetchAndParseProtobuf() (map[string]*dto.MetricFamily, error) {
+	url := m.baseURL + "metrics"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch metrics: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("metrics endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	families := make(map[string]*dto.MetricFamily)
+	decoder := expfmt.NewDecoder(resp.Body, expfmt.NewFormat(expfmt.TypeProtoDelim))
+	for {
+		mf := &dto.MetricFamily{}
+		if err := decoder.Decode(mf); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to decode protobuf: %w", err)
+		}
+		families[mf.GetName()] = mf
+	}
+	return families, nil
+}
+
 // HasMetric checks if a metric family exists by name.
 func HasMetric(families map[string]*dto.MetricFamily, name string) bool {
 	_, ok := families[name]

--- a/integration/tests/metrics/prometheus_test.go
+++ b/integration/tests/metrics/prometheus_test.go
@@ -460,3 +460,28 @@ func TestMetricsResponseContainsComments(t *testing.T) {
 	assert.True(t, strings.Contains(text, "# TYPE"),
 		"Metrics response should contain # TYPE comments")
 }
+
+// TestProtoCreatedTimestamps verifies that counter metrics have CreatedTimestamp
+// set when fetched via protobuf content negotiation.
+func TestProtoCreatedTimestamps(t *testing.T) {
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	client := framework.NewMetricsClient(fm.Hostname())
+	families, err := client.FetchAndParseProtobuf()
+	require.NoError(t, err, "Failed to fetch protobuf format")
+	require.NotEmpty(t, families, "Protobuf response should contain metric families")
+
+	// Counter metrics should have CreatedTimestamp
+	cpuUsage, ok := framework.GetMetricFamily(families, "container_cpu_usage_seconds_total")
+	require.True(t, ok, "container_cpu_usage_seconds_total should exist")
+	require.NotEmpty(t, cpuUsage.GetMetric(), "Should have at least one CPU usage metric")
+
+	for _, metric := range cpuUsage.GetMetric() {
+		ct := metric.GetCounter().GetCreatedTimestamp()
+		assert.NotNil(t, ct, "Counter should have CreatedTimestamp")
+		if ct != nil {
+			assert.Greater(t, ct.AsTime().Unix(), int64(0), "CreatedTimestamp should be positive")
+		}
+	}
+}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -2040,10 +2040,16 @@ func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric)
 			}
 			desc := cm.desc(labels)
 			for _, metricValue := range cm.getValues(stats) {
-				ch <- prometheus.NewMetricWithTimestamp(
-					metricValue.timestamp,
-					prometheus.MustNewConstMetric(desc, cm.valueType, float64(metricValue.value), append(values, metricValue.labels...)...),
-				)
+				labelValues := append(values, metricValue.labels...)
+				var m prometheus.Metric
+				if cm.valueType == prometheus.CounterValue && !cont.Spec.CreationTime.IsZero() {
+					m = prometheus.MustNewConstMetricWithCreatedTimestamp(
+						desc, cm.valueType, float64(metricValue.value), cont.Spec.CreationTime, labelValues...,
+					)
+				} else {
+					m = prometheus.MustNewConstMetric(desc, cm.valueType, float64(metricValue.value), labelValues...)
+				}
+				ch <- prometheus.NewMetricWithTimestamp(metricValue.timestamp, m)
 			}
 		}
 		if c.includedMetrics.Has(container.AppMetrics) {

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	clock "k8s.io/utils/clock/testing"
 )
@@ -462,5 +463,60 @@ func TestCPUBurstMetrics(t *testing.T) {
 			result := tc.getValue()
 			assert.Equal(t, tc.expectedValue, result)
 		})
+	}
+}
+
+func TestPrometheusCollectorCreatedTimestamp(t *testing.T) {
+	c := NewPrometheusCollector(testSubcontainersInfoProvider{}, func(container *info.ContainerInfo) map[string]string {
+		s := DefaultContainerLabels(container)
+		s["zone.name"] = "hello"
+		return s
+	}, container.AllMetrics, now, v2.RequestOptions{})
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(c)
+
+	metricFamilies, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	// The container creation time from the fake provider (prometheus_fake.go)
+	expectedCT := time.Unix(1257894000, 0)
+
+	// Counter metrics should have CreatedTimestamp set
+	counterMetrics := []string{
+		"container_cpu_user_seconds_total",
+		"container_cpu_system_seconds_total",
+		"container_cpu_usage_seconds_total",
+		"container_cpu_cfs_periods_total",
+		"container_cpu_cfs_throttled_periods_total",
+		"container_cpu_cfs_throttled_seconds_total",
+		"container_memory_failcnt",
+		"container_memory_failures_total",
+		"container_network_receive_bytes_total",
+		"container_network_transmit_bytes_total",
+	}
+
+	familyByName := make(map[string]*dto.MetricFamily, len(metricFamilies))
+	for _, mf := range metricFamilies {
+		familyByName[mf.GetName()] = mf
+	}
+
+	for _, name := range counterMetrics {
+		mf, ok := familyByName[name]
+		if !ok {
+			t.Errorf("Expected counter metric %s not found", name)
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			ct := m.GetCounter().GetCreatedTimestamp()
+			if ct == nil {
+				t.Errorf("Counter metric %s should have CreatedTimestamp set", name)
+			} else if ct.AsTime().Unix() != expectedCT.Unix() {
+				t.Errorf("Counter metric %s has wrong CreatedTimestamp: got %v, want %v",
+					name, ct.AsTime(), expectedCT)
+			}
+		}
 	}
 }


### PR DESCRIPTION
address #3846

Various layers of the prom ecosystem now supports or are actively developing StartTimestamp/CreatedTimestamp awareness.  CT values are natively supported by the prom-proto exposition format which the prom-go client supports.

```
make docker-test-integration
...
=== RUN   TestMetricsResponseContainsComments
--- PASS: TestMetricsResponseContainsComments (0.01s)
=== RUN   TestProtoCreatedTimestamps
--- PASS: TestProtoCreatedTimestamps (0.02s)
```