### PR TITLE
lib/model: make ContainerStats sub-stats pointers to convey collection presence

### DIFF
--- a/container/docker/fs.go
+++ b/container/docker/fs.go
@@ -46,7 +46,7 @@ func FsStats(
 	}
 
 	if metrics.Has(container.DiskIOMetrics) {
-		common.AssignDeviceNamesToDiskStats((*common.MachineInfoNamer)(mi), &stats.DiskIo)
+		common.AssignDeviceNamesToDiskStats((*common.MachineInfoNamer)(mi), stats.DiskIo)
 	}
 
 	if metrics.Has(container.DiskUsageMetrics) {

--- a/container/podman/handler.go
+++ b/container/podman/handler.go
@@ -283,7 +283,7 @@ func (h *containerHandler) GetStats() (*info.ContainerStats, error) {
 	}
 
 	if !h.needNet() {
-		stats.Network = info.NetworkStats{}
+		stats.Network = nil
 	}
 
 	// Get filesystem stats.

--- a/info/v1/test/datagen.go
+++ b/info/v1/test/datagen.go
@@ -31,6 +31,8 @@ func GenerateRandomStats(numStats, numCores int, duration time.Duration) []*info
 	}
 	for i := 0; i < numStats; i++ {
 		stats := new(info.ContainerStats)
+		stats.Cpu = &info.CpuStats{}
+		stats.Memory = &info.MemoryStats{}
 		stats.Timestamp = currentTime
 		currentTime = currentTime.Add(duration)
 

--- a/info/v2/conversion.go
+++ b/info/v2/conversion.go
@@ -68,7 +68,7 @@ func MachineStatsFromV1(cont *v1.ContainerInfo) []MachineStats {
 			Timestamp: val.Timestamp,
 		}
 		if cont.Spec.HasCpu {
-			stat.Cpu = &val.Cpu
+			stat.Cpu = val.Cpu
 			cpuInst, err := InstCpuStats(last, val)
 			if err != nil {
 				klog.Warningf("Could not get instant cpu stats: %v", err)
@@ -78,9 +78,9 @@ func MachineStatsFromV1(cont *v1.ContainerInfo) []MachineStats {
 			last = val
 		}
 		if cont.Spec.HasMemory {
-			stat.Memory = &val.Memory
+			stat.Memory = val.Memory
 		}
-		if cont.Spec.HasNetwork {
+		if cont.Spec.HasNetwork && val.Network != nil {
 			stat.Network = &NetworkStats{
 				// FIXME: Use reflection instead.
 				Tcp:        TcpStat(val.Network.Tcp),
@@ -106,7 +106,7 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 			ReferencedMemory: val.ReferencedMemory,
 		}
 		if spec.HasCpu {
-			stat.Cpu = &val.Cpu
+			stat.Cpu = val.Cpu
 			cpuInst, err := InstCpuStats(last, val)
 			if err != nil {
 				klog.Warningf("Could not get instant cpu stats: %v", err)
@@ -116,12 +116,12 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 			last = val
 		}
 		if spec.HasMemory {
-			stat.Memory = &val.Memory
+			stat.Memory = val.Memory
 		}
 		if spec.HasHugetlb {
 			stat.Hugetlb = &val.Hugetlb
 		}
-		if spec.HasNetwork {
+		if spec.HasNetwork && val.Network != nil {
 			// TODO: Handle TcpStats
 			stat.Network = &NetworkStats{
 				Tcp:        TcpStat(val.Network.Tcp),
@@ -130,7 +130,7 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 			}
 		}
 		if spec.HasProcesses {
-			stat.Processes = &val.Processes
+			stat.Processes = val.Processes
 		}
 		if spec.HasFilesystem {
 			if len(val.Filesystem) == 1 {
@@ -145,7 +145,7 @@ func ContainerStatsFromV1(containerName string, spec *v1.ContainerSpec, stats []
 			}
 		}
 		if spec.HasDiskIo {
-			stat.DiskIo = &val.DiskIo
+			stat.DiskIo = val.DiskIo
 		}
 		if spec.HasCustomMetrics {
 			stat.CustomMetrics = val.CustomMetrics
@@ -184,7 +184,7 @@ func DeprecatedStatsFromV1(cont *v1.ContainerInfo) []DeprecatedContainerStats {
 			ReferencedMemory: val.ReferencedMemory,
 		}
 		if stat.HasCpu {
-			stat.Cpu = val.Cpu
+			stat.Cpu = *val.Cpu
 			cpuInst, err := InstCpuStats(last, val)
 			if err != nil {
 				klog.Warningf("Could not get instant cpu stats: %v", err)
@@ -194,22 +194,22 @@ func DeprecatedStatsFromV1(cont *v1.ContainerInfo) []DeprecatedContainerStats {
 			last = val
 		}
 		if stat.HasMemory {
-			stat.Memory = val.Memory
+			stat.Memory = *val.Memory
 		}
 		if stat.HasHugetlb {
 			stat.Hugetlb = val.Hugetlb
 		}
-		if stat.HasNetwork {
+		if stat.HasNetwork && val.Network != nil {
 			stat.Network.Interfaces = val.Network.Interfaces
 		}
 		if stat.HasProcesses {
-			stat.Processes = val.Processes
+			stat.Processes = *val.Processes
 		}
 		if stat.HasFilesystem {
 			stat.Filesystem = val.Filesystem
 		}
 		if stat.HasDiskIo {
-			stat.DiskIo = val.DiskIo
+			stat.DiskIo = *val.DiskIo
 		}
 		if stat.HasCustomMetrics {
 			stat.CustomMetrics = val.CustomMetrics

--- a/info/v2/conversion_test.go
+++ b/info/v2/conversion_test.go
@@ -139,7 +139,7 @@ func TestContainerStatsFromV1(t *testing.T) {
 	}
 	v1Stats := v1.ContainerStats{
 		Timestamp: timestamp,
-		Memory: v1.MemoryStats{
+		Memory: &v1.MemoryStats{
 			Usage:             1,
 			Cache:             2,
 			RSS:               3,
@@ -156,7 +156,7 @@ func TestContainerStatsFromV1(t *testing.T) {
 				Pgmajfault: 20,
 			},
 		},
-		Network: v1.NetworkStats{
+		Network: &v1.NetworkStats{
 			InterfaceStats: v1.InterfaceStats{
 				Name:      "",
 				RxBytes:   1,
@@ -180,7 +180,7 @@ func TestContainerStatsFromV1(t *testing.T) {
 				TxDropped: 80,
 			}},
 		},
-		Processes: v1.ProcessStats{
+		Processes: &v1.ProcessStats{
 			ProcessCount:   5,
 			FdCount:        1,
 			ThreadsCurrent: 66,
@@ -262,11 +262,11 @@ func TestContainerStatsFromV1(t *testing.T) {
 	}
 	expectedV2Stats := ContainerStats{
 		Timestamp: timestamp,
-		Cpu:       &v1Stats.Cpu,
-		DiskIo:    &v1Stats.DiskIo,
-		Memory:    &v1Stats.Memory,
+		Cpu:       v1Stats.Cpu,
+		DiskIo:    v1Stats.DiskIo,
+		Memory:    v1Stats.Memory,
 		Hugetlb:   &v1Stats.Hugetlb,
-		Processes: &v1Stats.Processes,
+		Processes: v1Stats.Processes,
 		Network: &NetworkStats{
 			Interfaces: v1Stats.Network.Interfaces,
 		},
@@ -326,7 +326,7 @@ func TestInstCpuStats(t *testing.T) {
 		{
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						PerCpu: []uint64{100, 200},
 					},
@@ -334,7 +334,7 @@ func TestInstCpuStats(t *testing.T) {
 			},
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0).Add(time.Second),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						PerCpu: []uint64{100, 200, 300},
 					},
@@ -346,7 +346,7 @@ func TestInstCpuStats(t *testing.T) {
 		{
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						Total:  300,
 						PerCpu: []uint64{100, 200},
@@ -357,7 +357,7 @@ func TestInstCpuStats(t *testing.T) {
 			},
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0).Add(time.Second),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						Total:  200,
 						PerCpu: []uint64{100, 100},
@@ -372,7 +372,7 @@ func TestInstCpuStats(t *testing.T) {
 		{
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						Total:  300,
 						PerCpu: []uint64{100, 200},
@@ -383,7 +383,7 @@ func TestInstCpuStats(t *testing.T) {
 			},
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0).Add(time.Second),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						Total:  500,
 						PerCpu: []uint64{200, 300},
@@ -405,7 +405,7 @@ func TestInstCpuStats(t *testing.T) {
 		{
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						Total:  300,
 						PerCpu: []uint64{100, 200},
@@ -416,7 +416,7 @@ func TestInstCpuStats(t *testing.T) {
 			},
 			&v1.ContainerStats{
 				Timestamp: time.Unix(100, 0).Add(2 * time.Second),
-				Cpu: v1.CpuStats{
+				Cpu: &v1.CpuStats{
 					Usage: v1.CpuUsage{
 						Total:  500,
 						PerCpu: []uint64{200, 300},

--- a/integration/tests/api/test_utils.go
+++ b/integration/tests/api/test_utils.go
@@ -45,7 +45,7 @@ func inDelta(t *testing.T, expected, actual, delta uint64, description string) {
 }
 
 // Checks that CPU stats are valid.
-func checkCPUStats(t *testing.T, stat info.CpuStats) {
+func checkCPUStats(t *testing.T, stat *info.CpuStats) {
 	assert := assert.New(t)
 
 	assert.NotEqual(0, stat.Usage.Total, "Total CPU usage should not be zero")
@@ -66,7 +66,7 @@ func checkCPUStats(t *testing.T, stat info.CpuStats) {
 	// TODO(rjnagal): Add verification for cpu load.
 }
 
-func checkMemoryStats(t *testing.T, stat info.MemoryStats) {
+func checkMemoryStats(t *testing.T, stat *info.MemoryStats) {
 	assert := assert.New(t)
 
 	assert.NotEqual(0, stat.Usage, "Memory usage should not be zero")

--- a/integration/tests/crio/test_utils.go
+++ b/integration/tests/crio/test_utils.go
@@ -45,7 +45,7 @@ func inDelta(t *testing.T, expected, actual, delta uint64, description string) {
 }
 
 // Checks that CPU stats are valid.
-func checkCPUStats(t *testing.T, stat info.CpuStats) {
+func checkCPUStats(t *testing.T, stat *info.CpuStats) {
 	assert := assert.New(t)
 
 	assert.NotEqual(0, stat.Usage.Total, "Total CPU usage should not be zero")
@@ -65,7 +65,7 @@ func checkCPUStats(t *testing.T, stat info.CpuStats) {
 	inDelta(t, stat.Usage.Total, stat.Usage.User+stat.Usage.System, uint64((500 * time.Millisecond).Nanoseconds()), "User + system CPU usage")
 }
 
-func checkMemoryStats(t *testing.T, stat info.MemoryStats) {
+func checkMemoryStats(t *testing.T, stat *info.MemoryStats) {
 	assert := assert.New(t)
 
 	assert.NotEqual(0, stat.Usage, "Memory usage should not be zero")

--- a/lib/cache/memory/memory_test.go
+++ b/lib/cache/memory/memory_test.go
@@ -37,7 +37,7 @@ var (
 func makeStat(i int) *info.ContainerStats {
 	return &info.ContainerStats{
 		Timestamp: zero.Add(time.Duration(i) * time.Second),
-		Cpu: info.CpuStats{
+		Cpu: &info.CpuStats{
 			LoadAverage: int32(i),
 		},
 	}

--- a/lib/container/containerd/handler.go
+++ b/lib/container/containerd/handler.go
@@ -205,7 +205,7 @@ func (h *containerdContainerHandler) getFsStats(stats *info.ContainerStats) erro
 	}
 
 	if h.includedMetrics.Has(container.DiskIOMetrics) {
-		common.AssignDeviceNamesToDiskStats((*common.MachineInfoNamer)(mi), &stats.DiskIo)
+		common.AssignDeviceNamesToDiskStats((*common.MachineInfoNamer)(mi), stats.DiskIo)
 	}
 	return nil
 }

--- a/lib/container/crio/handler.go
+++ b/lib/container/crio/handler.go
@@ -239,7 +239,7 @@ func (h *crioContainerHandler) getFsStats(stats *info.ContainerStats) error {
 	}
 
 	if h.includedMetrics.Has(container.DiskIOMetrics) {
-		common.AssignDeviceNamesToDiskStats((*common.MachineInfoNamer)(mi), &stats.DiskIo)
+		common.AssignDeviceNamesToDiskStats((*common.MachineInfoNamer)(mi), stats.DiskIo)
 	}
 
 	if !h.includedMetrics.Has(container.DiskUsageMetrics) {
@@ -310,7 +310,7 @@ func (h *crioContainerHandler) GetStats() (*info.ContainerStats, error) {
 		return stats, err
 	}
 
-	if h.includedMetrics.Has(container.NetworkUsageMetrics) && len(stats.Network.Interfaces) == 0 {
+	if h.includedMetrics.Has(container.NetworkUsageMetrics) && (stats.Network == nil || len(stats.Network.Interfaces) == 0) {
 		// No network related information indicates that the pid of the
 		// container is not longer valid and we need to ask crio to
 		// provide the pid of another container from that pod

--- a/lib/container/libcontainer/handler.go
+++ b/lib/container/libcontainer/handler.go
@@ -119,6 +119,7 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 
 	// If we know the pid then get network stats from /proc/<pid>/net/dev
 	if h.pid > 0 {
+		stats.Network = &info.NetworkStats{}
 		if h.includedMetrics.Has(container.NetworkUsageMetrics) {
 			netStats, err := networkStatsFromProc(h.rootFs, h.pid)
 			if err != nil {
@@ -171,13 +172,16 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 	// file descriptors etc.) and not required a proper container's
 	// root PID (systemd services don't have the root PID atm)
 	if h.includedMetrics.Has(container.ProcessMetrics) {
+		stats.Processes = &info.ProcessStats{}
 		path, ok := common.GetControllerPath(h.cgroupManager.GetPaths(), "cpu", cgroups.IsCgroup2UnifiedMode())
 		if !ok {
 			klog.V(4).Infof("Could not find cgroups CPU for container %d", h.pid)
 		} else {
-			stats.Processes, err = processStatsFromProcs(h.rootFs, path, h.pid)
-			if err != nil {
-				klog.V(4).Infof("Unable to get Process Stats: %v", err)
+			ps, perr := processStatsFromProcs(h.rootFs, path, h.pid)
+			if perr != nil {
+				klog.V(4).Infof("Unable to get Process Stats: %v", perr)
+			} else {
+				*stats.Processes = ps
 			}
 		}
 
@@ -186,7 +190,7 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 	}
 
 	// For backwards compatibility.
-	if len(stats.Network.Interfaces) > 0 {
+	if stats.Network != nil && len(stats.Network.Interfaces) > 0 {
 		stats.Network.InterfaceStats = stats.Network.Interfaces[0]
 	}
 
@@ -770,6 +774,9 @@ func (h *Handler) GetProcesses() ([]int, error) {
 
 // Convert libcontainer stats to info.ContainerStats.
 func setCPUStats(s *cgroups.Stats, ret *info.ContainerStats, withPerCPU bool) {
+	if ret.Cpu == nil {
+		ret.Cpu = &info.CpuStats{}
+	}
 	ret.Cpu.Usage.User = s.CpuStats.CpuUsage.UsageInUsermode
 	ret.Cpu.Usage.System = s.CpuStats.CpuUsage.UsageInKernelmode
 	ret.Cpu.Usage.Total = s.CpuStats.CpuUsage.TotalUsage
@@ -792,6 +799,9 @@ func setCPUStats(s *cgroups.Stats, ret *info.ContainerStats, withPerCPU bool) {
 }
 
 func setDiskIoStats(s *cgroups.Stats, ret *info.ContainerStats) {
+	if ret.DiskIo == nil {
+		ret.DiskIo = &info.DiskIoStats{}
+	}
 	ret.DiskIo.IoServiceBytes = diskStatsCopy(s.BlkioStats.IoServiceBytesRecursive)
 	ret.DiskIo.IoServiced = diskStatsCopy(s.BlkioStats.IoServicedRecursive)
 	ret.DiskIo.IoQueued = diskStatsCopy(s.BlkioStats.IoQueuedRecursive)
@@ -808,6 +818,9 @@ func setDiskIoStats(s *cgroups.Stats, ret *info.ContainerStats) {
 }
 
 func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
+	if ret.Memory == nil {
+		ret.Memory = &info.MemoryStats{}
+	}
 	ret.Memory.Usage = s.MemoryStats.Usage.Usage
 	ret.Memory.MaxUsage = s.MemoryStats.Usage.MaxUsage
 	ret.Memory.Failcnt = s.MemoryStats.Usage.Failcnt
@@ -887,6 +900,9 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 }
 
 func setMemoryEvents(cgroupPath string, ret *info.ContainerStats) {
+	if ret.Memory == nil {
+		ret.Memory = &info.MemoryStats{}
+	}
 	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "high"); err == nil {
 		ret.Memory.Events.High = val
 	}
@@ -908,6 +924,9 @@ func getNumaStats(memoryStats map[uint8]uint64) map[uint8]uint64 {
 }
 
 func setMemoryNumaStats(s *cgroups.Stats, ret *info.ContainerStats) {
+	if ret.Memory == nil {
+		ret.Memory = &info.MemoryStats{}
+	}
 	ret.Memory.ContainerData.NumaStats.File = getNumaStats(s.MemoryStats.PageUsageByNUMA.File.Nodes)
 	ret.Memory.ContainerData.NumaStats.Anon = getNumaStats(s.MemoryStats.PageUsageByNUMA.Anon.Nodes)
 	ret.Memory.ContainerData.NumaStats.Unevictable = getNumaStats(s.MemoryStats.PageUsageByNUMA.Unevictable.Nodes)
@@ -947,6 +966,9 @@ func setPSIStats(s *cgroups.PSIStats, ret *info.PSIStats) {
 // read from pids path not cpu
 func setThreadsStats(s *cgroups.Stats, ret *info.ContainerStats) {
 	if s != nil {
+		if ret.Processes == nil {
+			ret.Processes = &info.ProcessStats{}
+		}
 		ret.Processes.ThreadsCurrent = s.PidsStats.Current
 		ret.Processes.ThreadsMax = s.PidsStats.Limit
 	}
@@ -955,11 +977,15 @@ func setThreadsStats(s *cgroups.Stats, ret *info.ContainerStats) {
 func newContainerStats(cgroupStats *cgroups.Stats, includedMetrics container.MetricSet) *info.ContainerStats {
 	ret := &info.ContainerStats{
 		Timestamp: time.Now(),
+		// Cpu and Memory are always collected, so they are always present.
+		Cpu:    &info.CpuStats{},
+		Memory: &info.MemoryStats{},
 	}
 
 	if s := cgroupStats; s != nil {
 		setCPUStats(s, ret, includedMetrics.Has(container.PerCpuUsageMetrics))
 		if includedMetrics.Has(container.DiskIOMetrics) {
+			ret.DiskIo = &info.DiskIoStats{}
 			setDiskIoStats(s, ret)
 		}
 		setMemoryStats(s, ret)

--- a/lib/container/libcontainer/handler_test.go
+++ b/lib/container/libcontainer/handler_test.go
@@ -133,7 +133,7 @@ func TestSetCPUStats(t *testing.T) {
 	setCPUStats(s, &ret, true)
 
 	expected := info.ContainerStats{
-		Cpu: info.CpuStats{
+		Cpu: &info.CpuStats{
 			Usage: info.CpuUsage{
 				PerCpu: perCPUUsage,
 				User:   s.CpuStats.CpuUsage.UsageInUsermode,
@@ -200,7 +200,7 @@ func TestSetMemoryStats(t *testing.T) {
 
 func TestSetProcessesStats(t *testing.T) {
 	ret := info.ContainerStats{
-		Processes: info.ProcessStats{
+		Processes: &info.ProcessStats{
 			ProcessCount: 1,
 			FdCount:      2,
 		},
@@ -215,7 +215,7 @@ func TestSetProcessesStats(t *testing.T) {
 
 	expected := info.ContainerStats{
 
-		Processes: info.ProcessStats{
+		Processes: &info.ProcessStats{
 			ProcessCount:   1,
 			FdCount:        2,
 			ThreadsCurrent: s.PidsStats.Current,

--- a/lib/container/raw/handler.go
+++ b/lib/container/raw/handler.go
@@ -222,7 +222,7 @@ func (h *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 	}
 
 	if h.includedMetrics.Has(container.DiskIOMetrics) {
-		common.AssignDeviceNamesToDiskStats(&fsNamer{fs: filesystems, factory: h.machineInfoFactory}, &stats.DiskIo)
+		common.AssignDeviceNamesToDiskStats(&fsNamer{fs: filesystems, factory: h.machineInfoFactory}, stats.DiskIo)
 
 	}
 	return nil

--- a/lib/container/raw/handler_test.go
+++ b/lib/container/raw/handler_test.go
@@ -534,13 +534,13 @@ func TestGetFsStats(t *testing.T) {
 				externalMounts:     c.externalMounts,
 				machineInfoFactory: machineInfo{},
 			}
-			stats := &info.ContainerStats{DiskIo: c.diskIO}
+			stats := &info.ContainerStats{DiskIo: &c.diskIO}
 			err := handler.getFsStats(stats)
 
 			assert.NoError(t, err)
 			assert.Len(t, stats.Filesystem, len(c.expectedFilesystems))
 			assert.Equal(t, c.expectedFilesystems, stats.Filesystem)
-			assert.Equal(t, c.expectedDiskIO, stats.DiskIo)
+			assert.Equal(t, c.expectedDiskIO, *stats.DiskIo)
 		})
 	}
 }

--- a/lib/metrics/prometheus.go
+++ b/lib/metrics/prometheus.go
@@ -151,6 +151,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative user cpu time consumed in seconds.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Cpu.Usage.User) / float64(time.Second),
@@ -163,6 +166,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative system cpu time consumed in seconds.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Cpu.Usage.System) / float64(time.Second),
@@ -176,6 +182,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"cpu"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					if len(s.Cpu.Usage.PerCpu) == 0 {
 						if s.Cpu.Usage.Total > 0 {
 							return metricValues{{
@@ -203,6 +212,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType: prometheus.CounterValue,
 				condition: func(s info.ContainerSpec) bool { return s.Cpu.Quota != 0 },
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Cpu.CFS.Periods),
@@ -215,6 +227,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType: prometheus.CounterValue,
 				condition: func(s info.ContainerSpec) bool { return s.Cpu.Quota != 0 },
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Cpu.CFS.ThrottledPeriods),
@@ -227,6 +242,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType: prometheus.CounterValue,
 				condition: func(s info.ContainerSpec) bool { return s.Cpu.Quota != 0 },
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Cpu.CFS.ThrottledTime) / float64(time.Second),
@@ -239,6 +257,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType: prometheus.CounterValue,
 				condition: func(s info.ContainerSpec) bool { return s.Cpu.Quota != 0 },
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Cpu.CFS.BurstsPeriods),
@@ -251,6 +272,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType: prometheus.CounterValue,
 				condition: func(s info.ContainerSpec) bool { return s.Cpu.Quota != 0 },
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Cpu.CFS.BurstTime) / float64(time.Second),
@@ -267,6 +291,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Time duration the processes of the container have run on the CPU.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{{
 						value:     float64(s.Cpu.Schedstat.RunTime) / float64(time.Second),
 						timestamp: s.Timestamp,
@@ -277,6 +304,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Time duration processes of the container have been waiting on a runqueue.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{{
 						value:     float64(s.Cpu.Schedstat.RunqueueTime) / float64(time.Second),
 						timestamp: s.Timestamp,
@@ -287,6 +317,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of times processes of the cgroup have run on the cpu",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{{
 						value:     float64(s.Cpu.Schedstat.RunPeriods),
 						timestamp: s.Timestamp,
@@ -302,6 +335,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Value of container cpu load average over the last 10 seconds.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Cpu.LoadAverage), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -309,6 +345,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Value of container cpu load.d average over the last 10 seconds.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Cpu.LoadDAverage), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -409,6 +448,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of bytes of page cache memory.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.Cache), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -416,6 +458,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Size of RSS in bytes.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.RSS), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -423,6 +468,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Size of kernel memory allocated in bytes.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.KernelUsage), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -430,6 +478,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Size of memory mapped files in bytes.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.MappedFile), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -437,6 +488,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Container swap usage in bytes.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.Swap), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -444,6 +498,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of memory usage hits limits",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{
 						value:     float64(s.Memory.Failcnt),
 						timestamp: s.Timestamp,
@@ -454,6 +511,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Current memory usage in bytes, including all memory regardless of when it was accessed",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.Usage), timestamp: s.Timestamp}}
 				},
 			},
@@ -462,6 +522,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Maximum memory usage recorded in bytes",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.MaxUsage), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -469,6 +532,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Current working set in bytes.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.WorkingSet), timestamp: s.Timestamp}}
 				},
 			},
@@ -477,6 +543,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Current total active file in bytes.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.TotalActiveFile), timestamp: s.Timestamp}}
 				},
 			},
@@ -485,6 +554,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Current total inactive file in bytes.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.TotalInactiveFile), timestamp: s.Timestamp}}
 				},
 			},
@@ -494,6 +566,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"failure_type", "scope"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Memory.ContainerData.Pgfault),
@@ -522,6 +597,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative count of memory.high throttle events for the container",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.Events.High), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -529,6 +607,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative count of memory.max limit hit events for the container",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.Events.Max), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -536,6 +617,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of bytes of file cache that has been modified but not yet written back to disk.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.FileDirty), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -543,6 +627,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of bytes of file cache that is currently being written back to disk.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.FileWriteback), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -550,6 +637,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative number of pages scanned by the page reclaim algorithm.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.Pgscan), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -557,6 +647,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative number of pages reclaimed by the page reclaim algorithm.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.Pgsteal), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -564,6 +657,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative number of refaults of previously evicted file pages.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.WorkingsetRefaultFile), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -571,6 +667,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Cumulative number of refaults of previously evicted anonymous pages.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Memory.WorkingsetRefaultAnon), timestamp: s.Timestamp}}
 				},
 			},
@@ -594,6 +693,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"type", "scope", "node"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					values := make(metricValues, 0)
 					values = append(values, getNumaStatsPerNode(s.Memory.ContainerData.NumaStats.File,
 						[]string{"file", "container"}, s.Timestamp)...)
@@ -666,6 +768,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoServiceBytes, "Read", asFloat64,
 						nil, nil,
@@ -678,6 +783,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoServiced, "Read", asFloat64,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -692,6 +800,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.Sectors, "Read", asFloat64,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -706,6 +817,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoMerged, "Read", asFloat64,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -720,6 +834,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoServiceTime, "Read", asNanosecondsToSeconds,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -734,6 +851,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoServiceBytes, "Write", asFloat64,
 						nil, nil,
@@ -746,6 +866,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoServiced, "Write", asFloat64,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -760,6 +883,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.Sectors, "Write", asFloat64,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -774,6 +900,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoMerged, "Write", asFloat64,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -788,6 +917,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoServiceTime, "Write", asNanosecondsToSeconds,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -802,6 +934,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoQueued, "Total", asFloat64,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -816,6 +951,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoServiceTime, "Total", asNanosecondsToSeconds,
 						s.Filesystem, func(fs *info.FsStats) float64 {
@@ -840,6 +978,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoCostUsage, "Count", asMicrosecondsToSeconds,
 						[]info.FsStats{}, nil,
@@ -852,6 +993,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoCostWait, "Count", asMicrosecondsToSeconds,
 						[]info.FsStats{}, nil,
@@ -864,6 +1008,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoCostIndebt, "Count", asMicrosecondsToSeconds,
 						[]info.FsStats{}, nil,
@@ -876,6 +1023,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return ioValues(
 						s.DiskIo.IoCostIndelay, "Count", asMicrosecondsToSeconds,
 						[]info.FsStats{}, nil,
@@ -889,6 +1039,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"device", "major", "minor", "operation"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					var values metricValues
 					for _, diskStat := range s.DiskIo.IoServiceBytes {
 						for operation, value := range diskStat.Stats {
@@ -915,6 +1068,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -931,6 +1087,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -947,6 +1106,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -963,6 +1125,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -979,6 +1144,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -995,6 +1163,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -1011,6 +1182,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -1027,6 +1201,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"interface"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Network.Interfaces))
 					for _, value := range s.Network.Interfaces {
 						values = append(values, metricValue{
@@ -1048,6 +1225,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"tcp_state"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Network.Tcp.Established),
@@ -1115,6 +1295,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"tcp_state"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Network.Tcp6.Established),
@@ -1184,6 +1367,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"tcp_state"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Network.TcpAdvanced.RtoAlgorithm),
@@ -1595,6 +1781,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"udp_state"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Network.Udp6.Listen),
@@ -1627,6 +1816,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"udp_state"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Network == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Network.Udp.Listen),
@@ -1660,6 +1852,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of processes running inside the container.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Processes == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Processes.ProcessCount), timestamp: s.Timestamp}}
 				},
 			},
@@ -1668,6 +1863,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of open file descriptors for the container.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Processes == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Processes.FdCount), timestamp: s.Timestamp}}
 				},
 			},
@@ -1676,6 +1874,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of open sockets for the container.",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Processes == nil {
+						return nil
+					}
 					return metricValues{{value: float64(s.Processes.SocketCount), timestamp: s.Timestamp}}
 				},
 			},
@@ -1684,6 +1885,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Maximum number of threads allowed inside the container, infinity if value is zero",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Processes == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Processes.ThreadsMax),
@@ -1697,6 +1901,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Number of threads running inside the container",
 				valueType: prometheus.GaugeValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Processes == nil {
+						return nil
+					}
 					return metricValues{
 						{
 							value:     float64(s.Processes.ThreadsCurrent),
@@ -1711,6 +1918,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				valueType:   prometheus.GaugeValue,
 				extraLabels: []string{"ulimit"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Processes == nil {
+						return nil
+					}
 					values := make(metricValues, 0, len(s.Processes.Ulimits))
 					for _, ulimit := range s.Processes.Ulimits {
 						values = append(values, metricValue{
@@ -1891,6 +2101,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Total time duration no tasks in the container could make progress due to CPU congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{{value: asMicrosecondsToSeconds(s.Cpu.PSI.Full.Total), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -1898,6 +2111,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Total time duration tasks in the container have waited due to CPU congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Cpu == nil {
+						return nil
+					}
 					return metricValues{{value: asMicrosecondsToSeconds(s.Cpu.PSI.Some.Total), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -1905,6 +2121,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Total time duration no tasks in the container could make progress due to memory congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: asMicrosecondsToSeconds(s.Memory.PSI.Full.Total), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -1912,6 +2131,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Total time duration tasks in the container have waited due to memory congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.Memory == nil {
+						return nil
+					}
 					return metricValues{{value: asMicrosecondsToSeconds(s.Memory.PSI.Some.Total), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -1919,6 +2141,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Total time duration no tasks in the container could make progress due to IO congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return metricValues{{value: asMicrosecondsToSeconds(s.DiskIo.PSI.Full.Total), timestamp: s.Timestamp}}
 				},
 			}, {
@@ -1926,6 +2151,9 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 				help:      "Total time duration tasks in the container have waited due to IO congestion.",
 				valueType: prometheus.CounterValue,
 				getValues: func(s *info.ContainerStats) metricValues {
+					if s.DiskIo == nil {
+						return nil
+					}
 					return metricValues{{value: asMicrosecondsToSeconds(s.DiskIo.PSI.Some.Total), timestamp: s.Timestamp}}
 				},
 			},

--- a/lib/metrics/prometheus_fake_test.go
+++ b/lib/metrics/prometheus_fake_test.go
@@ -309,7 +309,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, info.R
 			Stats: []*info.ContainerStats{
 				{
 					Timestamp: time.Unix(1395066363, 0),
-					Cpu: info.CpuStats{
+					Cpu: &info.CpuStats{
 						Usage: info.CpuUsage{
 							Total:  1,
 							PerCpu: []uint64{2, 3, 4, 5},
@@ -345,7 +345,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, info.R
 							},
 						},
 					},
-					Memory: info.MemoryStats{
+					Memory: &info.MemoryStats{
 						Usage:                 8,
 						MaxUsage:              8,
 						WorkingSet:            9,
@@ -411,7 +411,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, info.R
 							Failcnt:  0,
 						},
 					},
-					Network: info.NetworkStats{
+					Network: &info.NetworkStats{
 						InterfaceStats: info.InterfaceStats{
 							Name:      "eth0",
 							RxBytes:   14,
@@ -576,7 +576,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, info.R
 							TxQueued: 0,
 						},
 					},
-					DiskIo: info.DiskIoStats{
+					DiskIo: &info.DiskIoStats{
 						IoServiceBytes: []info.PerDiskStats{{
 							Device: "/dev/sdb",
 							Major:  8,
@@ -685,7 +685,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, info.R
 							DutyCycle:   6,
 						},
 					},
-					Processes: info.ProcessStats{
+					Processes: &info.ProcessStats{
 						ProcessCount:   1,
 						FdCount:        5,
 						SocketCount:    3,

--- a/lib/metrics/prometheus_test.go
+++ b/lib/metrics/prometheus_test.go
@@ -359,7 +359,7 @@ func TestGetContainerHealthState(t *testing.T) {
 func TestIOCostMetrics(t *testing.T) {
 	containerStats := &info.ContainerStats{
 		Timestamp: time.Unix(1395066363, 0),
-		DiskIo: info.DiskIoStats{
+		DiskIo: &info.DiskIoStats{
 			IoCostUsage: []info.PerDiskStats{{
 				Device: "sda1",
 				Major:  8,
@@ -431,7 +431,7 @@ func TestIOCostMetrics(t *testing.T) {
 func TestCPUBurstMetrics(t *testing.T) {
 	containerStats := &info.ContainerStats{
 		Timestamp: time.Unix(1395066363, 0),
-		Cpu: info.CpuStats{
+		Cpu: &info.CpuStats{
 			CFS: info.CpuCFS{
 				BurstsPeriods: 25,
 				BurstTime:     500000000,

--- a/lib/model/container.go
+++ b/lib/model/container.go
@@ -1032,14 +1032,14 @@ type Health struct {
 type ContainerStats struct {
 	// The time of this stat point.
 	Timestamp time.Time `json:"timestamp"`
-	Cpu       CpuStats  `json:"cpu,omitempty"`
+	Cpu       *CpuStats `json:"cpu,omitempty"`
 	// Instantaneous CPU (nanocores/s). Linux: derived from two cumulative samples
 	// by expose/library; Windows: set directly by winstats. (design §6.1)
 	CpuInst *CpuInstStats           `json:"cpu_inst,omitempty"`
-	DiskIo  DiskIoStats             `json:"diskio,omitempty"`
-	Memory  MemoryStats             `json:"memory,omitempty"`
+	DiskIo  *DiskIoStats            `json:"diskio,omitempty"`
+	Memory  *MemoryStats            `json:"memory,omitempty"`
 	Hugetlb map[string]HugetlbStats `json:"hugetlb,omitempty"`
-	Network NetworkStats            `json:"network,omitempty"`
+	Network *NetworkStats           `json:"network,omitempty"`
 	// Filesystem statistics
 	Filesystem []FsStats `json:"filesystem,omitempty"`
 
@@ -1050,7 +1050,7 @@ type ContainerStats struct {
 	Accelerators []AcceleratorStats `json:"accelerators,omitempty"`
 
 	// ProcessStats for Containers
-	Processes ProcessStats `json:"processes,omitempty"`
+	Processes *ProcessStats `json:"processes,omitempty"`
 
 	// Custom metrics from all collectors
 	CustomMetrics map[string][]MetricVal `json:"custom_metrics,omitempty"`

--- a/lib/model/projection.go
+++ b/lib/model/projection.go
@@ -45,7 +45,7 @@ type RequestOptions struct {
 // consecutive cumulative samples. Folded in from info/v2: the collapse turns
 // v2's read-time derivations into model-owned projections (design §6.1).
 func InstCpuStats(last, cur *ContainerStats) (*CpuInstStats, error) {
-	if last == nil {
+	if last == nil || cur == nil || last.Cpu == nil || cur.Cpu == nil {
 		return nil, nil
 	}
 	if !cur.Timestamp.After(last.Timestamp) {

--- a/lib/model/test/datagen.go
+++ b/lib/model/test/datagen.go
@@ -31,6 +31,8 @@ func GenerateRandomStats(numStats, numCores int, duration time.Duration) []*info
 	}
 	for i := 0; i < numStats; i++ {
 		stats := new(info.ContainerStats)
+		stats.Cpu = &info.CpuStats{}
+		stats.Memory = &info.MemoryStats{}
 		stats.Timestamp = currentTime
 		currentTime = currentTime.Add(duration)
 


### PR DESCRIPTION
## What

Make the per-subsystem container stats in `lib/model.ContainerStats` — `Cpu`, `Memory`, `Network`, `DiskIo`, `Processes` — pointers again. They became value types when the kubelet-focused `lib` module collapsed the `info/v1`/`info/v2` types into a single `model` package (v0.60.0).

## Why

A value type cannot distinguish "this subsystem was not collected" from "it was collected and is zero". The kubelet, and cAdvisor's own v1/v2 REST API, rely on a nil to mean "not collected" — it is how, for example, the kubelet decides whether to fall back to CRI network stats, or whether a container is terminated. With value types that signal is lost. This restores the `info/v2` shape so a nil again means "not collected".

This is needed by the kubelet PR kubernetes/kubernetes#139870, where the loss of the absent-versus-zero distinction was raised in review.

## How

- Handlers allocate each pointer when they actually collect the subsystem (Cpu/Memory are always collected; DiskIo/Network/Processes under their existing metric gates). The `set*` helpers also self-allocate so they stay safe to call standalone.
- The prometheus metrics collector nil-guards every `getValues` closure that reads one of these fields.
- The v1/v2 REST converters (`info/v2/conversion.go`) and the docker and podman handlers are updated for the pointer fields.
- `Filesystem` stays a `[]FsStats` slice — the metrics collector iterates it per device — so callers that want the single-device rollup build it themselves (unchanged behavior).

## Testing

- `go test ./...` in `lib` passes.
- Built and ran the cAdvisor binary on x86_64 Linux: `/healthz` ok, `/metrics` ~10k lines (cpu/memory/network/fs/process families present), `/api/v1.3/containers` and `/api/v2.0/{stats,summary}` all HTTP 200, no panics — exercising the metric guards, handler allocations, and the model→v2 conversion against real cgroups (including ones without network/process stats).
