### PR TITLE
Expose cgroup v2 memory.swap.events counters

### DIFF
--- a/container/libcontainer/handler.go
+++ b/container/libcontainer/handler.go
@@ -95,6 +95,7 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 
 	if cgroups.IsCgroup2UnifiedMode() {
 		setMemoryEvents(h.cgroupManager.Path(""), stats)
+		setSwapEvents(h.cgroupManager.Path(""), stats)
 	}
 
 	if h.includedMetrics.Has(container.ProcessSchedulerMetrics) {
@@ -894,6 +895,18 @@ func setMemoryEvents(cgroupPath string, ret *info.ContainerStats) {
 	}
 	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "max"); err == nil {
 		ret.Memory.Events.Max = val
+	}
+}
+
+func setSwapEvents(cgroupPath string, ret *info.ContainerStats) {
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.swap.events", "high"); err == nil {
+		ret.Memory.SwapEvents.High = val
+	}
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.swap.events", "max"); err == nil {
+		ret.Memory.SwapEvents.Max = val
+	}
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.swap.events", "fail"); err == nil {
+		ret.Memory.SwapEvents.Fail = val
 	}
 }
 

--- a/container/libcontainer/handler_test.go
+++ b/container/libcontainer/handler_test.go
@@ -443,3 +443,61 @@ func TestSetMemoryEventsFileNotFound(t *testing.T) {
 	assert.Equal(t, uint64(0), ret.Memory.Events.High)
 	assert.Equal(t, uint64(0), ret.Memory.Events.Max)
 }
+
+func TestSetSwapEvents(t *testing.T) {
+	cgroups.TestMode = true
+	defer func() { cgroups.TestMode = false }()
+
+	testData := []struct {
+		name    string
+		content string
+		high    uint64
+		max     uint64
+		fail    uint64
+	}{
+		{
+			"all counters",
+			"high 2\nmax 9\nfail 4\n",
+			2, 9, 4,
+		},
+		{
+			"zeros",
+			"high 0\nmax 0\nfail 0\n",
+			0, 0, 0,
+		},
+		{
+			"fail only",
+			"high 0\nmax 0\nfail 17\n",
+			0, 0, 17,
+		},
+		{
+			"empty file",
+			"",
+			0, 0, 0,
+		},
+	}
+
+	for _, testItem := range testData {
+		t.Run(testItem.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, "memory.swap.events"), []byte(testItem.content), 0o644)
+			assert.Nil(t, err)
+
+			var ret info.ContainerStats
+			setSwapEvents(dir, &ret)
+
+			assert.Equal(t, testItem.high, ret.Memory.SwapEvents.High)
+			assert.Equal(t, testItem.max, ret.Memory.SwapEvents.Max)
+			assert.Equal(t, testItem.fail, ret.Memory.SwapEvents.Fail)
+		})
+	}
+}
+
+func TestSetSwapEventsFileNotFound(t *testing.T) {
+	var ret info.ContainerStats
+	setSwapEvents("/nonexistent/path", &ret)
+
+	assert.Equal(t, uint64(0), ret.Memory.SwapEvents.High)
+	assert.Equal(t, uint64(0), ret.Memory.SwapEvents.Max)
+	assert.Equal(t, uint64(0), ret.Memory.SwapEvents.Fail)
+}

--- a/docs/storage/prometheus.md
+++ b/docs/storage/prometheus.md
@@ -56,6 +56,8 @@ Metric name | Type | Description | Unit (where applicable) | option parameter | 
 `container_memory_bandwidth_bytes` | Gauge | Total memory bandwidth usage statistics for container counted with RDT Memory Bandwidth Monitoring (MBM). | bytes | resctrl |
 `container_memory_bandwidth_local_bytes` | Gauge | Local memory bandwidth usage statistics for container counted with RDT Memory Bandwidth Monitoring (MBM). | bytes | resctrl |
 `container_memory_cache` | Gauge | Total page cache memory | bytes | memory |
