### PR TITLE
docker: collect fs stats for overlayfs storage driver

### DIFF
--- a/container/docker/fs.go
+++ b/container/docker/fs.go
@@ -54,7 +54,7 @@ func FsStats(
 		switch storageDriver {
 		case DevicemapperStorageDriver:
 			device = poolName
-		case AufsStorageDriver, OverlayStorageDriver, Overlay2StorageDriver, VfsStorageDriver:
+		case AufsStorageDriver, OverlayStorageDriver, Overlay2StorageDriver, ContainerdSnapshotterStorageDriver, VfsStorageDriver:
 			deviceInfo, err := globalFsInfo.GetDirFsDevice(rootfsStorageDir)
 			if err != nil {
 				return fmt.Errorf("unable to determine device info for dir: %v: %v", rootfsStorageDir, err)


### PR DESCRIPTION
## What

Include `ContainerdSnapshotterStorageDriver` in Docker `FsStats()` disk usage handling.

## Why

#3709 added Docker containerd snapshotter support for the `overlayfs` storage driver by loading the container rootfs path from the containerd spec.

However, `container/docker/fs.go` still falls through the default branch for `ContainerdSnapshotterStorageDriver`, so `stats.Filesystem` is not populated. As a result, per-container `container_fs_*` metrics are missing even though the Docker container itself is discovered correctly.

## Testing

Manually verified on Docker 29.5+ with storage driver `overlayfs`:

- before: `container_fs_usage_bytes{name!=""}` was not emitted
- after: `container_fs_usage_bytes`, `container_fs_limit_bytes`, and inode metrics are emitted for Docker containers

Related to #3709 and #3860.