### PR TITLE
fix(storage/kafka): negate verifySSL when setting InsecureSkipVerify

### DIFF
--- a/cmd/internal/storage/kafka/kafka.go
+++ b/cmd/internal/storage/kafka/kafka.go
@@ -117,9 +117,17 @@ func generateTLSConfig() (*tls.Config, error) {
 		caCertPool.AppendCertsFromPEM(caCert)
 
 		return &tls.Config{
-			Certificates:       []tls.Certificate{cert},
-			RootCAs:            caCertPool,
-			InsecureSkipVerify: *verifySSL,
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      caCertPool,
+			// `--storage_driver_kafka_ssl_verify` (default true) controls
+			// whether the broker's certificate chain is verified. The
+			// crypto/tls field with the opposite sense is
+			// `InsecureSkipVerify`, so the value must be negated. Prior to
+			// this fix `*verifySSL` was assigned directly, which disabled
+			// verification by default and allowed any MITM presenting a
+			// self-signed cert to read and inject the entire container
+			// metric stream the daemon publishes to Kafka.
+			InsecureSkipVerify: !*verifySSL,
 		}, nil
 	}
 


### PR DESCRIPTION
## Summary

`cmd/internal/storage/kafka/kafka.go:122` builds a `tls.Config` for the Kafka publisher with:

```go
InsecureSkipVerify: *verifySSL,
```

The flag declared at `:46`:

```go
verifySSL = flag.Bool("storage_driver_kafka_ssl_verify", true, "verify ssl certificate chain")
```

`InsecureSkipVerify=true` means *skip* verification. `verifySSL=true` is documented to mean *verify*. They have opposite senses. Because the flag defaults to `true`, every deployment that follows the docs to configure mTLS for Kafka (`--storage_driver_kafka_ssl_cert/_key/_ca`) silently runs with broker certificate-chain verification **disabled**.

Any MITM presenting a self-signed certificate then accepts the connection from cAdvisor and (a) reads the entire container metric stream the daemon publishes (container ID, name, image, all container labels — these often carry pod labels propagated from Helm releases / image tags from private registries / annotations that operators do not consider sensitive) and (b) injects forged metric records into Kafka topics that downstream monitoring/alerting consumes.

A second-order surprise: an operator wanting to turn verification off for a test cluster sets `--storage_driver_kafka_ssl_verify=false`, which maps to `InsecureSkipVerify: false` — i.e. verification stays on and they hit X.509 errors that nudge them back to `=true` to "fix" it.

## Fix

```diff
-		InsecureSkipVerify: *verifySSL,
+		InsecureSkipVerify: !*verifySSL,
```

That is the entire functional change. A comment documenting the negation is added so the next reader does not introduce the same bug.

## Test plan

- [x] `go build ./internal/storage/kafka/` clean.
- [x] Standalone PoC: a `tls.Config` built with the original assignment accepts a server presenting a self-signed cert whose issuer is **not** in the `RootCAs` pool; the same config built with the negated assignment rejects it with `x509: certificate signed by unknown authority`.

The bug has shipped continuously since the kafka driver was added in 2016. I did not find any open issue, PR, or GHSA addressing it.