+`container_memory_events_high_total` | Counter | Cumulative count of memory.high throttle events (cgroup v2) | | memory |
+`container_memory_events_max_total` | Counter | Cumulative count of memory.max limit hit events (cgroup v2) | | memory |
 `container_memory_failcnt` | Counter | Number of memory usage hits limits | | memory |
 `container_memory_failures_total` | Counter | Cumulative count of memory allocation failures | | memory |
 `container_memory_file_dirty_bytes` | Gauge | File cache that has been modified but not yet written back to disk (cgroup v2) | bytes | memory |
@@ -68,6 +70,9 @@ Metric name | Type | Description | Unit (where applicable) | option parameter | 
 `container_memory_pgsteal_total` | Counter | Cumulative number of pages reclaimed by the page reclaim algorithm (cgroup v2) | | memory |
 `container_memory_rss` | Gauge | Size of RSS | bytes | memory |
 `container_memory_swap` | Gauge | Container swap usage | bytes | memory |
+`container_memory_swap_events_fail_total` | Counter | Cumulative count of swap allocation failures (cgroup v2) | | memory |
+`container_memory_swap_events_high_total` | Counter | Cumulative count of memory.swap.high throttle events (cgroup v2) | | memory |
+`container_memory_swap_events_max_total` | Counter | Cumulative count of memory.swap.max limit hit events (cgroup v2) | | memory |
 `container_memory_usage_bytes` | Gauge | Current memory usage, including all memory regardless of when it was accessed | bytes | memory |
 `container_memory_working_set_bytes` | Gauge | Current working set | bytes | memory |
 `container_memory_workingset_refault_anon_total` | Counter | Cumulative number of refaults of previously evicted anonymous pages (cgroup v2) | | memory |

--- a/info/v1/container.go
+++ b/info/v1/container.go
@@ -488,11 +488,19 @@ type MemoryStats struct {
 	PSI PSIStats `json:"psi"`
 
 	Events MemoryEvents `json:"events,omitempty"`
+
+	SwapEvents SwapEvents `json:"swap_events,omitempty"`
 }
 
 type MemoryEvents struct {
 	High uint64 `json:"high"`
 	Max  uint64 `json:"max"`
+}
+
+type SwapEvents struct {
+	High uint64 `json:"high"`
+	Max  uint64 `json:"max"`
+	Fail uint64 `json:"fail"`
 }
 
 type CPUSetStats struct {

--- a/integration/tests/metrics/prometheus_test.go
+++ b/integration/tests/metrics/prometheus_test.go
@@ -119,6 +119,9 @@ func TestCoreMemoryMetricsExist(t *testing.T) {
 		"container_memory_rss",
 		"container_memory_events_high_total",
 		"container_memory_events_max_total",
+		"container_memory_swap_events_high_total",
+		"container_memory_swap_events_max_total",
+		"container_memory_swap_events_fail_total",
 	}
 
 	for _, name := range memoryMetrics {
@@ -289,6 +292,9 @@ func TestMetricsHaveCorrectTypes(t *testing.T) {
 		"container_network_transmit_bytes_total",
 		"container_memory_events_high_total",
 		"container_memory_events_max_total",
+		"container_memory_swap_events_high_total",
+		"container_memory_swap_events_max_total",
+		"container_memory_swap_events_fail_total",
 	}
 	for _, name := range counterMetrics {
 		if mf, ok := families[name]; ok {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -533,6 +533,27 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 					return metricValues{{value: float64(s.Memory.Events.Max), timestamp: s.Timestamp}}
 				},
 			}, {
+				name:      "container_memory_swap_events_high_total",
+				help:      "Cumulative count of memory.swap.high throttle events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.SwapEvents.High), timestamp: s.Timestamp}}
+				},
+			}, {
+				name:      "container_memory_swap_events_max_total",
+				help:      "Cumulative count of memory.swap.max limit hit events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.SwapEvents.Max), timestamp: s.Timestamp}}
+				},
+			}, {
+				name:      "container_memory_swap_events_fail_total",
+				help:      "Cumulative count of swap allocation failures for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.SwapEvents.Fail), timestamp: s.Timestamp}}
+				},
+			}, {
 				name:      "container_memory_file_dirty_bytes",
 				help:      "Number of bytes of file cache that has been modified but not yet written back to disk.",
 				valueType: prometheus.GaugeValue,

--- a/metrics/prometheus_fake.go
+++ b/metrics/prometheus_fake.go
@@ -399,6 +399,11 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 							High: 42,
 							Max:  5,
 						},
