### PR TITLE
Expose cgroup v2 memory.events as Prometheus metrics

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/fs2"
+	"github.com/opencontainers/cgroups/fscommon"
 	"k8s.io/klog/v2"
 
 	"github.com/google/cadvisor/container"
@@ -91,6 +92,10 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 		klog.V(4).Infof("Ignoring errors when gathering stats for root cgroup since some controllers don't have stats on the root cgroup: %v", err)
 	}
 	stats := newContainerStats(cgroupStats, h.includedMetrics)
+
+	if cgroups.IsCgroup2UnifiedMode() {
+		setMemoryEvents(h.cgroupManager.Path(""), stats)
+	}
 
 	if h.includedMetrics.Has(container.ProcessSchedulerMetrics) {
 		stats.Cpu.Schedstat, err = h.schedulerStatsFromProcs()
@@ -860,6 +865,15 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 		}
 	}
 	ret.Memory.WorkingSet = workingSet
+}
+
+func setMemoryEvents(cgroupPath string, ret *info.ContainerStats) {
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "high"); err == nil {
+		ret.Memory.Events.High = val
+	}
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "max"); err == nil {
+		ret.Memory.Events.Max = val
+	}
 }
 
 func setCPUSetStats(s *cgroups.Stats, ret *info.ContainerStats) {

--- a/container/libcontainer/handler_test.go
+++ b/container/libcontainer/handler_test.go
@@ -18,6 +18,7 @@ package libcontainer
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -350,4 +351,59 @@ func TestProcessMaxOpenFileLimitLine(t *testing.T) {
 	assert.Equal(t, "max_open_files", ulimit.Name)
 	assert.Equal(t, int64(1073741816), ulimit.SoftLimit)
 	assert.Equal(t, int64(1073741816), ulimit.HardLimit)
+}
+
+func TestSetMemoryEvents(t *testing.T) {
+	cgroups.TestMode = true
+	defer func() { cgroups.TestMode = false }()
+
+	testData := []struct {
+		name    string
+		content string
+		high    uint64
+		max     uint64
+	}{
+		{
+			"all counters",
+			"low 0\nhigh 42\nmax 5\noom 1\noom_kill 0\noom_group_kill 0\n",
+			42, 5,
+		},
+		{
+			"zeros",
+			"low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n",
+			0, 0,
+		},
+		{
+			"high only",
+			"low 0\nhigh 238\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n",
+			238, 0,
+		},
+		{
+			"empty file",
+			"",
+			0, 0,
+		},
+	}
+
+	for _, testItem := range testData {
+		t.Run(testItem.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, "memory.events"), []byte(testItem.content), 0o644)
+			assert.Nil(t, err)
+
+			var ret info.ContainerStats
+			setMemoryEvents(dir, &ret)
+
+			assert.Equal(t, testItem.high, ret.Memory.Events.High)
+			assert.Equal(t, testItem.max, ret.Memory.Events.Max)
+		})
+	}
+}
+
+func TestSetMemoryEventsFileNotFound(t *testing.T) {
+	var ret info.ContainerStats
+	setMemoryEvents("/nonexistent/path", &ret)
+
+	assert.Equal(t, uint64(0), ret.Memory.Events.High)
+	assert.Equal(t, uint64(0), ret.Memory.Events.Max)
 }

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -456,6 +456,13 @@ type MemoryStats struct {
 	HierarchicalData MemoryStatsMemoryData `json:"hierarchical_data,omitempty"`
 
 	PSI PSIStats `json:"psi"`
+
+	Events MemoryEvents `json:"events,omitempty"`
+}
+
+type MemoryEvents struct {
+	High uint64 `json:"high"`
+	Max  uint64 `json:"max"`
 }
 
 type CPUSetStats struct {

--- a/integration/tests/api/event_test.go
+++ b/integration/tests/api/event_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opencontainers/cgroups"
 	"github.com/stretchr/testify/require"
 
 	info "github.com/google/cadvisor/info/v1"
@@ -116,6 +117,47 @@ func TestOomKillEventConstraint(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestMemoryEventsMaxMetricAfterOom(t *testing.T) {
+	if !cgroups.IsCgroup2UnifiedMode() {
+		t.Skip("memory.events requires cgroup v2")
+	}
+
+	fm := framework.New(t)
+	defer fm.Cleanup()
+
+	containerID := fm.Docker().Run(
+		framework.DockerRunArgs{
+			Image: "registry.k8s.io/busybox:1.27",
+			Args:  []string{"-m=8M", "--memory-swap=8M"},
+		},
+		"sh", "-c", "dd if=/dev/zero of=/tmp/data bs=1M count=100; sleep 60",
+	)
+
+	client := framework.NewMetricsClient(fm.Hostname())
+
+	err := framework.RetryForDuration(func() error {
+		families, err := client.FetchAndParse()
+		if err != nil {
+			return err
+		}
+		mf, ok := framework.GetMetricFamily(families, "container_memory_events_max_total")
+		if !ok {
+			return fmt.Errorf("container_memory_events_max_total metric not found")
+		}
+		metrics := framework.FindMetricsWithLabelSubstring(mf, "id", containerID)
+		if len(metrics) == 0 {
+			return fmt.Errorf("no container_memory_events_max_total for container %s", containerID)
+		}
+		val := framework.GetCounterValue(metrics[0])
+		if val <= 0 {
+			return fmt.Errorf("container_memory_events_max_total is %v, want > 0", val)
+		}
+		return nil
+	}, 30*time.Second)
+
+	require.NoError(t, err)
 }
 
 func waitForStaticEvent(containerID string, urlRequest string, t *testing.T, fm framework.Framework, typeEvent info.EventType) {

--- a/integration/tests/metrics/prometheus_test.go
+++ b/integration/tests/metrics/prometheus_test.go
@@ -117,6 +117,8 @@ func TestCoreMemoryMetricsExist(t *testing.T) {
 		"container_memory_working_set_bytes",
 		"container_memory_cache",
 		"container_memory_rss",
+		"container_memory_events_high_total",
+		"container_memory_events_max_total",
 	}
 
 	for _, name := range memoryMetrics {
@@ -248,6 +250,8 @@ func TestMetricsHaveCorrectTypes(t *testing.T) {
 		"container_cpu_system_seconds_total",
 		"container_network_receive_bytes_total",
 		"container_network_transmit_bytes_total",
+		"container_memory_events_high_total",
+		"container_memory_events_max_total",
 	}
 	for _, name := range counterMetrics {
 		if mf, ok := families[name]; ok {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -518,6 +518,20 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 						},
 					}
 				},
+			}, {
+				name:      "container_memory_events_high_total",
+				help:      "Cumulative count of memory.high throttle events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Events.High), timestamp: s.Timestamp}}
+				},
+			}, {
+				name:      "container_memory_events_max_total",
+				help:      "Cumulative count of memory.max limit hit events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Events.Max), timestamp: s.Timestamp}}
+				},
 			},
 		}...)
 	}

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -389,6 +389,10 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Total:  2000,
 							},
 						},
