### PR TITLE
fix(build): update k8s-staging-test-infra image in integ tests

### DIFF
--- a/build/integration-in-docker-crio.sh
+++ b/build/integration-in-docker-crio.sh
@@ -76,7 +76,7 @@ function run_tests() {
     --cgroupns=host \
     --pid=host \
     --entrypoint="" \
-    gcr.io/k8s-staging-test-infra/bootstrap:v20250702-52f5173c3a \
+    gcr.io/k8s-staging-test-infra/bootstrap:v20251209-855adc2699 \
     bash -c "export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y $PACKAGES curl conntrack iptables dbus && \

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -61,7 +61,7 @@ function run_tests() {
     --privileged \
     --cap-add="sys_admin" \
     --entrypoint="" \
-    gcr.io/k8s-staging-test-infra/bootstrap:v20250702-52f5173c3a \
+    gcr.io/k8s-staging-test-infra/bootstrap:v20251209-855adc2699 \
     bash -c "export DEBIAN_FRONTEND=noninteractive && \
     apt update && \
     apt install -y $PACKAGES && \

--- a/integration/tests/api/docker_test.go
+++ b/integration/tests/api/docker_test.go
@@ -215,14 +215,14 @@ func TestDockerContainerSpec(t *testing.T) {
 
 	assert.True(containerInfo.Spec.HasCpu, "CPU should be isolated")
 	if cgroups.IsCgroup2UnifiedMode() {
-		// cpu shares are rounded slightly on cgroupv2 due to conversion between cgroupv1 (cpu.shares) and cgroupv2 (cpu.weight)
-		// When container is created via docker, runc will convert cpu shares to cpu.weight https://github.com/opencontainers/runc/blob/d11f4d756e85ece5cdba8bb69f8bd4db3cdcbeab/libcontainer/cgroups/utils.go#L423-L428
+		// cpu shares are converted on cgroupv2 due to conversion between cgroupv1 (cpu.shares) and cgroupv2 (cpu.weight)
+		// When container is created via docker, runc will convert cpu shares to cpu.weight using a log2-based quadratic formula https://github.com/opencontainers/cgroups/blob/v0.0.6/utils.go#L405-L427
 		// And cAdvisor will convert cpu.weight back to cpu shares in https://github.com/google/cadvisor/blob/24e7a9883d12f944fd4403861707f4bafcaf4f3d/container/common/helpers.go#L249-L260
 		// Worked example:
 		// cpuShares = 2048 (input to docker --cpu-shares)
-		// cpuWeight = int((1 + ((cpuShares-2)*9999)/262142))=79 (conversion done by runc)
-		// cpuWeight back to cpuShares = int(2 + ((cpuWeight-1)*262142)/9999)= 2046
-		var cgroupV2Shares uint64 = 2046
+		// l = log2(2048) = 11; exponent = (l*l + 125*l)/612 - 7/34 = 2.2386; cpuWeight = ceil(10^exponent) = 174 (conversion done by runc)
+		// cpuWeight back to cpuShares = int(2 + ((cpuWeight-1)*262142)/9999)= 4537
+		var cgroupV2Shares uint64 = 4537
 		assert.Equal(cgroupV2Shares, containerInfo.Spec.Cpu.Limit, "Container should have %d shares, has %d", cgroupV2Shares, containerInfo.Spec.Cpu.Limit)
 	} else {
 		assert.Equal(cpuShares, containerInfo.Spec.Cpu.Limit, "Container should have %d shares, has %d", cpuShares, containerInfo.Spec.Cpu.Limit)


### PR DESCRIPTION
Integration tests github action is failing due to the following error
```
Unable to find image 'gcr.io/k8s-staging-test-infra/bootstrap:v20250702-52f5173c3a' locally
docker: Error response from daemon: manifest for gcr.io/k8s-staging-test-infra/bootstrap:v20250702-52f5173c3a not found: manifest unknown: Failed to fetch "v20250702-52f5173c3a"
```
 This PR aims to update the image to fix the failures