### PR TITLE
deploy: add lib/go.mod to the image build's dependency cache

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /go/src/github.com/google/cadvisor
 
 # Cache Golang Dependencies for faster incremental builds
 ADD go.mod go.sum ./
+ADD lib/go.mod lib/go.sum ./lib/
 RUN go mod download
 ADD cmd/go.mod cmd/go.sum ./cmd/
 RUN cd cmd && go mod download


### PR DESCRIPTION
The container-image build fails at `go mod download`:

```
go: github.com/google/cadvisor/lib@v0.0.0 (replaced by ./lib): reading lib/go.mod: open /go/src/github.com/google/cadvisor/lib/go.mod: no such file or directory
```

The root `go.mod` replaces the `lib` submodule with `./lib`, so the dependency-cache step needs `lib/go.mod` present before `go mod download`. The `cmd` submodule was already handled this way; do the same for `lib`.

This broke the v0.60.0 image publish.
