### PR TITLE
cpuload/netlink: report the real error and skip the reader on cgroup v2

### DIFF
--- a/utils/cpuload/netlink/netlink.go
+++ b/utils/cpuload/netlink/netlink.go
@@ -210,7 +210,7 @@ func verifyHeader(msg syscall.NetlinkMessage) error {
 	case syscall.NLMSG_ERROR:
 		buf := bytes.NewBuffer(msg.Data)
 		var errno int32
-		err := binary.Read(buf, Endian, errno)
+		err := binary.Read(buf, Endian, &errno)
 		if err != nil {
 			return err
 		}

--- a/utils/cpuload/netlink/reader.go
+++ b/utils/cpuload/netlink/reader.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	info "github.com/google/cadvisor/info/v1"
+	"github.com/opencontainers/cgroups"
 
 	"k8s.io/klog/v2"
 )
@@ -31,6 +32,14 @@ type NetlinkReader struct {
 }
 
 func New() (*NetlinkReader, error) {
+	if cgroups.IsCgroup2UnifiedMode() {
+		// CGROUPSTATS_CMD_GET (cgroupstats) is only implemented for cgroup v1:
+		// the kernel's cgroupstats_build() rejects a cgroup v2 dentry with EINVAL,
+		// and there is no v2 equivalent. Fail clearly here so the manager skips the
+		// reader instead of aborting every container's stats update per housekeeping.
+		return nil, fmt.Errorf("cgroupstats is only supported on cgroup v1; cannot read cpu load on the cgroup v2 unified hierarchy")
+	}
+
 	conn, err := newConnection()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a new connection: %s", err)


### PR DESCRIPTION
`--enable_load_reader` breaks all container stats on cgroup v2 — `CGROUPSTATS_CMD_GET` is cgroup-v1-only, so the kernel returns EINVAL for every cgroup and `updateStats` aborts, leaving `/metrics` with only `container_scrape_error`. Root-cause analysis in #3137.

- `verifyHeader`: pass `&errno` so an `NLMSG_ERROR` reports the real netlink error instead of masking it as "invalid type int32".
- `netlink.New()`: detect the cgroup v2 unified hierarchy and fail cleanly, so the manager skips the reader instead of breaking all container stats.

This doesn't make cpu-load work on v2 (no `cgroupstats` equivalent; PSI is the path noted in #3137) — it removes the footgun. Verified on a v2 host: `--enable_load_reader` no longer drops `/metrics` to scrape-error-only.
