### PR TITLE
fix: skip PSI metrics when PSI is unavailable on host

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -918,11 +918,13 @@ func setPSIData(d *cgroups.PSIData, ret *info.PSIData) {
 	}
 }
 
-func setPSIStats(s *cgroups.PSIStats, ret *info.PSIStats) {
-	if s != nil {
-		setPSIData(&s.Full, &ret.Full)
-		setPSIData(&s.Some, &ret.Some)
-	}
+func setPSIStats(s *cgroups.PSIStats, ret **info.PSIStats) {
+    if s == nil {
+        return
+    }
+    *ret = &info.PSIStats{}
+    setPSIData(&s.Full, &(*ret).Full)
+    setPSIData(&s.Some, &(*ret).Some)
 }
 
 // read from pids path not cpu
@@ -956,3 +958,5 @@ func newContainerStats(cgroupStats *cgroups.Stats, includedMetrics container.Met
 	}
 	return ret
 }
+
+

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -372,7 +372,7 @@ type CpuStats struct {
 	LoadAverage int32 `json:"load_average"`
 	// from LoadStats.NrUninterruptible
 	LoadDAverage int32    `json:"load_d_average"`
-	PSI          PSIStats `json:"psi"`
+	PSI            *PSIStats      `json:"psi,omitempty"`
 }
 
 type PerDiskStats struct {
@@ -395,7 +395,7 @@ type DiskIoStats struct {
 	IoCostWait     []PerDiskStats `json:"io_cost_wait,omitempty"`
 	IoCostIndebt   []PerDiskStats `json:"io_cost_indebt,omitempty"`
 	IoCostIndelay  []PerDiskStats `json:"io_cost_indelay,omitempty"`
-	PSI            PSIStats       `json:"psi"`
+	PSI            *PSIStats      `json:"psi,omitempty"`
 }
 
 type HugetlbStats struct {
@@ -455,7 +455,7 @@ type MemoryStats struct {
 	ContainerData    MemoryStatsMemoryData `json:"container_data,omitempty"`
 	HierarchicalData MemoryStatsMemoryData `json:"hierarchical_data,omitempty"`
 
-	PSI PSIStats `json:"psi"`
+	PSI            *PSIStats      `json:"psi,omitempty"`
 
 	Events MemoryEvents `json:"events,omitempty"`
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1850,42 +1850,42 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Total time duration no tasks in the container could make progress due to CPU congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
-					return metricValues{{value: asMicrosecondsToSeconds(s.Cpu.PSI.Full.Total), timestamp: s.Timestamp}}
+					if s.Cpu.PSI == nil { return nil }; return metricValues{{value: asMicrosecondsToSeconds(s.Cpu.PSI.Full.Total), timestamp: s.Timestamp}}
 				},
 			}, {
 				name:      "container_pressure_cpu_waiting_seconds_total",
 				help:      "Total time duration tasks in the container have waited due to CPU congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
-					return metricValues{{value: asMicrosecondsToSeconds(s.Cpu.PSI.Some.Total), timestamp: s.Timestamp}}
+					if s.Cpu.PSI == nil { return nil }; return metricValues{{value: asMicrosecondsToSeconds(s.Cpu.PSI.Some.Total), timestamp: s.Timestamp}}
 				},
 			}, {
 				name:      "container_pressure_memory_stalled_seconds_total",
 				help:      "Total time duration no tasks in the container could make progress due to memory congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
-					return metricValues{{value: asMicrosecondsToSeconds(s.Memory.PSI.Full.Total), timestamp: s.Timestamp}}
+					if s.Memory.PSI == nil { return nil }; return metricValues{{value: asMicrosecondsToSeconds(s.Memory.PSI.Full.Total), timestamp: s.Timestamp}}
 				},
 			}, {
 				name:      "container_pressure_memory_waiting_seconds_total",
 				help:      "Total time duration tasks in the container have waited due to memory congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
-					return metricValues{{value: asMicrosecondsToSeconds(s.Memory.PSI.Some.Total), timestamp: s.Timestamp}}
+					if s.Memory.PSI == nil { return nil }; return metricValues{{value: asMicrosecondsToSeconds(s.Memory.PSI.Some.Total), timestamp: s.Timestamp}}
 				},
 			}, {
 				name:      "container_pressure_io_stalled_seconds_total",
 				help:      "Total time duration no tasks in the container could make progress due to IO congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
-					return metricValues{{value: asMicrosecondsToSeconds(s.DiskIo.PSI.Full.Total), timestamp: s.Timestamp}}
+					if s.DiskIo.PSI == nil { return nil }; return metricValues{{value: asMicrosecondsToSeconds(s.DiskIo.PSI.Full.Total), timestamp: s.Timestamp}}
 				},
 			}, {
 				name:      "container_pressure_io_waiting_seconds_total",
 				help:      "Total time duration tasks in the container have waited due to IO congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
-					return metricValues{{value: asMicrosecondsToSeconds(s.DiskIo.PSI.Some.Total), timestamp: s.Timestamp}}
+					if s.DiskIo.PSI == nil { return nil }; return metricValues{{value: asMicrosecondsToSeconds(s.DiskIo.PSI.Some.Total), timestamp: s.Timestamp}}
 				},
 			},
 		}...)
@@ -2207,3 +2207,4 @@ func getContainerHealthState(s *info.ContainerStats) metricValues {
 		timestamp: s.Timestamp,
 	}}
 }
+

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -331,7 +331,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 						},
 						LoadAverage:  2,
 						LoadDAverage: 2,
-						PSI: info.PSIStats{
+						PSI: &info.PSIStats{
 							Full: info.PSIData{
 								Avg10:  0.3,
 								Avg60:  0.2,
@@ -375,7 +375,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 						MappedFile:  16,
 						KernelUsage: 17,
 						Swap:        8192,
-						PSI: info.PSIStats{
+						PSI: &info.PSIStats{
 							Full: info.PSIData{
 								Avg10:  0.3,
 								Avg60:  0.2,
@@ -609,7 +609,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 							Minor:  1,
 							Stats:  map[string]uint64{"Count": 750000},
 						}},
-						PSI: info.PSIStats{
+						PSI: &info.PSIStats{
 							Full: info.PSIData{
 								Avg10:  0.3,
 								Avg60:  0.2,
@@ -842,3 +842,4 @@ func (p *erroringSubcontainersInfoProvider) GetRequestedContainersInfo(
 	}
 	return p.successfulProvider.GetRequestedContainersInfo(a, opt)
 }
+


### PR DESCRIPTION
Fixes #3852

## Problem
When PSI is unavailable (kernel compiled without CONFIG_PSI or booted
with psi=0), cAdvisor emits zeroes for all container_pressure_*
Prometheus metrics. Monitoring systems cannot distinguish "PSI
unavailable" from "system is idle under zero pressure."

## Fix
Changed CpuStats.PSI, MemoryStats.PSI, and DiskIoStats.PSI from value
types to pointer types (*PSIStats). When setPSIStats() receives nil from
the cgroups layer, the pointer stays nil. The Prometheus collector skips
emission when the pointer is nil.

## Testing
- `go build ./...` passes
- `go test ./info/... ./metrics/...` — PSI-related tests pass; pre-existing
  \r\n line ending failures in prometheus_machine_test.go are unrelated
  to this change and reproducible on master without any modifications.