### PR TITLE
docker: parse Docker versions with extra suffixes

### DIFF
--- a/container/docker/docker.go
+++ b/container/docker/docker.go
@@ -184,7 +184,7 @@ func APIVersionString() (string, error) {
 
 func ParseVersion(versionString string, regex *regexp.Regexp, length int) ([]int, error) {
 	matches := regex.FindAllStringSubmatch(versionString, -1)
-	if len(matches) != 1 {
+	if len(matches) == 0 {
 		return nil, fmt.Errorf("version string \"%v\" doesn't match expected regular expression: \"%v\"", versionString, regex.String())
 	}
 	versionStringArray := matches[0][1:]

--- a/container/docker/docker_test.go
+++ b/container/docker/docker_test.go
@@ -31,6 +31,7 @@ func TestParseDockerAPIVersion(t *testing.T) {
 		expectedError string
 	}{
 		{"17.03.0", VersionRe, 3, []int{17, 03, 0}, ""},
+		{"v20.10.12-v1.0.2", VersionRe, 3, []int{20, 10, 12}, ""},
 		{"17.a3.0", VersionRe, 3, []int{}, `version string "17.a3.0" doesn't match expected regular expression: "(\d+)\.(\d+)\.(\d+)"`},
 		{"1.20", apiVersionRe, 2, []int{1, 20}, ""},
 		{"1.a", apiVersionRe, 2, []int{}, `version string "1.a" doesn't match expected regular expression: "(\d+)\.(\d+)"`},


### PR DESCRIPTION
## Summary

Fixes #3830.

Some Docker builds report versions with more than one semantic-looking component, for example `v20.10.12-v1.0.2`. The Docker handler currently asks `ParseVersion` to find exactly one regex match, so those versions fail parsing and can prevent the Docker-specific container handler from registering.

This change keeps the existing parser behavior for invalid strings, but accepts the first valid version component when additional suffixes are present. That lets cAdvisor use the base Docker version (`20.10.12` in the example) instead of falling back away from Docker metadata handling.

## Test plan

- `GOOS=linux go test -c ./container/docker -o /tmp/cadvisor-container-docker.test`
- `go test ./container`
- `git diff --check`

Also attempted:

- `go test ./container/docker` on macOS: skipped by Go because this package is Linux-only (`build constraints exclude all Go files`).
- `GOOS=linux go test ./container/docker` on macOS: compiled but cannot execute the Linux test binary on macOS (`exec format error`).
- `go test ./...` on macOS: unrelated environment failures in Linux-only `opencontainers/cgroups` symbols and integration tests expecting cAdvisor on `localhost:8080`; packages before those failures, including `container`, passed.