+						Events: info.MemoryEvents{
+							High: 42,
+							Max:  5,
+						},
 					},
 					Hugetlb: map[string]info.HugetlbStats{
 						"2Mi": {

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -163,6 +163,12 @@ container_last_seen{container_env_foo_env="prod",container_label_foo_label="bar"
 # HELP container_memory_cache Number of bytes of page cache memory.
 # TYPE container_memory_cache gauge
 container_memory_cache{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 14 1395066363000
+# HELP container_memory_events_high_total Cumulative count of memory.high throttle events for the container
+# TYPE container_memory_events_high_total counter
+container_memory_events_high_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 42 1395066363000
+# HELP container_memory_events_max_total Cumulative count of memory.max limit hit events for the container
+# TYPE container_memory_events_max_total counter
+container_memory_events_max_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5 1395066363000
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
 container_memory_failcnt{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0 1395066363000

--- a/metrics/testdata/prometheus_metrics_whitelist_filtered
+++ b/metrics/testdata/prometheus_metrics_whitelist_filtered
@@ -163,6 +163,12 @@ container_last_seen{container_env_foo_env="prod",id="testcontainer",image="test"
 # HELP container_memory_cache Number of bytes of page cache memory.
 # TYPE container_memory_cache gauge
 container_memory_cache{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 14 1395066363000
+# HELP container_memory_events_high_total Cumulative count of memory.high throttle events for the container
+# TYPE container_memory_events_high_total counter
+container_memory_events_high_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 42 1395066363000
+# HELP container_memory_events_max_total Cumulative count of memory.max limit hit events for the container
+# TYPE container_memory_events_max_total counter
+container_memory_events_max_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5 1395066363000
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
 container_memory_failcnt{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0 1395066363000


### PR DESCRIPTION
Kubernetes KEP-2570 (MemoryQoS) uses cgroup v2 memory.high for throttling and memory.min/memory.low for memory protection. To observe the effect of these settings, operators need visibility into memory pressure events. cadvisor currently does not read the memory.events cgroup file. The existing `container_oom_events_total` metric comes from kernel log parsing, not cgroup counters.

Read memory.events on cgroup v2 and expose two new Prometheus counter metrics:

- container_memory_events_high_total: times the container was throttled for breaching memory.high
- container_memory_events_max_total: times the container's usage hit memory.max

xref: https://github.com/kubernetes/enhancements/issues/2570