### PR TITLE
Expose cgroup v2 memory.events OOM metrics

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -895,6 +895,15 @@ func setMemoryEvents(cgroupPath string, ret *info.ContainerStats) {
 	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "max"); err == nil {
 		ret.Memory.Events.Max = val
 	}
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "oom"); err == nil {
+		ret.Memory.Events.Oom = val
+	}
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "oom_kill"); err == nil {
+		ret.Memory.Events.OomKill = val
+	}
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "oom_group_kill"); err == nil {
+		ret.Memory.Events.OomGroupKill = val
+	}
 }
 
 func setCPUSetStats(s *cgroups.Stats, ret *info.ContainerStats) {

--- a/container/libcontainer/handler_test.go
+++ b/container/libcontainer/handler_test.go
@@ -394,30 +394,33 @@ func TestSetMemoryEvents(t *testing.T) {
 	defer func() { cgroups.TestMode = false }()
 
 	testData := []struct {
-		name    string
-		content string
-		high    uint64
-		max     uint64
+		name         string
+		content      string
+		high         uint64
+		max          uint64
+		oom          uint64
+		oomKill      uint64
+		oomGroupKill uint64
 	}{
 		{
 			"all counters",
-			"low 0\nhigh 42\nmax 5\noom 1\noom_kill 0\noom_group_kill 0\n",
-			42, 5,
+			"low 0\nhigh 42\nmax 5\noom 3\noom_kill 2\noom_group_kill 1\n",
+			42, 5, 3, 2, 1,
 		},
 		{
 			"zeros",
 			"low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n",
-			0, 0,
+			0, 0, 0, 0, 0,
 		},
 		{
 			"high only",
 			"low 0\nhigh 238\nmax 0\noom 0\noom_kill 0\noom_group_kill 0\n",
-			238, 0,
+			238, 0, 0, 0, 0,
 		},
 		{
 			"empty file",
 			"",
-			0, 0,
+			0, 0, 0, 0, 0,
 		},
 	}
 
@@ -432,6 +435,9 @@ func TestSetMemoryEvents(t *testing.T) {
 
 			assert.Equal(t, testItem.high, ret.Memory.Events.High)
 			assert.Equal(t, testItem.max, ret.Memory.Events.Max)
+			assert.Equal(t, testItem.oom, ret.Memory.Events.Oom)
+			assert.Equal(t, testItem.oomKill, ret.Memory.Events.OomKill)
+			assert.Equal(t, testItem.oomGroupKill, ret.Memory.Events.OomGroupKill)
 		})
 	}
 }
@@ -442,4 +448,7 @@ func TestSetMemoryEventsFileNotFound(t *testing.T) {
 
 	assert.Equal(t, uint64(0), ret.Memory.Events.High)
 	assert.Equal(t, uint64(0), ret.Memory.Events.Max)
+	assert.Equal(t, uint64(0), ret.Memory.Events.Oom)
+	assert.Equal(t, uint64(0), ret.Memory.Events.OomKill)
+	assert.Equal(t, uint64(0), ret.Memory.Events.OomGroupKill)
 }

--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -56,6 +56,9 @@ Metric name | Type | Description | Unit (where applicable) | option parameter | 
 `container_memory_bandwidth_bytes` | Gauge | Total memory bandwidth usage statistics for container counted with RDT Memory Bandwidth Monitoring (MBM). | bytes | resctrl |
 `container_memory_bandwidth_local_bytes` | Gauge | Local memory bandwidth usage statistics for container counted with RDT Memory Bandwidth Monitoring (MBM). | bytes | resctrl |
 `container_memory_cache` | Gauge | Total page cache memory | bytes | memory |
