### PR TITLE
lib/manager: allow disabling container discovery

### DIFF
--- a/lib/manager/manager.go
+++ b/lib/manager/manager.go
@@ -74,6 +74,7 @@ const (
 var HousekeepingConfigFlags = HousekeepingConfig{
 	flag.Duration("max_housekeeping_interval", 60*time.Second, "Largest interval to allow between container housekeepings"),
 	flag.Bool("allow_dynamic_housekeeping", true, "Whether to allow the housekeeping interval to be dynamic"),
+	false,
 }
 
 // The Manager interface defines operations for starting a manager and getting
@@ -157,6 +158,10 @@ type Manager interface {
 type HousekeepingConfig = struct {
 	Interval     *time.Duration
 	AllowDynamic *bool
+	// When set to true, the manager will not discover or watch for new
+	// containers. Only the root container ("/") is created at startup;
+	// other cgroup paths are created on demand when first queried.
+	DisableContainerDiscovery bool
 }
 
 // New takes a memory storage and returns a new manager.
@@ -208,6 +213,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, HousekeepingConfi
 		startupTime:                           time.Now(),
 		maxHousekeepingInterval:               *HousekeepingConfig.Interval,
 		allowDynamicHousekeeping:              *HousekeepingConfig.AllowDynamic,
+		disableContainerDiscovery:             HousekeepingConfig.DisableContainerDiscovery,
 		includedMetrics:                       includedMetricsSet,
 		containerWatchers:                     []watcher.ContainerWatcher{},
 		eventsChannel:                         eventsChannel,
@@ -291,21 +297,22 @@ func (c *containerMap) Range(f func(name namespacedContainerName, data *containe
 }
 
 type manager struct {
-	containers               containerMap
-	memoryCache              *memory.InMemoryCache
-	fsInfo                   fs.FsInfo
-	sysFs                    sysfs.SysFs
-	machineMu                sync.RWMutex // protects machineInfo
-	machineInfo              info.MachineInfo
-	quitChannels             []chan error
-	cadvisorContainer        string
-	inHostNamespace          bool
-	startupTime              time.Time
-	maxHousekeepingInterval  time.Duration
-	allowDynamicHousekeeping bool
-	includedMetrics          container.MetricSet
-	containerWatchers        []watcher.ContainerWatcher
-	eventsChannel            chan watcher.ContainerEvent
+	containers                containerMap
+	memoryCache               *memory.InMemoryCache
+	fsInfo                    fs.FsInfo
+	sysFs                     sysfs.SysFs
+	machineMu                 sync.RWMutex // protects machineInfo
+	machineInfo               info.MachineInfo
+	quitChannels              []chan error
+	cadvisorContainer         string
+	inHostNamespace           bool
+	startupTime               time.Time
+	maxHousekeepingInterval   time.Duration
+	allowDynamicHousekeeping  bool
+	disableContainerDiscovery bool
+	includedMetrics           container.MetricSet
+	containerWatchers         []watcher.ContainerWatcher
+	eventsChannel             chan watcher.ContainerEvent
 	// List of raw container cgroup path prefix whitelist.
 	rawContainerCgroupPathPrefixWhiteList []string
 	// List of container env prefix whitelist, the matched container envs would be collected into metrics as extra labels.
@@ -324,18 +331,22 @@ type manager struct {
 
 // Start the container manager.
 func (m *manager) Start() error {
-	m.containerWatchers = container.InitializePlugins(m, m.fsInfo, m.includedMetrics)
+	if !m.disableContainerDiscovery {
+		m.containerWatchers = container.InitializePlugins(m, m.fsInfo, m.includedMetrics)
+	}
 
 	err := raw.Register(m, m.fsInfo, m.includedMetrics, m.rawContainerCgroupPathPrefixWhiteList)
 	if err != nil {
 		klog.Errorf("Registration of the raw container factory failed: %v", err)
 	}
 
-	rawWatcher, err := raw.NewRawContainerWatcher(m.includedMetrics)
-	if err != nil {
-		return err
+	if !m.disableContainerDiscovery {
+		rawWatcher, err := raw.NewRawContainerWatcher(m.includedMetrics)
+		if err != nil {
+			return err
+		}
+		m.containerWatchers = append(m.containerWatchers, rawWatcher)
 	}
-	m.containerWatchers = append(m.containerWatchers, rawWatcher)
 
 	// If there are no factories, don't start any housekeeping and serve the information we do have.
 	if !container.HasFactories() {
@@ -347,25 +358,30 @@ func (m *manager) Start() error {
 	if err != nil {
 		return err
 	}
-	klog.V(2).Infof("Starting recovery of all containers")
-	err = m.detectSubcontainers("/")
-	if err != nil {
-		return err
-	}
-	klog.V(2).Infof("Recovery completed")
 
-	// Watch for new container.
-	quitWatcher := make(chan error)
-	err = m.watchForNewContainers(quitWatcher)
-	if err != nil {
-		return err
-	}
-	m.quitChannels = append(m.quitChannels, quitWatcher)
+	if !m.disableContainerDiscovery {
+		klog.V(2).Infof("Starting recovery of all containers")
+		err = m.detectSubcontainers("/")
+		if err != nil {
+			return err
+		}
+		klog.V(2).Infof("Recovery completed")
 
-	// Look for new containers in the main housekeeping thread.
-	quitGlobalHousekeeping := make(chan error)
-	m.quitChannels = append(m.quitChannels, quitGlobalHousekeeping)
-	go m.globalHousekeeping(quitGlobalHousekeeping)
+		// Watch for new container.
+		quitWatcher := make(chan error)
+		err = m.watchForNewContainers(quitWatcher)
+		if err != nil {
+			return err
+		}
+		m.quitChannels = append(m.quitChannels, quitWatcher)
+
+		// Look for new containers in the main housekeeping thread.
+		quitGlobalHousekeeping := make(chan error)
+		m.quitChannels = append(m.quitChannels, quitGlobalHousekeeping)
+		go m.globalHousekeeping(quitGlobalHousekeeping)
+	} else {
+		klog.V(2).Infof("Container discovery disabled; only root container will be tracked")
+	}
 
 	quitUpdateMachineInfo := make(chan error)
 	m.quitChannels = append(m.quitChannels, quitUpdateMachineInfo)
@@ -543,10 +559,21 @@ func (m *manager) containerDataToContainerInfo(cont *containerData, query *info.
 
 func (m *manager) getContainer(containerName string) (*containerData, error) {
 	cont, ok := m.containers.Load(namespacedContainerName{Name: containerName})
-	if !ok {
-		return nil, fmt.Errorf("unknown container %q", containerName)
+	if ok {
+		return cont, nil
 	}
-	return cont, nil
+
+	if m.disableContainerDiscovery {
+		if err := m.createContainer(containerName, watcher.Raw); err != nil {
+			return nil, fmt.Errorf("on-demand creation of container %q failed: %v", containerName, err)
+		}
+		cont, ok = m.containers.Load(namespacedContainerName{Name: containerName})
+		if ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unknown container %q", containerName)
 }
 
 func (m *manager) getSubcontainers(containerName string) map[string]*containerData {

--- a/lib/manager/manager_test.go
+++ b/lib/manager/manager_test.go
@@ -28,6 +28,7 @@ import (
 	itest "github.com/google/cadvisor/lib/model/test"
 	"github.com/google/cadvisor/lib/stats"
 	"github.com/google/cadvisor/lib/utils/sysfs/fakesysfs"
+	"github.com/google/cadvisor/lib/watcher"
 
 	"github.com/stretchr/testify/assert"
 
@@ -749,6 +750,84 @@ func (m *threadSafeEventHandler) AddEvent(e *info.Event) error {
 	defer m.mu.Unlock()
 	m.events = append(m.events, e)
 	return nil
+}
+
+// mockContainerHandlerFactory is a minimal ContainerHandlerFactory for testing
+// on-demand container creation without requiring real cgroup access.
+type mockContainerHandlerFactory struct {
+	canHandle bool
+	canAccept bool
+}
+
+func (f *mockContainerHandlerFactory) String() string { return "mock" }
+
+func (f *mockContainerHandlerFactory) DebugInfo() map[string][]string {
+	return map[string][]string{}
+}
+
+func (f *mockContainerHandlerFactory) CanHandleAndAccept(name string) (bool, bool, error) {
+	return f.canHandle, f.canAccept, nil
+}
+
+func (f *mockContainerHandlerFactory) NewContainerHandler(name string, metadataEnvAllowList []string, inHostNamespace bool) (container.ContainerHandler, error) {
+	return &mockHandler{
+		ref:  info.ContainerReference{Name: name},
+		spec: info.ContainerSpec{HasCpu: true},
+	}, nil
+}
+
+func TestGetContainerDiscoveryDisabled(t *testing.T) {
+	container.ClearContainerHandlerFactories()
+	defer container.ClearContainerHandlerFactories()
+
+	container.RegisterContainerHandlerFactory(
+		&mockContainerHandlerFactory{canHandle: true, canAccept: true},
+		[]watcher.ContainerWatchSource{watcher.Raw},
+	)
+
+	m := newTestManager()
+	m.disableContainerDiscovery = true
+
+	// First call: container doesn't exist, should be lazily created.
+	cont, err := m.getContainer("/system.slice/kubelet.service")
+	if err != nil {
+		t.Fatalf("getContainer() returned unexpected error: %v", err)
+	}
+	if cont == nil {
+		t.Fatal("getContainer() returned nil container")
+	}
+	if cont.info.Name != "/system.slice/kubelet.service" {
+		t.Errorf("container name = %q, want /system.slice/kubelet.service", cont.info.Name)
+	}
+
+	// Second call: should return cached container without re-creating.
+	cont2, err := m.getContainer("/system.slice/kubelet.service")
+	if err != nil {
+		t.Fatalf("second getContainer() returned unexpected error: %v", err)
+	}
+	if cont2 != cont {
+		t.Error("second getContainer() returned a different container instance, expected cached")
+	}
+}
+
+func TestGetContainerDiscoveryEnabled(t *testing.T) {
+	container.ClearContainerHandlerFactories()
+	defer container.ClearContainerHandlerFactories()
+
+	container.RegisterContainerHandlerFactory(
+		&mockContainerHandlerFactory{canHandle: true, canAccept: true},
+		[]watcher.ContainerWatchSource{watcher.Raw},
+	)
+
+	m := newTestManager()
+
+	_, err := m.getContainer("/system.slice/kubelet.service")
+	if err == nil {
+		t.Fatal("getContainer() should return error when container discovery is not disabled")
+	}
+	if !strings.Contains(err.Error(), "unknown container") {
+		t.Errorf("error = %q, want it to contain 'unknown container'", err)
+	}
 }
 
 // TestContainerDataStopConcurrent verifies that concurrent calls to Stop()


### PR DESCRIPTION
When Kubelet has CRI stats enabled, the container runtime handles container tracking and cAdvisor is only queried for the root container stats. Discovering and watching all containers at startup is unnecessary overhead in that mode.

Add a DisableContainerDiscovery option to HousekeepingConfig that skips plugin initialization, cgroup watchers, subcontainer scanning, and the global housekeeping loop. The root container is still created at startup to serve node-level resource and filesystem stats. Other containers are created lazily via getContainer() on first query.