### PR TITLE
crio: add retry to ContainerInfo call

### DIFF
--- a/lib/container/crio/client.go
+++ b/lib/container/crio/client.go
@@ -17,6 +17,7 @@ package crio
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -26,6 +27,11 @@ import (
 	"syscall"
 	"time"
 )
+
+// ErrContainerNotFound indicates that CRI-O does not yet know about the
+// requested container. This is expected during a short window after the
+// container cgroup is created but before CRI-O finishes registration.
+var ErrContainerNotFound = errors.New("container not found")
 
 var crioClientTimeout = flag.Duration("crio_client_timeout", time.Duration(0), "CRI-O client timeout. Default is no timeout.")
 
@@ -151,6 +157,9 @@ func (c *crioClientImpl) ContainerInfo(id string) (*ContainerInfo, error) {
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error finding container %s: status %d", id, resp.StatusCode)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("error finding container %s: %s: %w", id, string(respBody), ErrContainerNotFound)
 		}
 		return nil, fmt.Errorf("error finding container %s: status %d returned error %s", id, resp.StatusCode, string(respBody))
 	}

--- a/lib/container/crio/handler.go
+++ b/lib/container/crio/handler.go
@@ -18,10 +18,12 @@
 package crio
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/opencontainers/cgroups"
 
@@ -30,6 +32,8 @@ import (
 	containerlibcontainer "github.com/google/cadvisor/lib/container/libcontainer"
 	"github.com/google/cadvisor/lib/fs"
 	info "github.com/google/cadvisor/lib/model"
+
+	"k8s.io/klog/v2"
 )
 
 type crioContainerHandler struct {
@@ -108,9 +112,27 @@ func newCrioContainerHandler(
 	id := ContainerNameToCrioId(name)
 	pidKnown := true
 
-	cInfo, err := client.ContainerInfo(id)
-	if err != nil {
-		return nil, err
+	// Cgroup is created during container setup. When cadvisor sees the cgroup
+	// via inotify, the container may not be fully registered in CRI-O yet.
+	// Use retry+backoff to tolerate the race condition, mirroring the
+	// containerd handler's approach for the same issue.
+	var cInfo *ContainerInfo
+	backoff := 100 * time.Millisecond
+	retry := 5
+	for {
+		cInfo, err = client.ContainerInfo(id)
+		if err == nil && cInfo != nil {
+			break
+		}
+
+		if !errors.Is(err, ErrContainerNotFound) || retry == 0 {
+			return nil, err
+		}
+
+		klog.V(4).Infof("Container %s not yet registered in CRI-O, retrying (%d retries left): %v", id, retry, err)
+		retry--
+		time.Sleep(backoff)
+		backoff *= 2
 	}
 	if cInfo.Pid == 0 {
 		// If pid is not known yet, network related stats can not be retrieved by the


### PR DESCRIPTION
## Summary

When cadvisor detects a new container cgroup via inotify, the container may not yet be fully registered in CRI-O. This race condition causes `ContainerInfo` to return HTTP 404, which cadvisor treats as a fatal error and logs:

```
Failed to process watch event: Error finding container <id>: Status 404 returned error can't find the container with id <id>
```

This is the same race condition that the containerd handler already handles with a retry+backoff loop around `TaskPid` ([lib/container/containerd/handler.go, lines 94-118](https://github.com/google/cadvisor/blob/master/lib/container/containerd/handler.go#L94-L118)).

## Root Cause

1. cadvisor watches for new cgroups via inotify
2. CRI-O creates the container cgroup early during container setup
3. cadvisor sees the cgroup and immediately calls CRI-O's `/containers/<id>` API
4. CRI-O has not yet finished registering the container internally → returns HTTP 404
5. cadvisor logs this as a warning and fails to track the container

The race window is widened in environments using GPG-signed container images, where signature verification delays CRI-O's container registration.

## Fix

- Add an `ErrContainerNotFound` sentinel error in `client.go`
- Wrap HTTP 404 responses from CRI-O's `ContainerInfo` with the sentinel (using `%w`)
- Add a retry loop with exponential backoff (5 retries, 100ms initial, doubling) in `handler.go`'s `newCrioContainerHandler`, mirroring the existing containerd handler pattern
- Non-404 errors fail immediately without retry
- Added `klog.V(4)` logging for observability during retries

## Prior Work

Supersedes #3842 by @haircommander, which addressed the same issue but was closed as stale. This PR reimplements the same approach with the following improvements:
- Exported `ErrContainerNotFound` sentinel (vs unexported `errNotFound`)
- Fixed format string bug in error wrapping
- Added `klog.V(4)` retry logging for observability

cc @haircommander