### PR TITLE
deploy: bump base images to Alpine 3.23

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.25-alpine3.22 AS build
+FROM registry.hub.docker.com/library/golang:1.25-alpine3.23 AS build
 
 # Install build depdencies for all supported arches
 RUN apk --no-cache add bash build-base cmake device-mapper findutils git \
@@ -49,7 +49,7 @@ RUN export GO_TAGS="libpfm,netgo"; \
     fi; \
     GO_FLAGS="-tags=$GO_TAGS" ./build/build.sh
 
-FROM mirror.gcr.io/library/alpine:3.22
+FROM mirror.gcr.io/library/alpine:3.23
 MAINTAINER dengnan@google.com vmarmol@google.com vishnuk@google.com jimmidyson@gmail.com stclair@google.com
 
 RUN apk --no-cache add libc6-compat device-mapper findutils ndctl thin-provisioning-tools zfs && \


### PR DESCRIPTION
## Summary
- Bump the build stage from `golang:1.25-alpine3.22` to `golang:1.25-alpine3.23`.
- Bump the runtime image from `alpine:3.22` to `alpine:3.23`.

Alpine 3.23 is the current stable release (2025-12-03). Rebuilding on the newer base pulls in `busybox 1.37.0-r20+` (CVE-2024-58251, BusyBox netstat ANSI-escape DoS) and Go 1.25.10 via `golang:1.25-alpine3.23` (CVE-2025-58183, `archive/tar` unbounded sparse-region allocation, fixed in 1.25.9).
