### PR TITLE
docker: parse suffixed Docker versions strictly

### DIFF
--- a/container/docker/docker.go
+++ b/container/docker/docker.go
@@ -114,7 +114,7 @@ func ValidateInfo(GetInfo func() (*dockersystem.Info, error), ServerVersion func
 		}
 	}
 
-	version, err := ParseVersion(info.ServerVersion, VersionRe, 3)
+	version, err := ParseVersion(info.ServerVersion, dockerVersionRe, 3)
 	if err != nil {
 		return nil, err
 	}

--- a/container/docker/docker_test.go
+++ b/container/docker/docker_test.go
@@ -30,8 +30,10 @@ func TestParseDockerAPIVersion(t *testing.T) {
 		expected      []int
 		expectedError string
 	}{
-		{"17.03.0", VersionRe, 3, []int{17, 03, 0}, ""},
-		{"17.a3.0", VersionRe, 3, []int{}, `version string "17.a3.0" doesn't match expected regular expression: "(\d+)\.(\d+)\.(\d+)"`},
+		{"17.03.0", dockerVersionRe, 3, []int{17, 03, 0}, ""},
+		{"v20.10.12-v1.0.2", dockerVersionRe, 3, []int{20, 10, 12}, ""},
+		{"17.a3.0", dockerVersionRe, 3, []int{}, `version string "17.a3.0" doesn't match expected regular expression: "^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$"`},
+		{"random text 1.2.3 and also 9.9.9 build", dockerVersionRe, 3, []int{}, `version string "random text 1.2.3 and also 9.9.9 build" doesn't match expected regular expression: "^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$"`},
 		{"1.20", apiVersionRe, 2, []int{1, 20}, ""},
 		{"1.a", apiVersionRe, 2, []int{}, `version string "1.a" doesn't match expected regular expression: "(\d+)\.(\d+)"`},
 	}

--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -193,10 +193,12 @@ func (f *dockerFactory) DebugInfo() map[string][]string {
 }
 
 var (
-	versionRegexpString    = `(\d+)\.(\d+)\.(\d+)`
-	VersionRe              = regexp.MustCompile(versionRegexpString)
-	apiVersionRegexpString = `(\d+)\.(\d+)`
-	apiVersionRe           = regexp.MustCompile(apiVersionRegexpString)
+	versionRegexpString       = `(\d+)\.(\d+)\.(\d+)`
+	VersionRe                 = regexp.MustCompile(versionRegexpString)
+	dockerVersionRegexpString = `^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$`
+	dockerVersionRe           = regexp.MustCompile(dockerVersionRegexpString)
+	apiVersionRegexpString    = `(\d+)\.(\d+)`
+	apiVersionRe              = regexp.MustCompile(apiVersionRegexpString)
 )
 
 func StartThinPoolWatcher(dockerInfo *dockersystem.Info) (*devicemapper.ThinPoolWatcher, error) {
@@ -320,7 +322,7 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics
 	}
 
 	// Version already validated above, assume no error here.
-	dockerVersion, _ := ParseVersion(dockerInfo.ServerVersion, VersionRe, 3)
+	dockerVersion, _ := ParseVersion(dockerInfo.ServerVersion, dockerVersionRe, 3)
 
 	dockerAPIVersion, _ := APIVersion()
 


### PR DESCRIPTION
Fixes #3830. This is a replacement for the closed #3876 with the maintainer feedback addressed.

Docker server versions can be reported with a leading `v` and build/distribution suffixes such as `v20.10.12-v1.0.2`. cAdvisor currently parses Docker server versions with the generic unanchored `VersionRe`, which rejects that form because it finds multiple semantic-version substrings.

This change adds a Docker-specific server-version regexp that:
- requires the version to start at the beginning of the string, with an optional `v` prefix;
- captures the base `major.minor.patch`;
- allows an optional suffix after the base version;
- rejects arbitrary text such as `random text 1.2.3 and also 9.9.9 build`.

`VersionRe` remains unchanged for kernel-version parsing, so this does not broaden the older generic parser behavior.

Validation:
- `GOOS=linux go test -c ./container/docker -o /tmp/cadvisor-container-docker.test`
- `go test ./container`
- `git diff --check`

Note: `container/docker` is Linux-only, so on macOS I compile-validated the Linux test binary instead of executing it locally.