### PR TITLE
ci: avoid duplicating release notes on existing releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -99,6 +99,25 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
 
+      # softprops/action-gh-release appends freshly generated notes to any
+      # existing release body. Maintainers often create the GitHub Release
+      # (with auto-generated notes) before this workflow uploads binaries,
+      # which produced duplicated "What's Changed" sections. Only generate
+      # notes when the release does not already have a body.
+      - name: Decide whether to generate release notes
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            body="$(gh release view "${VERSION}" --json body -q .body 2>/dev/null || true)"
+            if [ -n "${body}" ]; then
+              echo "generate=false" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          fi
+          echo "generate=true" >> "${GITHUB_OUTPUT}"
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -107,6 +126,6 @@ jobs:
           name: cAdvisor ${{ env.VERSION }}
           draft: false
           prerelease: ${{ contains(env.VERSION, 'alpha') || contains(env.VERSION, 'beta') || contains(env.VERSION, 'rc') }}
-          generate_release_notes: true
+          generate_release_notes: ${{ steps.release_notes.outputs.generate }}
           files: |
             artifacts/**/*


### PR DESCRIPTION
## Problem

Several cAdvisor GitHub releases contain duplicated release notes (e.g. `What's Changed`, PR list, `Full Changelog` appear twice):

- https://github.com/google/cadvisor/releases/tag/v0.60.2
- https://github.com/google/cadvisor/releases/tag/v0.60.1
- (and many other recent tags)

## Root cause

The `Release Binaries` workflow uses `softprops/action-gh-release` with `generate_release_notes: true`.

That action **appends** freshly generated notes to any existing release body. Maintainers typically create the GitHub Release (with auto-generated notes, author = maintainer) **before** this workflow finishes building and uploads binaries. The create-release job then finds the existing release and regenerates notes, producing a duplicate body.

Timeline for `v0.60.5` (same pattern on other tags):

1. Release created/published by maintainer with notes (~05:07–05:08)
2. Tag push starts the workflow (~05:08)
3. `create-release` job runs later (~05:18) and softprops appends notes again
4. Assets are uploaded by `github-actions[bot]`

## Fix

Before calling softprops, check whether the release already has a body:

- **Body present** → `generate_release_notes: false` (only attach artifacts)
- **No release / empty body** → `generate_release_notes: true` (generate notes once)

## Test

Workflow YAML only; verified against release timeline and softprops update path (`prepareReleaseMutation` concatenates generated notes onto an existing body).

Fixes #3901