+						SwapEvents: info.SwapEvents{
+							High: 8,
+							Max:  6,
+							Fail: 7,
+						},
 					},
 					Hugetlb: map[string]info.HugetlbStats{
 						"2Mi": {

--- a/metrics/testdata/prometheus_metrics
+++ b/metrics/testdata/prometheus_metrics
@@ -169,6 +169,15 @@ container_memory_events_high_total{container_env_foo_env="prod",container_label_
 # HELP container_memory_events_max_total Cumulative count of memory.max limit hit events for the container
 # TYPE container_memory_events_max_total counter
 container_memory_events_max_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5 1395066363000
+# HELP container_memory_swap_events_high_total Cumulative count of memory.swap.high throttle events for the container
+# TYPE container_memory_swap_events_high_total counter
+container_memory_swap_events_high_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8 1395066363000
+# HELP container_memory_swap_events_max_total Cumulative count of memory.swap.max limit hit events for the container
+# TYPE container_memory_swap_events_max_total counter
+container_memory_swap_events_max_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 6 1395066363000
+# HELP container_memory_swap_events_fail_total Cumulative count of swap allocation failures for the container
+# TYPE container_memory_swap_events_fail_total counter
+container_memory_swap_events_fail_total{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 7 1395066363000
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
 container_memory_failcnt{container_env_foo_env="prod",container_label_foo_label="bar",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0 1395066363000

--- a/metrics/testdata/prometheus_metrics_whitelist_filtered
+++ b/metrics/testdata/prometheus_metrics_whitelist_filtered
@@ -169,6 +169,15 @@ container_memory_events_high_total{container_env_foo_env="prod",id="testcontaine
 # HELP container_memory_events_max_total Cumulative count of memory.max limit hit events for the container
 # TYPE container_memory_events_max_total counter
 container_memory_events_max_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 5 1395066363000
+# HELP container_memory_swap_events_high_total Cumulative count of memory.swap.high throttle events for the container
+# TYPE container_memory_swap_events_high_total counter
+container_memory_swap_events_high_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 8 1395066363000
+# HELP container_memory_swap_events_max_total Cumulative count of memory.swap.max limit hit events for the container
+# TYPE container_memory_swap_events_max_total counter
+container_memory_swap_events_max_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 6 1395066363000
+# HELP container_memory_swap_events_fail_total Cumulative count of swap allocation failures for the container
+# TYPE container_memory_swap_events_fail_total counter
+container_memory_swap_events_fail_total{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 7 1395066363000
 # HELP container_memory_failcnt Number of memory usage hits limits
 # TYPE container_memory_failcnt counter
 container_memory_failcnt{container_env_foo_env="prod",id="testcontainer",image="test",name="testcontaineralias",zone_name="hello"} 0 1395066363000


### PR DESCRIPTION
**What:**
Exposes the three memory.swap.events counters from cgroup v2 as Prometheus metrics:

- `container_memory_swap_events_high_total` - times swap usage crossed the memory.swap.high throttle threshold
- `container_memory_swap_events_max_total` - times a swap allocation was rejected because memory.swap.max would be exceeded
- `container_memory_swap_events_fail_total` - times a swap allocation failed (hit memory.swap.max or the system ran out of swap)

Also backfills the docs for the existing `container_memory_events_high_total` / `container_memory_events_max_total` metrics, which were added previously but never documented.

**Why:**
`cAdvisor` already publishes `memory.events (high/max)` and some additional metrics in https://github.com/google/cadvisor/pull/3889, but there's no visibility into swap pressure. 

When a container is being throttled on swap or having swap allocations denied, the only signal today is indirect (rising swap usage). That's a production-proven implementation.