### PR TITLE
fix: add v-prefixed GHCR image tags for release consistency

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -54,6 +54,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' && github.ref == format('refs/tags/{0}', github.ref_name) }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary
- Add `type=semver,pattern=v{{version}}` to the container publish workflow
- This publishes **both** `0.55.1` and `v0.55.1` tags to GHCR
- Fixes the inconsistency where GitHub Releases use `v`-prefixed tags but GHCR images don't

## Problem
Users look at the [Releases page](https://github.com/google/cadvisor/releases) and see `v0.55.1`, then naturally run:
```bash
docker pull ghcr.io/google/cadvisor:v0.55.1
# Error: not found
```
This has broken CI/CD pipelines (see #3856, #3712, #3807).

## Change
One line added to `.github/workflows/publish-container.yml`:
```yaml
type=semver,pattern=v{{version}}
```

This makes `docker/metadata-action` generate an additional tag with the `v` prefix, so both formats work.

## Test plan
- For tag `v0.55.1`, the workflow will now generate:
  - `0.55.1` (existing, `{{version}}`)
  - `v0.55.1` (new, `v{{version}}`)
  - `0.55` (existing, `{{major}}.{{minor}}`)
  - `latest`
  - SHA-based tag

Fixes #3856