### PR TITLE
feat(manager/container): add configurable initial splay and max jitter factors

### DIFF
--- a/manager/container.go
+++ b/manager/container.go
@@ -47,9 +47,13 @@ import (
 	"k8s.io/utils/clock"
 )
 
+const jitterDefault = 1.0
+
 // Housekeeping interval.
 var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
 var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
+var InitialSplayFactor = flag.Float64("initial_splay_factor", jitterDefault, "Factor for the initial splay b/w the container housekeepings, default is 1.0. If negative value is passed, the value will be reset to default")
+var JitterFactor = flag.Float64("jitter_factor", jitterDefault, "Factor for the jitters after the initial splay b/w the container housekeepings, default is 1.0. If negative value is passed, the value will be reset to default")
 
 // TODO: replace regular expressions with something simpler, such as strings.Split().
 // cgroup type chosen to fetch the cgroup path of a process.
@@ -91,6 +95,9 @@ type containerData struct {
 	housekeepingInterval     time.Duration
 	maxHousekeepingInterval  time.Duration
 	allowDynamicHousekeeping bool
+	firstHousekeeping        bool
+	initialSplayFactor       float64
+	jitterFactor             float64
 	infoLastUpdatedTime      atomicTime // Unix nano
 	statsLastUpdatedTime     atomicTime // Unix nano
 	lastErrorTime            time.Time
@@ -121,11 +128,11 @@ type containerData struct {
 }
 
 // jitter returns a time.Duration between duration and duration + maxFactor * duration,
-// to allow clients to avoid converging on periodic behavior.  If maxFactor is 0.0, a
-// suggested default value will be chosen.
+// to allow clients to avoid converging on periodic behavior. If maxFactor is 0.0, no
+// jitter is applied. If maxFactor is negative, a suggested default value will be chosen.
 func jitter(duration time.Duration, maxFactor float64) time.Duration {
-	if maxFactor <= 0.0 {
-		maxFactor = 1.0
+	if maxFactor < 0.0 {
+		maxFactor = jitterDefault
 	}
 	wait := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
 	return wait
@@ -458,6 +465,9 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
 		housekeepingInterval:     *HousekeepingInterval,
 		maxHousekeepingInterval:  maxHousekeepingInterval,
 		allowDynamicHousekeeping: allowDynamicHousekeeping,
+		firstHousekeeping:        true,
+		initialSplayFactor:       *InitialSplayFactor,
+		jitterFactor:             *JitterFactor,
 		logUsage:                 logUsage,
 		loadAvg:                  -1.0, // negative value indicates uninitialized.
 		loadDAvg:                 -1.0, // negative value indicates uninitialized.
@@ -491,7 +501,6 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
 		cont.summaryReader = nil
 		klog.V(5).Infof("Failed to create summary reader for %q: %v", ref.Name, err)
 	}
-
 	return cont, nil
 }
 
@@ -519,7 +528,13 @@ func (cd *containerData) nextHousekeepingInterval() time.Duration {
 		}
 	}
 
-	return jitter(cd.housekeepingInterval, 1.0)
+	jitterFactor := cd.jitterFactor
+	if cd.firstHousekeeping {
+		jitterFactor = cd.initialSplayFactor
+		cd.firstHousekeeping = false
+	}
+
+	return jitter(cd.housekeepingInterval, jitterFactor)
 }
 
 // TODO(vmarmol): Implement stats collecting as a custom collector.

--- a/manager/container_test.go
+++ b/manager/container_test.go
@@ -538,3 +538,56 @@ func TestGetCgroupPath(t *testing.T) {
 		})
 	}
 }
+
+func TestNextHousekeepingInterval(t *testing.T) {
+	base := 1 * time.Second
+	tests := []struct {
+		name              string
+		splayFactor       float64
+		jitterFactor      float64
+		firstHousekeeping bool
+		expectedMin       time.Duration
+		expectedMax       time.Duration
+	}{
+		{
+			name:              "first housekeeping uses splay factor",
+			splayFactor:       2.0,
+			jitterFactor:      1.0,
+			firstHousekeeping: true,
+			expectedMin:       base,
+			expectedMax:       base + time.Duration(2.0*float64(base)),
+		},
+		{
+			name:              "subsequent housekeeping uses jitter factor",
+			splayFactor:       1.0,
+			jitterFactor:      0.5,
+			firstHousekeeping: false,
+			expectedMin:       base,
+			expectedMax:       base + time.Duration(0.5*float64(base)),
+		},
+		{
+			name:              "zero jitter factor results in no jitter",
+			splayFactor:       1.0,
+			jitterFactor:      0.0,
+			firstHousekeeping: false,
+			expectedMin:       base,
+			expectedMax:       base,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cd, _, _, _ := newTestContainerData(t)
+			cd.allowDynamicHousekeeping = false
+			cd.housekeepingInterval = base
+			cd.firstHousekeeping = tc.firstHousekeeping
+			cd.initialSplayFactor = tc.splayFactor
+			cd.jitterFactor = tc.jitterFactor
+
+			got := cd.nextHousekeepingInterval()
+			assert.GreaterOrEqual(t, got, tc.expectedMin)
+			assert.LessOrEqual(t, got, tc.expectedMax)
+			assert.False(t, cd.firstHousekeeping)
+		})
+	}
+}


### PR DESCRIPTION
This PR is an extension of https://github.com/google/cadvisor/pull/2918.
The initial [jitter](https://github.com/google/cadvisor/issues/1053) PR aims to avoid CPU spikes when hundreds of HKs are running. Although it does the job as intended, the actual interval ranges from [HK, 2HK], resulting in higher variance when `cadvisor` metric timestamps are considered for rate calculations in counter metrics. Since the jitter factor is not configurable, it is impossible to reduce the variance in the current scenarios.
Also, a good way to avoid CPU spikes is to spread out the container HKs initially, so that subsequent jitter can be set to zero and we get the same benefit as with random jitter every time.

To keep the change backward-compatible, the default values are set to `1.0`.

Attaching a screenshot showing how this change helped to reduce variance with initial splay at `1.0` and jitter factor at `0.0`, without CPU spikes in `cadvisor`.

<img width="1673" height="560" alt="image (3)" src="https://github.com/user-attachments/assets/972d6d4c-1bdf-4dd6-84fa-ae5e3da15856" />
