### PR TITLE
build: discover bootstrap image tag instead of pinning it

### DIFF
--- a/build/integration-in-docker-crio.sh
+++ b/build/integration-in-docker-crio.sh
@@ -76,7 +76,7 @@ function run_tests() {
     --cgroupns=host \
     --pid=host \
     --entrypoint="" \
-    gcr.io/k8s-staging-test-infra/bootstrap:v20251209-855adc2699 \
+    "${BOOTSTRAP_IMAGE}" \
     bash -c "export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y $PACKAGES curl conntrack iptables dbus && \
@@ -206,4 +206,12 @@ PACKAGES=${PACKAGES:-"sudo"}
 BUILD_PACKAGES=${BUILD_PACKAGES:-}
 CADVISOR_ARGS=${CADVISOR_ARGS:-}
 GOLANG_VERSION=${GOLANG_VERSION:-"1.25"}
+
+# The staging registry garbage-collects old images, so a pinned tag rots.
+# Discover the newest dated tag instead; set BOOTSTRAP_TAG to pin one.
+BOOTSTRAP_TAG=${BOOTSTRAP_TAG:-$(curl -sSfL https://gcr.io/v2/k8s-staging-test-infra/bootstrap/tags/list \
+  | grep -oE 'v[0-9]{8}-[0-9a-f]+' | sort -ru | head -n1)}
+[ -n "${BOOTSTRAP_TAG}" ] || { echo "Failed to discover bootstrap image tag" >&2; exit 1; }
+BOOTSTRAP_IMAGE="gcr.io/k8s-staging-test-infra/bootstrap:${BOOTSTRAP_TAG}"
+
 run_tests

--- a/build/integration-in-docker.sh
+++ b/build/integration-in-docker.sh
@@ -61,7 +61,7 @@ function run_tests() {
     --privileged \
     --cap-add="sys_admin" \
     --entrypoint="" \
-    gcr.io/k8s-staging-test-infra/bootstrap:v20251209-855adc2699 \
+    "${BOOTSTRAP_IMAGE}" \
     bash -c "export DEBIAN_FRONTEND=noninteractive && \
     apt update && \
     apt install -y $PACKAGES && \
@@ -74,4 +74,12 @@ BUILD_PACKAGES=${BUILD_PACKAGES:-}
 CADVISOR_ARGS=${CADVISOR_ARGS:-}
 GOLANG_VERSION=${GOLANG_VERSION:-"1.25"}
 DEBIAN_VERSION=${DEBIAN_VERSION:-"trixie"}
+
+# The staging registry garbage-collects old images, so a pinned tag rots.
+# Discover the newest dated tag instead; set BOOTSTRAP_TAG to pin one.
+BOOTSTRAP_TAG=${BOOTSTRAP_TAG:-$(curl -sSfL https://gcr.io/v2/k8s-staging-test-infra/bootstrap/tags/list \
+  | grep -oE 'v[0-9]{8}-[0-9a-f]+' | sort -ru | head -n1)}
+[ -n "${BOOTSTRAP_TAG}" ] || { echo "Failed to discover bootstrap image tag" >&2; exit 1; }
+BOOTSTRAP_IMAGE="gcr.io/k8s-staging-test-infra/bootstrap:${BOOTSTRAP_TAG}"
+
 run_tests


### PR DESCRIPTION
## What this does

The integration test scripts pin `gcr.io/k8s-staging-test-infra/bootstrap` to a dated tag. The staging registry garbage-collects old images, so the pinned tag periodically disappears and all integration jobs fail at image pull:

```
docker: Error response from daemon: manifest for gcr.io/k8s-staging-test-infra/bootstrap:v20251209-855adc2699 not found: manifest unknown
```

Seen on https://github.com/google/cadvisor/actions/runs/29123920768 (test-integration and test-integration-crio jobs on #3912).

Instead of bumping the pin again, query the registry tag list at runtime and use the newest dated tag:

```bash
BOOTSTRAP_TAG=${BOOTSTRAP_TAG:-$(curl -sSfL https://gcr.io/v2/k8s-staging-test-infra/bootstrap/tags/list \
  | grep -oE 'v[0-9]{8}-[0-9a-f]+' | sort -ru | head -n1)}
```

- The dated tags (`vYYYYMMDD-<sha>`) sort lexically by date, so `sort -ru | head -n1` picks the newest.
- The resolved tag still shows up in the CI logs via `set -x`, so runs remain traceable to an exact image.
- `BOOTSTRAP_TAG` can be set to pin a specific tag when needed (e.g. to bisect an image regression).
- If discovery fails, the script exits with an explicit error instead of running with an empty image name.

## Testing

- `bash -n` on both scripts.
- Discovery pipeline currently resolves `v20260710-6dab2861c0`; its manifest returns HTTP 200 from gcr.io.
- Failure path (unreachable repo) exits 1 with an error; pinned `BOOTSTRAP_TAG` bypasses the curl.