+`container_memory_events_oom_group_kill_total` | Counter | Cumulative count of memory OOM group kill events for the container | | memory |
+`container_memory_events_oom_kill_total` | Counter | Cumulative count of memory OOM kill events for the container | | memory |
+`container_memory_events_oom_total` | Counter | Cumulative count of memory allocation failure events for the container | | memory |
 `container_memory_failcnt` | Counter | Number of memory usage hits limits | | memory |
 `container_memory_failures_total` | Counter | Cumulative count of memory allocation failures | | memory |
 `container_memory_file_dirty_bytes` | Gauge | File cache that has been modified but not yet written back to disk (cgroup v2) | bytes | memory |

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -491,8 +491,11 @@ type MemoryStats struct {
 }
 
 type MemoryEvents struct {
-	High uint64 `json:"high"`
-	Max  uint64 `json:"max"`
+	High         uint64 `json:"high"`
+	Max          uint64 `json:"max"`
+	Oom          uint64 `json:"oom"`
+	OomKill      uint64 `json:"oom_kill"`
+	OomGroupKill uint64 `json:"oom_group_kill"`
 }
 
 type CPUSetStats struct {

--- a/integration/tests/metrics/prometheus_test.go
+++ b/integration/tests/metrics/prometheus_test.go
@@ -119,6 +119,9 @@ func TestCoreMemoryMetricsExist(t *testing.T) {
 		"container_memory_rss",
 		"container_memory_events_high_total",
 		"container_memory_events_max_total",
+		"container_memory_events_oom_total",
+		"container_memory_events_oom_kill_total",
+		"container_memory_events_oom_group_kill_total",
 	}
 
 	for _, name := range memoryMetrics {
@@ -289,6 +292,9 @@ func TestMetricsHaveCorrectTypes(t *testing.T) {
 		"container_network_transmit_bytes_total",
 		"container_memory_events_high_total",
 		"container_memory_events_max_total",
+		"container_memory_events_oom_total",
+		"container_memory_events_oom_kill_total",
+		"container_memory_events_oom_group_kill_total",
 	}
 	for _, name := range counterMetrics {
 		if mf, ok := families[name]; ok {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -533,6 +533,27 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 					return metricValues{{value: float64(s.Memory.Events.Max), timestamp: s.Timestamp}}
 				},
 			}, {
+				name:      "container_memory_events_oom_total",
+				help:      "Cumulative count of memory allocation failure events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Events.Oom), timestamp: s.Timestamp}}
+				},
+			}, {
+				name:      "container_memory_events_oom_kill_total",
+				help:      "Cumulative count of memory OOM kill events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Events.OomKill), timestamp: s.Timestamp}}
+				},
+			}, {
+				name:      "container_memory_events_oom_group_kill_total",
+				help:      "Cumulative count of memory OOM group kill events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Events.OomGroupKill), timestamp: s.Timestamp}}
+				},
+			}, {
 				name:      "container_memory_file_dirty_bytes",
 				help:      "Number of bytes of file cache that has been modified but not yet written back to disk.",
 				valueType: prometheus.GaugeValue,

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -396,8 +396,11 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 							},
 						},
 						Events: info.MemoryEvents{
-							High: 42,
-							Max:  5,
+							High:         42,
+							Max:          5,
+							Oom:          3,
+							OomKill:      2,
+							OomGroupKill: 1,
 						},
 					},
 					Hugetlb: map[string]info.HugetlbStats{

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -169,6 +169,15 @@ container_memory_events_high_total{container_env_foo_env="prod",container_label_
 # HELP container_memory_events_max_total Cumulative count of memory.max limit hit events for the container
 # TYPE container_memory_events_max_total counter
 container_memory_events_max_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5 1395066363000
+# HELP container_memory_events_oom_total Cumulative count of memory allocation failure events for the container
+# TYPE container_memory_events_oom_total counter
+container_memory_events_oom_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3 1395066363000
+# HELP container_memory_events_oom_kill_total Cumulative count of memory OOM kill events for the container
+# TYPE container_memory_events_oom_kill_total counter
+container_memory_events_oom_kill_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2 1395066363000
+# HELP container_memory_events_oom_group_kill_total Cumulative count of memory OOM group kill events for the container
+# TYPE container_memory_events_oom_group_kill_total counter
+container_memory_events_oom_group_kill_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1 1395066363000
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
 container_memory_failcnt{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0 1395066363000

--- a/metrics/testdata/prometheus_metrics_whitelist_filtered
+++ b/metrics/testdata/prometheus_metrics_whitelist_filtered
@@ -169,6 +169,15 @@ container_memory_events_high_total{container_env_foo_env="prod",id="testcontaine
 # HELP container_memory_events_max_total Cumulative count of memory.max limit hit events for the container
 # TYPE container_memory_events_max_total counter
 container_memory_events_max_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5 1395066363000
+# HELP container_memory_events_oom_total Cumulative count of memory allocation failure events for the container
+# TYPE container_memory_events_oom_total counter
+container_memory_events_oom_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 3 1395066363000
+# HELP container_memory_events_oom_kill_total Cumulative count of memory OOM kill events for the container
+# TYPE container_memory_events_oom_kill_total counter
+container_memory_events_oom_kill_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 2 1395066363000
+# HELP container_memory_events_oom_group_kill_total Cumulative count of memory OOM group kill events for the container
+# TYPE container_memory_events_oom_group_kill_total counter
+container_memory_events_oom_group_kill_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 1 1395066363000
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
 container_memory_failcnt{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0 1395066363000


### PR DESCRIPTION
### What:
Follow-up to #3870. Expose the remaining cgroup v2 `memory.events` OOM counters as Prometheus metrics:
- `container_memory_events_oom_total`
- `container_memory_events_oom_kill_total`
- `container_memory_events_oom_group_kill_total`

### Why:
`memory.events` already contains these OOM counters on cgroup v2 systems. Exposing them gives operators direct cgroup-level visibility into allocation failures and OOM kills. This is separate from the existing `container_oom_events_total` metric, which comes from the OOM event path rather than the cgroup v2 `memory.events` counters.

### How:
- Read `oom`, `oom_kill`, and `oom_group_kill` in the existing `setMemoryEvents` path.
- Add the fields to `info/v1.MemoryEvents` and emit them under the existing memory metric set.
- Update unit tests, integration metric checks, docs, and Prometheus golden files.
