### PR TITLE
docker: keep metadata when containerd socket is unavailable

### DIFF
--- a/container/docker/factory.go
+++ b/container/docker/factory.go
@@ -355,10 +355,11 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics
 		}
 	}
 
-	if StorageDriver(dockerInfo.Driver) == ContainerdSnapshotterStorageDriver {
+	if StorageDriver(dockerInfo.Driver) == ContainerdSnapshotterStorageDriver && includedMetrics.Has(container.DiskUsageMetrics) {
 		containerdClient, err = containerd.Client(*containerd.ArgContainerdEndpoint, "moby")
 		if err != nil {
-			return fmt.Errorf("unable to create containerd client: %v", err)
+			klog.Warningf("Docker filesystem stats will not be reported: unable to create containerd client: %v", err)
+			includedMetrics = includedMetrics.Difference(container.MetricSet{container.DiskUsageMetrics: struct{}{}})
 		}
 	}
 

--- a/container/docker/handler.go
+++ b/container/docker/handler.go
@@ -125,7 +125,7 @@ func getRwLayerID(containerID, storageDir string, sd StorageDriver, dockerVersio
 
 // newContainerHandler returns a new container.ContainerHandler
 func newContainerHandler(
-	client *dclient.Client,
+	client dclient.APIClient,
 	containerdClient containerd.ContainerdClient,
 	name string,
 	machineInfoFactory info.MachineInfoFactory,
@@ -163,29 +163,34 @@ func newContainerHandler(
 	otherStorageDir := path.Join(storageDir, pathToContainersDir, id)
 
 	var rootfsStorageDir, zfsFilesystem, zfsParent string
-	if storageDriver == ContainerdSnapshotterStorageDriver {
-		ctx := namespaces.WithNamespace(context.Background(), "moby")
-		cntr, err := containerdClient.LoadContainer(ctx, id)
-		if err != nil {
-			return nil, err
-		}
+	if metrics.Has(container.DiskUsageMetrics) {
+		if storageDriver == ContainerdSnapshotterStorageDriver {
+			if containerdClient == nil {
+				return nil, fmt.Errorf("containerd client is required for Docker filesystem stats with %q storage driver", storageDriver)
+			}
+			ctx := namespaces.WithNamespace(context.Background(), "moby")
+			cntr, err := containerdClient.LoadContainer(ctx, id)
+			if err != nil {
+				return nil, err
+			}
 
-		var spec specs.Spec
-		if err := json.Unmarshal(cntr.Spec.Value, &spec); err != nil {
-			return nil, err
-		}
-		rootfsStorageDir = spec.Root.Path
-	} else {
-		rwLayerID, err := getRwLayerID(id, storageDir, storageDriver, dockerVersion)
-		if err != nil {
-			return nil, err
-		}
+			var spec specs.Spec
+			if err := json.Unmarshal(cntr.Spec.Value, &spec); err != nil {
+				return nil, err
+			}
+			rootfsStorageDir = spec.Root.Path
+		} else {
+			rwLayerID, err := getRwLayerID(id, storageDir, storageDriver, dockerVersion)
+			if err != nil {
+				return nil, err
+			}
 
-		// Determine the rootfs storage dir OR the pool name to determine the device.
-		// For devicemapper, we only need the thin pool name, and that is passed in to this call
-		rootfsStorageDir, zfsFilesystem, zfsParent, err = DetermineDeviceStorage(storageDriver, storageDir, rwLayerID)
-		if err != nil {
-			return nil, fmt.Errorf("unable to determine device storage: %v", err)
+			// Determine the rootfs storage dir OR the pool name to determine the device.
+			// For devicemapper, we only need the thin pool name, and that is passed in to this call
+			rootfsStorageDir, zfsFilesystem, zfsParent, err = DetermineDeviceStorage(storageDriver, storageDir, rwLayerID)
+			if err != nil {
+				return nil, fmt.Errorf("unable to determine device storage: %v", err)
+			}
 		}
 	}
 

--- a/container/docker/handler_test.go
+++ b/container/docker/handler_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/moby/moby/api/types/container"
 	dclient "github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	info "github.com/google/cadvisor/info/v1"
+	cadvisorcontainer "github.com/google/cadvisor/lib/container"
 	"github.com/google/cadvisor/lib/fs"
 )
 
@@ -158,6 +160,56 @@ func TestDockerEnvWhitelist(t *testing.T) {
 	as.Equal(newEnvsMatchWithEmptyPrefix, emptyExpected)
 	as.Equal(rawEnvsMatchWithEmptyWhitelist, emptyExpected)
 
+}
+
+func TestNewContainerHandlerAllowsContainerdSnapshotterWithoutDiskMetrics(t *testing.T) {
+	as := assert.New(t)
+
+	containerID := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	created := "2026-07-09T15:47:24.000000000Z"
+	client := &mockDockerClientForExitCode{
+		inspectResp: dclient.ContainerInspectResult{
+			Container: container.InspectResponse{
+				ID:   containerID,
+				Name: "/test-container",
+				Config: &container.Config{
+					Image:  "redis:7-alpine",
+					Labels: map[string]string{"com.docker.compose.service": "redis"},
+				},
+				HostConfig:      &container.HostConfig{},
+				NetworkSettings: &container.NetworkSettings{},
+				State: &container.State{
+					Pid: 1,
+				},
+				Created: created,
+			},
+		},
+	}
+
+	handler, err := newContainerHandler(
+		client,
+		nil,
+		"/docker/"+containerID,
+		nil,
+		nil,
+		ContainerdSnapshotterStorageDriver,
+		"/var/lib/docker",
+		map[string]string{},
+		true,
+		nil,
+		[]int{28, 5, 1},
+		cadvisorcontainer.MetricSet{cadvisorcontainer.CpuUsageMetrics: struct{}{}},
+		"",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	ref, err := handler.ContainerReference()
+	as.NoError(err)
+	as.Equal("test-container", ref.Aliases[0])
+
+	as.Equal("redis", handler.GetContainerLabels()["com.docker.compose.service"])
 }
 
 func TestAddDiskStatsCheck(t *testing.T) {


### PR DESCRIPTION

## Summary

Keep Docker metadata collection available when cAdvisor detects the
containerd snapshotter storage driver (`overlayfs`) but cannot connect to
the containerd socket.

This is a follow-up to #3709.

## Problem

In the reproduced Docker Desktop environment, the Docker API is available
through `/var/run/docker.sock` and reports `overlayfs` as the storage
driver, but `/run/containerd/containerd.sock` is not exposed to the
cAdvisor container.

cAdvisor currently treats failure to create the containerd client as a
Docker factory registration failure:

```text
Registration of the docker container factory failed:
unable to create containerd client:
containerd: cannot unix dial containerd api service:
dial unix /run/containerd/containerd.sock:
connect: no such file or directory
```

The raw cgroup handler continues to expose resource metrics, but Docker
metadata is unavailable because the Docker handler is never created.

Before this change, metrics only contained the cgroup path:

```text
container_last_seen{id="/docker/<container-id>"}
```

The container name, image, Docker labels, and Compose labels were missing.

## Fix

- Only create the containerd client when Docker disk usage metrics are enabled.
- If the containerd socket is unavailable, log a warning and disable
  `DiskUsageMetrics` for the Docker factory instead of aborting registration.
- Only resolve the container root filesystem when disk usage metrics are enabled.
- Continue creating Docker handlers so metadata can be collected through
  Docker `ContainerInspect`.
- Add a regression test covering an `overlayfs` Docker handler without a
  containerd client or disk usage metrics.

After this change, Docker factory registration succeeds and metadata is
restored:

```text
container_last_seen{
  id="/docker/<container-id>",
  name="cadvisor_label_test_backend",
  container_label_com_docker_compose_service="backend",
  container_label_test_role="backend"
}
```

## Degraded behavior

When the containerd socket is unavailable, per-container disk usage metrics
such as `container_fs_usage_bytes`, filesystem limits, and inode usage are
not reported.

CPU, memory, disk I/O, container names, images, and Docker/Compose labels
remain available.

## Testing

- `go test -count=1 ./container/docker`
- `cd lib && go test -count=1 ./container/... ./manager ./metrics`
- Built the cAdvisor image with `deploy/Dockerfile`
- Verified with Docker Desktop 28.5.1, cgroup v2, and the `overlayfs`
  storage driver
- Confirmed Docker factory registration succeeds after the containerd
  connection warning
- Confirmed `name`, image, Compose service, and custom Docker labels are
  present in Prometheus metrics
- Confirmed no panic or repeated stats collection errors

